### PR TITLE
ci(release): remove build artifacts from release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,6 @@ jobs:
           _output/dist/*.tar.gz
           _output/dist/*.zip
           _output/dist/checksums.txt
-          _output/build/*-*-*-*
-          _output/build/*-*-*-*.exe
         token: ${{ secrets.GITHUB_TOKEN }}
 
   docker-release:


### PR DESCRIPTION
Clean up release assets by excluding intermediate build files that are not needed for the final release