### PR TITLE
docs: remove outdated paths

### DIFF
--- a/DEVELOPMENT-CN.md
+++ b/DEVELOPMENT-CN.md
@@ -138,9 +138,9 @@ make swagger-switauth    # 为switauth生成
 ```
 
 文档生成位置：
-- `internal/switserve/docs/` - SwitServe API文档
-- `internal/switauth/docs/` - SwitAuth API文档
-- `docs/generated/` - 统一文档链接
+- `docs/generated/switserve/` - SwitServe API 文档
+- `docs/generated/switauth/` - SwitAuth API 文档
+- `docs/generated/` - 统一文档根目录
 
 ## 项目结构
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,9 +138,9 @@ make swagger-switauth    # Generate for switauth
 ```
 
 Documentation is generated in:
-- `internal/switserve/docs/` - SwitServe API docs
-- `internal/switauth/docs/` - SwitAuth API docs
-- `docs/generated/` - Unified documentation links
+- `docs/generated/switserve/` - SwitServe API docs
+- `docs/generated/switauth/` - SwitAuth API docs
+- `docs/generated/` - Root for generated documentation
 
 ## Project Structure
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -62,17 +62,25 @@ api/
 ├── buf.yaml              # Buf 主配置文件
 ├── buf.gen.yaml          # 代码生成配置
 ├── buf.lock              # 依赖锁文件
-├── proto/                # Protocol Buffer 定义
-│   └── swit/
-│       └── v1/          # API 版本 1
-│           └── greeter/ # 问候服务
-├── gen/                 # 生成的代码
-│   ├── go/             # Go 代码
-│   └── openapiv2/      # OpenAPI 文档
-└── docs/               # 文档
-    ├── README.md       # API 使用文档
-    └── MIGRATION.md    # 迁移指南
+└── proto/               # Protocol Buffer 定义
+    └── swit/
+        ├── common/
+        │   └── v1/
+        │       ├── common.proto
+        │       └── health.proto
+        ├── communication/
+        │   └── v1/
+        │       └── notification.proto
+        ├── interaction/
+        │   └── v1/
+        │       └── greeter.proto
+        └── user/
+            └── v1/
+                ├── auth.proto
+                └── user.proto
 ```
+
+如需生成 `api/gen/` 目录和 Swagger 文档，可执行 `make proto` 和 `make swagger`，这些产物不会提交到版本库中。
 
 ### API 设计原则
 
@@ -954,8 +962,8 @@ make help             # 显示所有可用命令及说明
 - [SwitAuth 服务](docs/services/switauth/README.md) - 身份验证服务模式
 
 ### API 和协议文档
-- [API 文档](api/docs/README.md) - Protocol Buffer 定义和 API 模式
-- [生成的 API 参考](docs/generated/) - 自动生成的 API 文档
+- [Protocol Buffer 定义](api/proto/) - 源 API 规格
+- 生成的 Swagger 参考 (`docs/generated/`，通过 `make swagger`)
 
 ### 开发和贡献
 - [开发指南](DEVELOPMENT.md) - 框架开发环境设置

--- a/README.md
+++ b/README.md
@@ -62,17 +62,25 @@ api/
 ├── buf.yaml              # Buf main configuration
 ├── buf.gen.yaml          # Code generation configuration
 ├── buf.lock              # Dependency lock file
-├── proto/                # Protocol Buffer definitions
-│   └── swit/
-│       └── v1/          # API version 1
-│           └── greeter/ # Greeter service
-├── gen/                 # Generated code
-│   ├── go/             # Go code
-│   └── openapiv2/      # OpenAPI documentation
-└── docs/               # Documentation
-    ├── README.md       # API usage documentation
-    └── MIGRATION.md    # Migration guide
+└── proto/               # Protocol Buffer definitions
+    └── swit/
+        ├── common/
+        │   └── v1/
+        │       ├── common.proto
+        │       └── health.proto
+        ├── communication/
+        │   └── v1/
+        │       └── notification.proto
+        ├── interaction/
+        │   └── v1/
+        │       └── greeter.proto
+        └── user/
+            └── v1/
+                ├── auth.proto
+                └── user.proto
 ```
+
+Generated artifacts such as `api/gen/` and Swagger documentation are produced by the build tools (`make proto`, `make swagger`) and are not committed to the repository.
 
 ### API Design Principles
 
@@ -955,8 +963,8 @@ For detailed command options and parameters, run `make help` or refer to the spe
 - [SwitAuth Service](docs/services/switauth/README.md) - Authentication service patterns
 
 ### API and Protocol Documentation
-- [API Documentation](api/docs/README.md) - Protocol Buffer definitions and API patterns
-- [Generated API Reference](docs/generated/) - Auto-generated API documentation
+- [Protocol Buffer Definitions](api/proto/) - Source API specifications
+- Generated Swagger reference (`docs/generated/`, via `make swagger`)
 
 ### Development and Contribution
 - [Development Guide](DEVELOPMENT.md) - Framework development environment setup


### PR DESCRIPTION
## Summary
- update API structure docs to remove stale paths
- clarify generated documentation locations
- correct gRPC API directory layout in both README files

## Testing
- `go test ./... 2>&1 | tail -n 20` *(fails: pkg/server)*

------
https://chatgpt.com/codex/tasks/task_e_689d69803750832ab889381aa555afe8