### PR TITLE
添加 Prometheus 集成的 HTTP 和 gRPC 中间件，支持指标收集和处理，包含相关测试用例和配置选项。

### DIFF
--- a/examples/prometheus-integration-test/main.go
+++ b/examples/prometheus-integration-test/main.go
@@ -1,0 +1,421 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Package main demonstrates Prometheus metrics integration with the framework
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/middleware"
+	"github.com/innovationmech/swit/pkg/server"
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+// PrometheusTestService demonstrates Prometheus metrics integration
+type PrometheusTestService struct {
+	name string
+}
+
+// NewPrometheusTestService creates a new test service
+func NewPrometheusTestService(name string) *PrometheusTestService {
+	return &PrometheusTestService{
+		name: name,
+	}
+}
+
+// RegisterServices registers the HTTP handlers with metrics
+func (s *PrometheusTestService) RegisterServices(registry server.BusinessServiceRegistry) error {
+	// Register HTTP handler
+	httpHandler := &PrometheusTestHTTPHandler{serviceName: s.name}
+	if err := registry.RegisterBusinessHTTPHandler(httpHandler); err != nil {
+		return fmt.Errorf("failed to register HTTP handler: %w", err)
+	}
+
+	// Register health check
+	healthCheck := &PrometheusTestHealthCheck{serviceName: s.name}
+	if err := registry.RegisterBusinessHealthCheck(healthCheck); err != nil {
+		return fmt.Errorf("failed to register health check: %w", err)
+	}
+
+	return nil
+}
+
+// PrometheusTestHTTPHandler implements the HTTPHandler interface
+type PrometheusTestHTTPHandler struct {
+	serviceName string
+}
+
+// RegisterRoutes registers HTTP routes with the router
+func (h *PrometheusTestHTTPHandler) RegisterRoutes(router interface{}) error {
+	ginRouter, ok := router.(gin.IRouter)
+	if !ok {
+		return fmt.Errorf("expected gin.IRouter, got %T", router)
+	}
+
+	// Register API routes for testing metrics
+	api := ginRouter.Group("/api/v1")
+	{
+		api.GET("/test", h.handleTest)
+		api.POST("/slow", h.handleSlow)
+		api.GET("/error", h.handleError)
+		api.GET("/users/:id", h.handleUserByID)
+	}
+
+	return nil
+}
+
+// GetServiceName returns the service name
+func (h *PrometheusTestHTTPHandler) GetServiceName() string {
+	return h.serviceName
+}
+
+// handleTest handles the test endpoint
+func (h *PrometheusTestHTTPHandler) handleTest(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"message":   "Test endpoint for Prometheus metrics",
+		"service":   h.serviceName,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleSlow handles a slow endpoint to test duration metrics
+func (h *PrometheusTestHTTPHandler) handleSlow(c *gin.Context) {
+	// Simulate slow processing
+	time.Sleep(500 * time.Millisecond)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":   "Slow endpoint completed",
+		"service":   h.serviceName,
+		"duration":  "500ms",
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleError handles an endpoint that returns errors
+func (h *PrometheusTestHTTPHandler) handleError(c *gin.Context) {
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error":     "Intentional error for testing",
+		"service":   h.serviceName,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleUserByID handles parameterized path for testing path normalization
+func (h *PrometheusTestHTTPHandler) handleUserByID(c *gin.Context) {
+	userID := c.Param("id")
+	c.JSON(http.StatusOK, gin.H{
+		"user_id":   userID,
+		"service":   h.serviceName,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// PrometheusTestHealthCheck implements the HealthCheck interface
+type PrometheusTestHealthCheck struct {
+	serviceName string
+}
+
+// Check performs a health check
+func (h *PrometheusTestHealthCheck) Check(ctx context.Context) error {
+	return nil
+}
+
+// GetServiceName returns the service name
+func (h *PrometheusTestHealthCheck) GetServiceName() string {
+	return h.serviceName
+}
+
+// SimpleDependencyContainer implements the DependencyContainer interface
+type SimpleDependencyContainer struct {
+	services map[string]interface{}
+	closed   bool
+}
+
+// NewSimpleDependencyContainer creates a new dependency container
+func NewSimpleDependencyContainer() *SimpleDependencyContainer {
+	return &SimpleDependencyContainer{
+		services: make(map[string]interface{}),
+		closed:   false,
+	}
+}
+
+// GetService retrieves a service by name
+func (d *SimpleDependencyContainer) GetService(name string) (interface{}, error) {
+	if d.closed {
+		return nil, fmt.Errorf("dependency container is closed")
+	}
+
+	service, exists := d.services[name]
+	if !exists {
+		return nil, fmt.Errorf("service %s not found", name)
+	}
+
+	return service, nil
+}
+
+// Close closes the dependency container
+func (d *SimpleDependencyContainer) Close() error {
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return nil
+}
+
+// AddService adds a service to the container
+func (d *SimpleDependencyContainer) AddService(name string, service interface{}) {
+	d.services[name] = service
+}
+
+// MetricsCollectorAdapter adapts server.PrometheusMetricsCollector to types.MetricsCollector
+type MetricsCollectorAdapter struct {
+	collector *server.PrometheusMetricsCollector
+}
+
+func NewMetricsCollectorAdapter(collector *server.PrometheusMetricsCollector) *MetricsCollectorAdapter {
+	return &MetricsCollectorAdapter{collector: collector}
+}
+
+func (a *MetricsCollectorAdapter) IncrementCounter(name string, labels map[string]string) {
+	a.collector.IncrementCounter(name, labels)
+}
+
+func (a *MetricsCollectorAdapter) AddToCounter(name string, value float64, labels map[string]string) {
+	a.collector.AddToCounter(name, value, labels)
+}
+
+func (a *MetricsCollectorAdapter) SetGauge(name string, value float64, labels map[string]string) {
+	a.collector.SetGauge(name, value, labels)
+}
+
+func (a *MetricsCollectorAdapter) IncrementGauge(name string, labels map[string]string) {
+	a.collector.IncrementGauge(name, labels)
+}
+
+func (a *MetricsCollectorAdapter) DecrementGauge(name string, labels map[string]string) {
+	a.collector.DecrementGauge(name, labels)
+}
+
+func (a *MetricsCollectorAdapter) ObserveHistogram(name string, value float64, labels map[string]string) {
+	a.collector.ObserveHistogram(name, value, labels)
+}
+
+func (a *MetricsCollectorAdapter) GetMetrics() []types.Metric {
+	serverMetrics := a.collector.GetMetrics()
+	typesMetrics := make([]types.Metric, len(serverMetrics))
+
+	for i, sm := range serverMetrics {
+		// Convert value to float64
+		var value float64
+		switch v := sm.Value.(type) {
+		case int64:
+			value = float64(v)
+		case float64:
+			value = v
+		case map[string]interface{}:
+			// For histogram/summary, use the sum if available
+			if sum, ok := v["sum"].(float64); ok {
+				value = sum
+			}
+		default:
+			value = 0
+		}
+
+		typesMetrics[i] = types.Metric{
+			Name:        sm.Name,
+			Type:        types.MetricType(sm.Type),
+			Value:       value,
+			Labels:      sm.Labels,
+			Timestamp:   sm.Timestamp.Unix(),
+			Description: sm.Description,
+		}
+	}
+
+	return typesMetrics
+}
+
+func (a *MetricsCollectorAdapter) GetMetric(name string) (*types.Metric, bool) {
+	serverMetric, found := a.collector.GetMetric(name)
+	if !found {
+		return nil, false
+	}
+
+	// Convert value to float64
+	var value float64
+	switch v := serverMetric.Value.(type) {
+	case int64:
+		value = float64(v)
+	case float64:
+		value = v
+	case map[string]interface{}:
+		// For histogram/summary, use the sum if available
+		if sum, ok := v["sum"].(float64); ok {
+			value = sum
+		}
+	default:
+		value = 0
+	}
+
+	typesMetric := &types.Metric{
+		Name:        serverMetric.Name,
+		Type:        types.MetricType(serverMetric.Type),
+		Value:       value,
+		Labels:      serverMetric.Labels,
+		Timestamp:   serverMetric.Timestamp.Unix(),
+		Description: serverMetric.Description,
+	}
+
+	return typesMetric, true
+}
+
+func (a *MetricsCollectorAdapter) Reset() {
+	a.collector.Reset()
+}
+
+func main() {
+	// Initialize logger
+	logger.InitLogger()
+
+	// Create a Prometheus metrics collector for demonstration
+	prometheusConfig := server.DefaultPrometheusConfig()
+	prometheusConfig.Namespace = "swit_test"
+	prometheusConfig.Subsystem = "prometheus_integration"
+
+	prometheusCollector := server.NewPrometheusMetricsCollector(prometheusConfig)
+
+	// Create an adapter to make it compatible with types.MetricsCollector
+	metricsAdapter := NewMetricsCollectorAdapter(prometheusCollector)
+
+	// Create HTTP middleware for Prometheus
+	httpMiddlewareConfig := middleware.DefaultPrometheusHTTPConfig()
+	httpMiddlewareConfig.ServiceName = "prometheus-test-service"
+	httpMiddleware := middleware.NewPrometheusHTTPMiddleware(metricsAdapter, httpMiddlewareConfig)
+
+	// Create server configuration
+	config := &server.ServerConfig{
+		ServiceName: "prometheus-test-service",
+		HTTP: server.HTTPConfig{
+			Port:         getEnv("HTTP_PORT", "8080"),
+			EnableReady:  true,
+			Enabled:      true,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		},
+		GRPC: server.GRPCConfig{
+			Enabled: false,
+		},
+		ShutdownTimeout: 30 * time.Second,
+		Discovery: server.DiscoveryConfig{
+			Enabled: false,
+		},
+		Middleware: server.MiddlewareConfig{
+			EnableCORS:    true,
+			EnableLogging: true,
+		},
+	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		logger.GetLogger().Fatal("Invalid configuration",
+			zap.Error(err))
+	}
+
+	// Create service and dependencies
+	service := NewPrometheusTestService("prometheus-test-service")
+	deps := NewSimpleDependencyContainer()
+
+	// Add dependencies
+	deps.AddService("config", config)
+	deps.AddService("version", "1.0.0-prometheus-test")
+
+	// Create base server
+	baseServer, err := server.NewBusinessServerCore(config, service, deps)
+	if err != nil {
+		logger.GetLogger().Fatal("Failed to create server",
+			zap.Error(err))
+	}
+
+	// Note: In a production setup, you would integrate the middleware through
+	// the server's middleware manager. For this demo, we'll show how the
+	// middleware works conceptually.
+
+	// Start server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := baseServer.Start(ctx); err != nil {
+		logger.GetLogger().Fatal("Failed to start server",
+			zap.Error(err))
+	}
+
+	httpAddr := baseServer.GetHTTPAddress()
+	logger.GetLogger().Info("Prometheus test service started successfully",
+		zap.String("http_address", httpAddr),
+		zap.String("service_name", "prometheus-test-service"))
+
+	// Log example endpoints
+	logger.GetLogger().Info("Test endpoints available:",
+		zap.String("test", fmt.Sprintf("http://%s/api/v1/test", httpAddr)),
+		zap.String("slow", fmt.Sprintf("http://%s/api/v1/slow", httpAddr)),
+		zap.String("error", fmt.Sprintf("http://%s/api/v1/error", httpAddr)),
+		zap.String("user", fmt.Sprintf("http://%s/api/v1/users/123", httpAddr)),
+		zap.String("metrics", fmt.Sprintf("http://%s/debug/metrics", httpAddr)),
+		zap.String("health", fmt.Sprintf("http://%s/health", httpAddr)))
+
+	logger.GetLogger().Info("Prometheus middleware created successfully",
+		zap.String("middleware_config", fmt.Sprintf("%+v", httpMiddlewareConfig)),
+		zap.Int("path_cardinality", httpMiddleware.GetPathCardinality()))
+
+	// Wait for shutdown signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	logger.GetLogger().Info("Shutdown signal received, stopping server")
+
+	// Graceful shutdown
+	if err := baseServer.Shutdown(); err != nil {
+		logger.GetLogger().Error("Error during shutdown",
+			zap.Error(err))
+	} else {
+		logger.GetLogger().Info("Server stopped gracefully")
+	}
+}
+
+// getEnv gets an environment variable with a default value
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/pkg/middleware/prometheus_grpc.go
+++ b/pkg/middleware/prometheus_grpc.go
@@ -1,0 +1,376 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+// PrometheusGRPCConfig configures the gRPC interceptor for Prometheus metrics
+type PrometheusGRPCConfig struct {
+	// Enabled controls whether metrics collection is active
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// ExcludeMethods contains gRPC methods to exclude from metrics
+	ExcludeMethods []string `yaml:"exclude_methods" json:"exclude_methods"`
+
+	// CollectMessageSize enables message size metrics collection
+	CollectMessageSize bool `yaml:"collect_message_size" json:"collect_message_size"`
+
+	// CollectStreamMessages enables per-message metrics for streaming RPCs
+	CollectStreamMessages bool `yaml:"collect_stream_messages" json:"collect_stream_messages"`
+
+	// ServiceName is the service name label for metrics
+	ServiceName string `yaml:"service_name" json:"service_name"`
+
+	// HandleStreamingErrors controls whether to track streaming errors separately
+	HandleStreamingErrors bool `yaml:"handle_streaming_errors" json:"handle_streaming_errors"`
+}
+
+// DefaultPrometheusGRPCConfig returns sensible defaults for gRPC metrics interceptor
+func DefaultPrometheusGRPCConfig() *PrometheusGRPCConfig {
+	return &PrometheusGRPCConfig{
+		Enabled: true,
+		ExcludeMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+		},
+		CollectMessageSize:    true,
+		CollectStreamMessages: true,
+		ServiceName:           "unknown",
+		HandleStreamingErrors: true,
+	}
+}
+
+// PrometheusGRPCInterceptor provides gRPC metrics collection interceptors
+type PrometheusGRPCInterceptor struct {
+	config           *PrometheusGRPCConfig
+	metricsCollector types.MetricsCollector
+}
+
+// NewPrometheusGRPCInterceptor creates a new gRPC metrics interceptor
+func NewPrometheusGRPCInterceptor(collector types.MetricsCollector, config *PrometheusGRPCConfig) *PrometheusGRPCInterceptor {
+	if config == nil {
+		config = DefaultPrometheusGRPCConfig()
+	}
+
+	return &PrometheusGRPCInterceptor{
+		config:           config,
+		metricsCollector: collector,
+	}
+}
+
+// UnaryServerInterceptor returns a grpc.UnaryServerInterceptor for metrics collection
+func (i *PrometheusGRPCInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// Skip if metrics collection is disabled
+		if !i.config.Enabled {
+			return handler(ctx, req)
+		}
+
+		// Check if this method should be excluded
+		if i.shouldExcludeMethod(info.FullMethod) {
+			return handler(ctx, req)
+		}
+
+		// Start timing and record start
+		start := time.Now()
+
+		// Record server started
+		i.recordServerStarted(info.FullMethod)
+
+		// Execute the RPC
+		resp, err := handler(ctx, req)
+
+		// Calculate duration
+		duration := time.Since(start)
+
+		// Collect metrics
+		i.collectUnaryMetrics(info.FullMethod, duration, req, resp, err)
+
+		return resp, err
+	}
+}
+
+// StreamServerInterceptor returns a grpc.StreamServerInterceptor for metrics collection
+func (i *PrometheusGRPCInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		// Skip if metrics collection is disabled
+		if !i.config.Enabled {
+			return handler(srv, stream)
+		}
+
+		// Check if this method should be excluded
+		if i.shouldExcludeMethod(info.FullMethod) {
+			return handler(srv, stream)
+		}
+
+		// Start timing and record start
+		start := time.Now()
+
+		// Record server started
+		i.recordServerStarted(info.FullMethod)
+
+		// Wrap the stream for message counting
+		wrappedStream := &metricsServerStream{
+			ServerStream: stream,
+			method:       info.FullMethod,
+			interceptor:  i,
+		}
+
+		// Execute the RPC
+		err := handler(srv, wrappedStream)
+
+		// Calculate duration
+		duration := time.Since(start)
+
+		// Collect metrics
+		i.collectStreamMetrics(info.FullMethod, duration, wrappedStream.sentCount, wrappedStream.receivedCount, err)
+
+		return err
+	}
+}
+
+// metricsServerStream wraps grpc.ServerStream to collect message metrics
+type metricsServerStream struct {
+	grpc.ServerStream
+	method        string
+	interceptor   *PrometheusGRPCInterceptor
+	sentCount     int
+	receivedCount int
+}
+
+func (s *metricsServerStream) SendMsg(m interface{}) error {
+	err := s.ServerStream.SendMsg(m)
+	if err == nil && s.interceptor.config.CollectStreamMessages {
+		s.sentCount++
+		s.interceptor.recordMessageSent(s.method)
+	}
+	return err
+}
+
+func (s *metricsServerStream) RecvMsg(m interface{}) error {
+	err := s.ServerStream.RecvMsg(m)
+	if err == nil && s.interceptor.config.CollectStreamMessages {
+		s.receivedCount++
+		s.interceptor.recordMessageReceived(s.method)
+	}
+	return err
+}
+
+// collectUnaryMetrics collects metrics for unary RPCs
+func (i *PrometheusGRPCInterceptor) collectUnaryMetrics(method string, duration time.Duration, req, resp interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Error("gRPC unary metrics collection panic",
+				zap.String("method", method),
+				zap.Any("panic", r))
+		}
+	}()
+
+	// Get status code
+	code := codes.OK
+	if err != nil {
+		if st, ok := status.FromError(err); ok {
+			code = st.Code()
+		} else {
+			code = codes.Unknown
+		}
+	}
+
+	labels := map[string]string{
+		"service": i.config.ServiceName,
+		"method":  method,
+	}
+
+	// Record completion
+	completionLabels := make(map[string]string)
+	for k, v := range labels {
+		completionLabels[k] = v
+	}
+	completionLabels["code"] = code.String()
+
+	i.safeIncrementCounter("grpc_server_handled_total", completionLabels)
+
+	// Record handling duration
+	i.safeObserveHistogram("grpc_server_handling_seconds", duration.Seconds(), labels)
+
+	// Record message counts for unary (1 each)
+	if i.config.CollectMessageSize {
+		i.safeIncrementCounter("grpc_server_msg_received_total", labels)
+		if err == nil {
+			i.safeIncrementCounter("grpc_server_msg_sent_total", labels)
+		}
+	}
+}
+
+// collectStreamMetrics collects metrics for streaming RPCs
+func (i *PrometheusGRPCInterceptor) collectStreamMetrics(method string, duration time.Duration, sentCount, receivedCount int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Error("gRPC stream metrics collection panic",
+				zap.String("method", method),
+				zap.Any("panic", r))
+		}
+	}()
+
+	// Get status code
+	code := codes.OK
+	if err != nil {
+		if st, ok := status.FromError(err); ok {
+			code = st.Code()
+		} else {
+			code = codes.Unknown
+		}
+	}
+
+	labels := map[string]string{
+		"service": i.config.ServiceName,
+		"method":  method,
+	}
+
+	// Record completion
+	completionLabels := make(map[string]string)
+	for k, v := range labels {
+		completionLabels[k] = v
+	}
+	completionLabels["code"] = code.String()
+
+	i.safeIncrementCounter("grpc_server_handled_total", completionLabels)
+
+	// Record handling duration
+	i.safeObserveHistogram("grpc_server_handling_seconds", duration.Seconds(), labels)
+}
+
+// recordServerStarted records when an RPC starts
+func (i *PrometheusGRPCInterceptor) recordServerStarted(method string) {
+	labels := map[string]string{
+		"service": i.config.ServiceName,
+		"method":  method,
+	}
+	i.safeIncrementCounter("grpc_server_started_total", labels)
+}
+
+// recordMessageSent records when a message is sent
+func (i *PrometheusGRPCInterceptor) recordMessageSent(method string) {
+	labels := map[string]string{
+		"service": i.config.ServiceName,
+		"method":  method,
+	}
+	i.safeIncrementCounter("grpc_server_msg_sent_total", labels)
+}
+
+// recordMessageReceived records when a message is received
+func (i *PrometheusGRPCInterceptor) recordMessageReceived(method string) {
+	labels := map[string]string{
+		"service": i.config.ServiceName,
+		"method":  method,
+	}
+	i.safeIncrementCounter("grpc_server_msg_received_total", labels)
+}
+
+// shouldExcludeMethod checks if a method should be excluded from metrics
+func (i *PrometheusGRPCInterceptor) shouldExcludeMethod(method string) bool {
+	for _, excludeMethod := range i.config.ExcludeMethods {
+		if method == excludeMethod {
+			return true
+		}
+	}
+	return false
+}
+
+// Safe metric collection methods with error handling
+
+func (i *PrometheusGRPCInterceptor) safeIncrementCounter(name string, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("gRPC counter increment panic",
+				zap.String("metric", name),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if i.metricsCollector != nil {
+		i.metricsCollector.IncrementCounter(name, labels)
+	}
+}
+
+func (i *PrometheusGRPCInterceptor) safeObserveHistogram(name string, value float64, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("gRPC histogram observation panic",
+				zap.String("metric", name),
+				zap.Float64("value", value),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if i.metricsCollector != nil {
+		i.metricsCollector.ObserveHistogram(name, value, labels)
+	}
+}
+
+func (i *PrometheusGRPCInterceptor) safeIncrementGauge(name string, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("gRPC gauge increment panic",
+				zap.String("metric", name),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if i.metricsCollector != nil {
+		i.metricsCollector.IncrementGauge(name, labels)
+	}
+}
+
+// GetConfig returns the interceptor configuration
+func (i *PrometheusGRPCInterceptor) GetConfig() *PrometheusGRPCConfig {
+	return i.config
+}
+
+// UpdateConfig updates the interceptor configuration (thread-safe for basic fields)
+func (i *PrometheusGRPCInterceptor) UpdateConfig(config *PrometheusGRPCConfig) {
+	if config == nil {
+		return
+	}
+
+	// Only update fields that are safe to change at runtime
+	i.config.Enabled = config.Enabled
+	i.config.ExcludeMethods = config.ExcludeMethods
+	i.config.CollectMessageSize = config.CollectMessageSize
+	i.config.CollectStreamMessages = config.CollectStreamMessages
+}
+
+// GetMetricsCollector returns the underlying metrics collector
+func (i *PrometheusGRPCInterceptor) GetMetricsCollector() types.MetricsCollector {
+	return i.metricsCollector
+}

--- a/pkg/middleware/prometheus_grpc_test.go
+++ b/pkg/middleware/prometheus_grpc_test.go
@@ -1,0 +1,1124 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+// mockGRPCMetricsCollector is the same as the HTTP one but included here for clarity
+type mockGRPCMetricsCollector struct {
+	mu         sync.RWMutex
+	counters   map[string]float64
+	gauges     map[string]float64
+	histograms map[string][]float64
+	labels     map[string]map[string]string
+	panics     bool
+}
+
+func newMockGRPCMetricsCollector() *mockGRPCMetricsCollector {
+	return &mockGRPCMetricsCollector{
+		counters:   make(map[string]float64),
+		gauges:     make(map[string]float64),
+		histograms: make(map[string][]float64),
+		labels:     make(map[string]map[string]string),
+	}
+}
+
+func (m *mockGRPCMetricsCollector) IncrementCounter(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.counters[key]++
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) AddToCounter(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.counters[key] += value
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) SetGauge(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key] = value
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) IncrementGauge(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key]++
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) DecrementGauge(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key]--
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) ObserveHistogram(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.histograms[key] = append(m.histograms[key], value)
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockGRPCMetricsCollector) GetMetrics() []types.Metric {
+	return nil
+}
+
+func (m *mockGRPCMetricsCollector) GetMetric(name string) (*types.Metric, bool) {
+	return nil, false
+}
+
+func (m *mockGRPCMetricsCollector) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.counters = make(map[string]float64)
+	m.gauges = make(map[string]float64)
+	m.histograms = make(map[string][]float64)
+	m.labels = make(map[string]map[string]string)
+}
+
+func (m *mockGRPCMetricsCollector) getKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+
+	// Sort label keys for deterministic key generation
+	var keys []string
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	parts = append(parts, name)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, labels[k]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (m *mockGRPCMetricsCollector) copyLabels(labels map[string]string) map[string]string {
+	copied := make(map[string]string)
+	for k, v := range labels {
+		copied[k] = v
+	}
+	return copied
+}
+
+// Helper methods for testing
+func (m *mockGRPCMetricsCollector) getCounterValue(name string, labels map[string]string) float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	return m.counters[key]
+}
+
+func (m *mockGRPCMetricsCollector) getGaugeValue(name string, labels map[string]string) float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	return m.gauges[key]
+}
+
+func (m *mockGRPCMetricsCollector) getHistogramValues(name string, labels map[string]string) []float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	values := make([]float64, len(m.histograms[key]))
+	copy(values, m.histograms[key])
+	return values
+}
+
+func (m *mockGRPCMetricsCollector) setPanics(panics bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.panics = panics
+}
+
+// Mock gRPC service implementations
+type mockUnaryHandler func(ctx context.Context, req interface{}) (interface{}, error)
+type mockStreamHandler func(srv interface{}, stream grpc.ServerStream) error
+
+type mockServerStream struct {
+	ctx      context.Context
+	sentMsgs []interface{}
+	recvMsgs []interface{}
+	recvErr  error
+	sendErr  error
+}
+
+func newMockServerStream(ctx context.Context) *mockServerStream {
+	return &mockServerStream{
+		ctx:      ctx,
+		sentMsgs: make([]interface{}, 0),
+		recvMsgs: make([]interface{}, 0),
+	}
+}
+
+func (s *mockServerStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *mockServerStream) SendMsg(m interface{}) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sentMsgs = append(s.sentMsgs, m)
+	return nil
+}
+
+func (s *mockServerStream) RecvMsg(m interface{}) error {
+	if s.recvErr != nil {
+		return s.recvErr
+	}
+	if len(s.recvMsgs) == 0 {
+		return io.EOF
+	}
+	// Simulate receiving a message
+	s.recvMsgs = s.recvMsgs[1:]
+	return nil
+}
+
+// Required methods for grpc.ServerStream interface
+func (s *mockServerStream) SetHeader(md metadata.MD) error {
+	return nil
+}
+
+func (s *mockServerStream) SendHeader(md metadata.MD) error {
+	return nil
+}
+
+func (s *mockServerStream) SetTrailer(md metadata.MD) {
+}
+
+func (s *mockServerStream) setSendError(err error) {
+	s.sendErr = err
+}
+
+func (s *mockServerStream) setRecvError(err error) {
+	s.recvErr = err
+}
+
+func (s *mockServerStream) addRecvMsg(msg interface{}) {
+	s.recvMsgs = append(s.recvMsgs, msg)
+}
+
+func TestDefaultPrometheusGRPCConfig(t *testing.T) {
+	config := DefaultPrometheusGRPCConfig()
+
+	assert.True(t, config.Enabled)
+	assert.True(t, config.CollectMessageSize)
+	assert.True(t, config.CollectStreamMessages)
+	assert.True(t, config.HandleStreamingErrors)
+	assert.Equal(t, "unknown", config.ServiceName)
+
+	expectedExcludeMethods := []string{
+		"/grpc.health.v1.Health/Check",
+		"/grpc.health.v1.Health/Watch",
+	}
+	assert.Equal(t, expectedExcludeMethods, config.ExcludeMethods)
+}
+
+func TestNewPrometheusGRPCInterceptor(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+
+	t.Run("WithConfig", func(t *testing.T) {
+		config := &PrometheusGRPCConfig{
+			Enabled:     true,
+			ServiceName: "test-service",
+		}
+
+		interceptor := NewPrometheusGRPCInterceptor(collector, config)
+		assert.NotNil(t, interceptor)
+		assert.Equal(t, config, interceptor.config)
+		assert.Equal(t, collector, interceptor.metricsCollector)
+		// Registry is no longer exposed in the interceptor
+	})
+
+	t.Run("WithNilConfig", func(t *testing.T) {
+		interceptor := NewPrometheusGRPCInterceptor(collector, nil)
+		assert.NotNil(t, interceptor)
+		assert.NotNil(t, interceptor.config)
+		assert.Equal(t, DefaultPrometheusGRPCConfig(), interceptor.config)
+	})
+}
+
+func TestPrometheusGRPCInterceptor_UnaryInterceptor(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:            true,
+		ServiceName:        "test-service",
+		CollectMessageSize: true,
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	t.Run("SuccessfulUnaryCall", func(t *testing.T) {
+		collector.Reset()
+
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return "response", nil
+		}
+
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "/test.TestService/TestMethod",
+		}
+
+		ctx := context.Background()
+		resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "response", resp)
+
+		// Verify metrics
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestMethod",
+		}
+
+		// Check server started
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+
+		// Check server handled with OK code
+		handledLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestMethod",
+			"code":    codes.OK.String(),
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_handled_total", handledLabels))
+
+		// Check handling duration
+		durations := collector.getHistogramValues("grpc_server_handling_seconds", expectedLabels)
+		assert.Len(t, durations, 1)
+		assert.Greater(t, durations[0], float64(0))
+
+		// Check message counts
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+	})
+
+	t.Run("UnaryCallWithError", func(t *testing.T) {
+		collector.Reset()
+
+		expectedErr := status.Error(codes.InvalidArgument, "invalid request")
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return nil, expectedErr
+		}
+
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "/test.TestService/TestMethod",
+		}
+
+		ctx := context.Background()
+		resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, expectedErr, err)
+
+		// Verify metrics with error code
+		handledLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestMethod",
+			"code":    codes.InvalidArgument.String(),
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_handled_total", handledLabels))
+
+		// Message received but not sent due to error
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestMethod",
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+	})
+
+	t.Run("UnaryCallWithNonGRPCError", func(t *testing.T) {
+		collector.Reset()
+
+		expectedErr := errors.New("regular error")
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return nil, expectedErr
+		}
+
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "/test.TestService/TestMethod",
+		}
+
+		ctx := context.Background()
+		_, err := unaryInterceptor(ctx, "request", info, handler)
+
+		assert.Error(t, err)
+
+		// Should be classified as Unknown status
+		handledLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestMethod",
+			"code":    codes.Unknown.String(),
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_handled_total", handledLabels))
+	})
+}
+
+func TestPrometheusGRPCInterceptor_StreamInterceptor(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:               true,
+		ServiceName:           "test-service",
+		CollectStreamMessages: true,
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	streamInterceptor := interceptor.StreamServerInterceptor()
+
+	t.Run("SuccessfulStreamCall", func(t *testing.T) {
+		collector.Reset()
+
+		handler := func(srv interface{}, stream grpc.ServerStream) error {
+			// Simulate receiving and sending messages
+			mockStream := stream.(*metricsServerStream)
+
+			// Simulate receiving 3 messages
+			for i := 0; i < 3; i++ {
+				err := mockStream.RecvMsg(fmt.Sprintf("msg%d", i))
+				if err != nil && err != io.EOF {
+					return err
+				}
+			}
+
+			// Simulate sending 2 messages
+			for i := 0; i < 2; i++ {
+				err := mockStream.SendMsg(fmt.Sprintf("response%d", i))
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
+
+		info := &grpc.StreamServerInfo{
+			FullMethod: "/test.TestService/TestStream",
+		}
+
+		ctx := context.Background()
+		mockStream := newMockServerStream(ctx)
+		// Add messages to receive
+		for i := 0; i < 3; i++ {
+			mockStream.addRecvMsg(fmt.Sprintf("msg%d", i))
+		}
+
+		err := streamInterceptor(nil, mockStream, info, handler)
+		assert.NoError(t, err)
+
+		// Verify metrics
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+
+		// Check server started
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+
+		// Check server handled with OK code
+		handledLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+			"code":    codes.OK.String(),
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_handled_total", handledLabels))
+
+		// Check handling duration
+		durations := collector.getHistogramValues("grpc_server_handling_seconds", expectedLabels)
+		assert.Len(t, durations, 1)
+		assert.Greater(t, durations[0], float64(0))
+
+		// Check message counts - these are tracked via the wrapped stream
+		assert.Equal(t, float64(3), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+		assert.Equal(t, float64(2), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+	})
+
+	t.Run("StreamCallWithError", func(t *testing.T) {
+		collector.Reset()
+
+		expectedErr := status.Error(codes.Internal, "stream error")
+		handler := func(srv interface{}, stream grpc.ServerStream) error {
+			return expectedErr
+		}
+
+		info := &grpc.StreamServerInfo{
+			FullMethod: "/test.TestService/TestStream",
+		}
+
+		ctx := context.Background()
+		mockStream := newMockServerStream(ctx)
+
+		err := streamInterceptor(nil, mockStream, info, handler)
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+
+		// Verify error is tracked
+		handledLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+			"code":    codes.Internal.String(),
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_handled_total", handledLabels))
+	})
+}
+
+func TestPrometheusGRPCInterceptor_ExcludeMethods(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:        true,
+		ServiceName:    "test-service",
+		ExcludeMethods: []string{"/grpc.health.v1.Health/Check", "/test.TestService/ExcludedMethod"},
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	t.Run("ExcludedMethod", func(t *testing.T) {
+		collector.Reset()
+
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return "response", nil
+		}
+
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "/grpc.health.v1.Health/Check",
+		}
+
+		ctx := context.Background()
+		resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "response", resp)
+
+		// No metrics should be collected for excluded methods
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/grpc.health.v1.Health/Check",
+		}
+
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+	})
+
+	t.Run("IncludedMethod", func(t *testing.T) {
+		collector.Reset()
+
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return "response", nil
+		}
+
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "/test.TestService/IncludedMethod",
+		}
+
+		ctx := context.Background()
+		resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "response", resp)
+
+		// Metrics should be collected for included methods
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/IncludedMethod",
+		}
+
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+	})
+}
+
+func TestPrometheusGRPCInterceptor_Disabled(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:     false,
+		ServiceName: "test-service",
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+	}
+
+	ctx := context.Background()
+	resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "response", resp)
+
+	// No metrics should be collected when disabled
+	expectedLabels := map[string]string{
+		"service": "test-service",
+		"method":  "/test.TestService/TestMethod",
+	}
+
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+}
+
+func TestPrometheusGRPCInterceptor_PanicRecovery(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+	}
+
+	// Enable panics in collector
+	collector.setPanics(true)
+
+	ctx := context.Background()
+
+	// Should not panic even if metrics collection panics
+	assert.NotPanics(t, func() {
+		resp, err := unaryInterceptor(ctx, "request", info, handler)
+		assert.NoError(t, err)
+		assert.Equal(t, "response", resp)
+	})
+}
+
+func TestPrometheusGRPCInterceptor_MessageSizeCollection(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:            true,
+		ServiceName:        "test-service",
+		CollectMessageSize: false, // Disabled
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+	}
+
+	ctx := context.Background()
+	_, err := unaryInterceptor(ctx, "request", info, handler)
+	assert.NoError(t, err)
+
+	// Message size metrics should not be collected when disabled
+	expectedLabels := map[string]string{
+		"service": "test-service",
+		"method":  "/test.TestService/TestMethod",
+	}
+
+	// Server started and handled should still be tracked
+	assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+
+	// But message counts should not be tracked
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+}
+
+func TestPrometheusGRPCInterceptor_StreamMessageCollection(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:               true,
+		ServiceName:           "test-service",
+		CollectStreamMessages: false, // Disabled
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	streamInterceptor := interceptor.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		// Try to send and receive messages
+		wrappedStream := stream.(*metricsServerStream)
+
+		_ = wrappedStream.SendMsg("response")
+		_ = wrappedStream.RecvMsg("request")
+
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/test.TestService/TestStream",
+	}
+
+	ctx := context.Background()
+	mockStream := newMockServerStream(ctx)
+	mockStream.addRecvMsg("request")
+
+	err := streamInterceptor(nil, mockStream, info, handler)
+	assert.NoError(t, err)
+
+	// Stream message metrics should not be collected when disabled
+	expectedLabels := map[string]string{
+		"service": "test-service",
+		"method":  "/test.TestService/TestStream",
+	}
+
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+	assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+}
+
+func TestPrometheusGRPCInterceptor_UpdateConfig(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	interceptor := NewPrometheusGRPCInterceptor(collector, &PrometheusGRPCConfig{
+		Enabled:               false,
+		ExcludeMethods:        []string{"/health"},
+		CollectMessageSize:    false,
+		CollectStreamMessages: false,
+	})
+
+	newConfig := &PrometheusGRPCConfig{
+		Enabled:               true,
+		ExcludeMethods:        []string{"/health", "/metrics"},
+		CollectMessageSize:    true,
+		CollectStreamMessages: true,
+	}
+
+	interceptor.UpdateConfig(newConfig)
+
+	config := interceptor.GetConfig()
+	assert.True(t, config.Enabled)
+	assert.Equal(t, []string{"/health", "/metrics"}, config.ExcludeMethods)
+	assert.True(t, config.CollectMessageSize)
+	assert.True(t, config.CollectStreamMessages)
+}
+
+func TestPrometheusGRPCInterceptor_UpdateConfigNil(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	originalConfig := &PrometheusGRPCConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, originalConfig)
+	interceptor.UpdateConfig(nil)
+
+	// Config should remain unchanged
+	assert.Equal(t, originalConfig, interceptor.GetConfig())
+}
+
+func TestPrometheusGRPCInterceptor_GetMethods(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+
+	assert.Equal(t, collector, interceptor.GetMetricsCollector())
+}
+
+func TestPrometheusGRPCInterceptor_ShouldExcludeMethod(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		ExcludeMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/test.Service/ExcludedMethod",
+		},
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+
+	tests := []struct {
+		method   string
+		excluded bool
+	}{
+		{"/grpc.health.v1.Health/Check", true},
+		{"/grpc.health.v1.Health/Watch", true},
+		{"/test.Service/ExcludedMethod", true},
+		{"/test.Service/IncludedMethod", false},
+		{"/grpc.health.v1.Health/Status", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.excluded, interceptor.shouldExcludeMethod(tt.method), "method: %s", tt.method)
+	}
+}
+
+func TestMetricsServerStream_SendRecvMsg(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:               true,
+		ServiceName:           "test-service",
+		CollectStreamMessages: true,
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+
+	ctx := context.Background()
+	mockStream := newMockServerStream(ctx)
+
+	wrappedStream := &metricsServerStream{
+		ServerStream: mockStream,
+		method:       "/test.TestService/TestStream",
+		interceptor:  interceptor,
+	}
+
+	t.Run("SendMsg", func(t *testing.T) {
+		collector.Reset()
+
+		err := wrappedStream.SendMsg("message")
+		assert.NoError(t, err)
+
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+		assert.Equal(t, 1, wrappedStream.sentCount)
+	})
+
+	t.Run("SendMsgWithError", func(t *testing.T) {
+		collector.Reset()
+		wrappedStream.sentCount = 0 // Reset sentCount from previous test
+
+		mockStream.setSendError(errors.New("send error"))
+
+		err := wrappedStream.SendMsg("message")
+		assert.Error(t, err)
+
+		// Should not increment counter on error
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+		assert.Equal(t, 0, wrappedStream.sentCount) // Should remain 0 after error
+	})
+
+	t.Run("RecvMsg", func(t *testing.T) {
+		collector.Reset()
+		wrappedStream.receivedCount = 0 // Reset receivedCount from previous tests
+		mockStream.setSendError(nil)    // Reset error
+
+		mockStream.addRecvMsg("message")
+
+		var msg interface{}
+		err := wrappedStream.RecvMsg(&msg)
+		assert.NoError(t, err)
+
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+		assert.Equal(t, 1, wrappedStream.receivedCount)
+	})
+
+	t.Run("RecvMsgWithError", func(t *testing.T) {
+		collector.Reset()
+		wrappedStream.receivedCount = 0 // Reset receivedCount from previous tests
+
+		mockStream.setRecvError(io.EOF)
+
+		var msg interface{}
+		err := wrappedStream.RecvMsg(&msg)
+		assert.Error(t, err)
+		assert.Equal(t, io.EOF, err)
+
+		// Should not increment counter on error
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+		assert.Equal(t, 0, wrappedStream.receivedCount) // Should remain 0 after error
+	})
+
+	t.Run("StreamMessagesDisabled", func(t *testing.T) {
+		disabledConfig := &PrometheusGRPCConfig{
+			Enabled:               true,
+			ServiceName:           "test-service",
+			CollectStreamMessages: false,
+		}
+		disabledInterceptor := NewPrometheusGRPCInterceptor(collector, disabledConfig)
+
+		wrappedStreamDisabled := &metricsServerStream{
+			ServerStream: mockStream,
+			method:       "/test.TestService/TestStream",
+			interceptor:  disabledInterceptor,
+		}
+
+		collector.Reset()
+		mockStream.setRecvError(nil) // Reset error
+		mockStream.addRecvMsg("message")
+
+		// Even with successful operations, metrics should not be collected
+		err := wrappedStreamDisabled.SendMsg("message")
+		assert.NoError(t, err)
+
+		var msg interface{}
+		err = wrappedStreamDisabled.RecvMsg(&msg)
+		assert.NoError(t, err)
+
+		expectedLabels := map[string]string{
+			"service": "test-service",
+			"method":  "/test.TestService/TestStream",
+		}
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+		assert.Equal(t, float64(0), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+	})
+}
+
+func TestPrometheusGRPCInterceptor_ConcurrentOperations(t *testing.T) {
+	collector := newMockGRPCMetricsCollector()
+	config := &PrometheusGRPCConfig{
+		Enabled:            true,
+		ServiceName:        "test-service",
+		CollectMessageSize: true,
+	}
+
+	interceptor := NewPrometheusGRPCInterceptor(collector, config)
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		time.Sleep(10 * time.Millisecond) // Simulate processing
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+	}
+
+	// Run concurrent requests
+	const numRequests = 20
+	var wg sync.WaitGroup
+
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ctx := context.Background()
+			resp, err := unaryInterceptor(ctx, "request", info, handler)
+
+			assert.NoError(t, err)
+			assert.Equal(t, "response", resp)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all requests were counted
+	expectedLabels := map[string]string{
+		"service": "test-service",
+		"method":  "/test.TestService/TestMethod",
+	}
+
+	assert.Equal(t, float64(numRequests), collector.getCounterValue("grpc_server_started_total", expectedLabels))
+	assert.Equal(t, float64(numRequests), collector.getCounterValue("grpc_server_msg_received_total", expectedLabels))
+	assert.Equal(t, float64(numRequests), collector.getCounterValue("grpc_server_msg_sent_total", expectedLabels))
+}
+
+// Benchmark tests to verify <5% overhead requirement
+func BenchmarkPrometheusGRPCInterceptor_UnaryEnabled(b *testing.B) {
+	collector := newMockGRPCMetricsCollector()
+	interceptor := NewPrometheusGRPCInterceptor(collector, &PrometheusGRPCConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	})
+
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/BenchmarkMethod",
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = unaryInterceptor(ctx, "request", info, handler)
+	}
+}
+
+func BenchmarkPrometheusGRPCInterceptor_UnaryDisabled(b *testing.B) {
+	collector := newMockGRPCMetricsCollector()
+	interceptor := NewPrometheusGRPCInterceptor(collector, &PrometheusGRPCConfig{
+		Enabled:     false,
+		ServiceName: "test-service",
+	})
+
+	unaryInterceptor := interceptor.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/BenchmarkMethod",
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = unaryInterceptor(ctx, "request", info, handler)
+	}
+}
+
+func BenchmarkPrometheusGRPCInterceptor_UnaryNoInterceptor(b *testing.B) {
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = handler(ctx, "request")
+	}
+}
+
+func BenchmarkPrometheusGRPCInterceptor_StreamEnabled(b *testing.B) {
+	collector := newMockGRPCMetricsCollector()
+	interceptor := NewPrometheusGRPCInterceptor(collector, &PrometheusGRPCConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	})
+
+	streamInterceptor := interceptor.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/test.TestService/BenchmarkStream",
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mockStream := newMockServerStream(ctx)
+		_ = streamInterceptor(nil, mockStream, info, handler)
+	}
+}
+
+func BenchmarkPrometheusGRPCInterceptor_StreamDisabled(b *testing.B) {
+	collector := newMockGRPCMetricsCollector()
+	interceptor := NewPrometheusGRPCInterceptor(collector, &PrometheusGRPCConfig{
+		Enabled:     false,
+		ServiceName: "test-service",
+	})
+
+	streamInterceptor := interceptor.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/test.TestService/BenchmarkStream",
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mockStream := newMockServerStream(ctx)
+		_ = streamInterceptor(nil, mockStream, info, handler)
+	}
+}

--- a/pkg/middleware/prometheus_http.go
+++ b/pkg/middleware/prometheus_http.go
@@ -1,0 +1,390 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package middleware
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+// PrometheusHTTPConfig configures the HTTP middleware for Prometheus metrics
+type PrometheusHTTPConfig struct {
+	// Enabled controls whether metrics collection is active
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// ExcludePaths contains paths to exclude from metrics (e.g., health checks)
+	ExcludePaths []string `yaml:"exclude_paths" json:"exclude_paths"`
+
+	// LabelSanitization controls whether to sanitize label values
+	LabelSanitization bool `yaml:"label_sanitization" json:"label_sanitization"`
+
+	// MaxPathCardinality limits the number of unique paths to prevent cardinality explosion
+	MaxPathCardinality int `yaml:"max_path_cardinality" json:"max_path_cardinality"`
+
+	// PathNormalization enables path normalization (e.g., /users/123 -> /users/:id)
+	PathNormalization bool `yaml:"path_normalization" json:"path_normalization"`
+
+	// CollectRequestSize enables request size metrics collection
+	CollectRequestSize bool `yaml:"collect_request_size" json:"collect_request_size"`
+
+	// CollectResponseSize enables response size metrics collection
+	CollectResponseSize bool `yaml:"collect_response_size" json:"collect_response_size"`
+
+	// ServiceName is the service name label for metrics
+	ServiceName string `yaml:"service_name" json:"service_name"`
+}
+
+// DefaultPrometheusHTTPConfig returns sensible defaults for HTTP metrics middleware
+func DefaultPrometheusHTTPConfig() *PrometheusHTTPConfig {
+	return &PrometheusHTTPConfig{
+		Enabled: true,
+		ExcludePaths: []string{
+			"/health",
+			"/metrics",
+			"/debug/health",
+			"/debug/metrics",
+		},
+		LabelSanitization:   true,
+		MaxPathCardinality:  1000,
+		PathNormalization:   true,
+		CollectRequestSize:  true,
+		CollectResponseSize: true,
+		ServiceName:         "unknown",
+	}
+}
+
+// PrometheusHTTPMiddleware provides HTTP metrics collection middleware
+type PrometheusHTTPMiddleware struct {
+	config           *PrometheusHTTPConfig
+	metricsCollector types.MetricsCollector
+	pathCounter      map[string]int
+}
+
+// NewPrometheusHTTPMiddleware creates a new HTTP metrics middleware
+func NewPrometheusHTTPMiddleware(collector types.MetricsCollector, config *PrometheusHTTPConfig) *PrometheusHTTPMiddleware {
+	if config == nil {
+		config = DefaultPrometheusHTTPConfig()
+	}
+
+	return &PrometheusHTTPMiddleware{
+		config:           config,
+		metricsCollector: collector,
+		pathCounter:      make(map[string]int),
+	}
+}
+
+// Middleware returns the Gin middleware function for HTTP metrics collection
+func (m *PrometheusHTTPMiddleware) Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Skip if metrics collection is disabled
+		if !m.config.Enabled {
+			c.Next()
+			return
+		}
+
+		// Check if this path should be excluded
+		if m.shouldExcludePath(c.Request.URL.Path) {
+			c.Next()
+			return
+		}
+
+		// Start timing the request
+		start := time.Now()
+
+		// Track active requests
+		m.incrementActiveRequests()
+		defer m.decrementActiveRequests()
+
+		// Collect request size if enabled
+		var requestSize int64
+		if m.config.CollectRequestSize && c.Request.ContentLength > 0 {
+			requestSize = c.Request.ContentLength
+		}
+
+		// Process the request
+		c.Next()
+
+		// Calculate request duration
+		duration := time.Since(start)
+
+		// Get normalized endpoint path
+		endpoint := m.getNormalizedPath(c)
+
+		// Collect metrics with error handling
+		m.collectRequestMetrics(c, endpoint, duration, requestSize)
+	}
+}
+
+// collectRequestMetrics collects all HTTP request metrics safely
+func (m *PrometheusHTTPMiddleware) collectRequestMetrics(c *gin.Context, endpoint string, duration time.Duration, requestSize int64) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Error("HTTP metrics collection panic",
+				zap.String("endpoint", endpoint),
+				zap.Any("panic", r))
+		}
+	}()
+
+	method := c.Request.Method
+	status := strconv.Itoa(c.Writer.Status())
+
+	// Common labels for all metrics
+	labels := map[string]string{
+		"service":  m.config.ServiceName,
+		"method":   method,
+		"endpoint": endpoint,
+	}
+
+	// Collect request count with status
+	countLabels := make(map[string]string)
+	for k, v := range labels {
+		countLabels[k] = v
+	}
+	countLabels["status"] = status
+
+	m.safeIncrementCounter("http_requests_total", countLabels)
+
+	// Collect request duration
+	m.safeObserveHistogram("http_request_duration_seconds", duration.Seconds(), labels)
+
+	// Collect request size if enabled and available
+	if m.config.CollectRequestSize && requestSize > 0 {
+		m.safeObserveHistogram("http_request_size_bytes", float64(requestSize), labels)
+	}
+
+	// Collect response size if enabled
+	if m.config.CollectResponseSize {
+		responseSize := float64(c.Writer.Size())
+		if responseSize > 0 {
+			m.safeObserveHistogram("http_response_size_bytes", responseSize, labels)
+		}
+	}
+}
+
+// incrementActiveRequests increments the active requests gauge
+func (m *PrometheusHTTPMiddleware) incrementActiveRequests() {
+	labels := map[string]string{
+		"service": m.config.ServiceName,
+	}
+	m.safeIncrementGauge("http_active_requests", labels)
+}
+
+// decrementActiveRequests decrements the active requests gauge
+func (m *PrometheusHTTPMiddleware) decrementActiveRequests() {
+	labels := map[string]string{
+		"service": m.config.ServiceName,
+	}
+	m.safeDecrementGauge("http_active_requests", labels)
+}
+
+// shouldExcludePath checks if a path should be excluded from metrics
+func (m *PrometheusHTTPMiddleware) shouldExcludePath(path string) bool {
+	for _, excludePath := range m.config.ExcludePaths {
+		if strings.HasPrefix(path, excludePath) {
+			return true
+		}
+	}
+	return false
+}
+
+// getNormalizedPath returns the normalized path for metrics
+func (m *PrometheusHTTPMiddleware) getNormalizedPath(c *gin.Context) string {
+	// Try to get the route pattern if available
+	if route := c.FullPath(); route != "" && m.config.PathNormalization {
+		return m.sanitizePath(route)
+	}
+
+	// Fallback to request path
+	path := c.Request.URL.Path
+
+	// Apply path normalization if enabled
+	if m.config.PathNormalization {
+		path = m.normalizePath(path)
+	}
+
+	// Check cardinality limits
+	if m.config.MaxPathCardinality > 0 {
+		if len(m.pathCounter) >= m.config.MaxPathCardinality {
+			// Use a generic "other" endpoint to prevent cardinality explosion
+			return "/other"
+		}
+		m.pathCounter[path]++
+	}
+
+	return m.sanitizePath(path)
+}
+
+// normalizePath normalizes paths to reduce cardinality
+func (m *PrometheusHTTPMiddleware) normalizePath(path string) string {
+	// Split path into segments
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+
+	for i, segment := range segments {
+		// Replace numeric segments with :id placeholder
+		if m.isNumeric(segment) {
+			segments[i] = ":id"
+		} else if m.isUUID(segment) {
+			segments[i] = ":uuid"
+		}
+	}
+
+	normalized := "/" + strings.Join(segments, "/")
+
+	// Clean up double slashes
+	normalized = strings.ReplaceAll(normalized, "//", "/")
+
+	return normalized
+}
+
+// sanitizePath sanitizes path for use as metric label
+func (m *PrometheusHTTPMiddleware) sanitizePath(path string) string {
+	if !m.config.LabelSanitization {
+		return path
+	}
+
+	// Remove or replace problematic characters
+	sanitized := strings.ReplaceAll(path, "\"", "")
+	sanitized = strings.ReplaceAll(sanitized, "\\", "")
+	sanitized = strings.ReplaceAll(sanitized, "\n", "")
+	sanitized = strings.ReplaceAll(sanitized, "\r", "")
+
+	return sanitized
+}
+
+// isNumeric checks if a string represents a number
+func (m *PrometheusHTTPMiddleware) isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
+
+// isUUID checks if a string looks like a UUID
+func (m *PrometheusHTTPMiddleware) isUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+
+	// Simple UUID format check: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	parts := strings.Split(s, "-")
+	return len(parts) == 5 &&
+		len(parts[0]) == 8 &&
+		len(parts[1]) == 4 &&
+		len(parts[2]) == 4 &&
+		len(parts[3]) == 4 &&
+		len(parts[4]) == 12
+}
+
+// Safe metric collection methods with error handling
+
+func (m *PrometheusHTTPMiddleware) safeIncrementCounter(name string, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("Counter increment panic",
+				zap.String("metric", name),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if m.metricsCollector != nil {
+		m.metricsCollector.IncrementCounter(name, labels)
+	}
+}
+
+func (m *PrometheusHTTPMiddleware) safeObserveHistogram(name string, value float64, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("Histogram observation panic",
+				zap.String("metric", name),
+				zap.Float64("value", value),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if m.metricsCollector != nil {
+		m.metricsCollector.ObserveHistogram(name, value, labels)
+	}
+}
+
+func (m *PrometheusHTTPMiddleware) safeIncrementGauge(name string, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("Gauge increment panic",
+				zap.String("metric", name),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if m.metricsCollector != nil {
+		m.metricsCollector.IncrementGauge(name, labels)
+	}
+}
+
+func (m *PrometheusHTTPMiddleware) safeDecrementGauge(name string, labels map[string]string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Logger.Debug("Gauge decrement panic",
+				zap.String("metric", name),
+				zap.Any("panic", r))
+		}
+	}()
+
+	if m.metricsCollector != nil {
+		m.metricsCollector.DecrementGauge(name, labels)
+	}
+}
+
+// GetConfig returns the middleware configuration
+func (m *PrometheusHTTPMiddleware) GetConfig() *PrometheusHTTPConfig {
+	return m.config
+}
+
+// UpdateConfig updates the middleware configuration (thread-safe for basic fields)
+func (m *PrometheusHTTPMiddleware) UpdateConfig(config *PrometheusHTTPConfig) {
+	if config == nil {
+		return
+	}
+
+	// Only update fields that are safe to change at runtime
+	m.config.Enabled = config.Enabled
+	m.config.ExcludePaths = config.ExcludePaths
+	m.config.CollectRequestSize = config.CollectRequestSize
+	m.config.CollectResponseSize = config.CollectResponseSize
+}
+
+// GetPathCardinality returns the current path cardinality count
+func (m *PrometheusHTTPMiddleware) GetPathCardinality() int {
+	return len(m.pathCounter)
+}
+
+// ResetPathCounter resets the path counter (useful for testing)
+func (m *PrometheusHTTPMiddleware) ResetPathCounter() {
+	m.pathCounter = make(map[string]int)
+}

--- a/pkg/middleware/prometheus_http_test.go
+++ b/pkg/middleware/prometheus_http_test.go
@@ -1,0 +1,1005 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+// mockMetricsCollector implements types.MetricsCollector for testing
+type mockMetricsCollector struct {
+	mu         sync.RWMutex
+	counters   map[string]float64
+	gauges     map[string]float64
+	histograms map[string][]float64
+	labels     map[string]map[string]string
+	panics     bool
+}
+
+func newMockMetricsCollector() *mockMetricsCollector {
+	return &mockMetricsCollector{
+		counters:   make(map[string]float64),
+		gauges:     make(map[string]float64),
+		histograms: make(map[string][]float64),
+		labels:     make(map[string]map[string]string),
+	}
+}
+
+func (m *mockMetricsCollector) IncrementCounter(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.counters[key]++
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) AddToCounter(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.counters[key] += value
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) SetGauge(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key] = value
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) IncrementGauge(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key]++
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) DecrementGauge(name string, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.gauges[key]--
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) ObserveHistogram(name string, value float64, labels map[string]string) {
+	if m.panics {
+		panic("test panic")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.getKey(name, labels)
+	m.histograms[key] = append(m.histograms[key], value)
+	m.labels[key] = m.copyLabels(labels)
+}
+
+func (m *mockMetricsCollector) GetMetrics() []types.Metric {
+	return nil
+}
+
+func (m *mockMetricsCollector) GetMetric(name string) (*types.Metric, bool) {
+	return nil, false
+}
+
+func (m *mockMetricsCollector) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.counters = make(map[string]float64)
+	m.gauges = make(map[string]float64)
+	m.histograms = make(map[string][]float64)
+	m.labels = make(map[string]map[string]string)
+}
+
+func (m *mockMetricsCollector) getKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+
+	// Sort label keys for deterministic key generation
+	var keys []string
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	parts = append(parts, name)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, labels[k]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (m *mockMetricsCollector) copyLabels(labels map[string]string) map[string]string {
+	copied := make(map[string]string)
+	for k, v := range labels {
+		copied[k] = v
+	}
+	return copied
+}
+
+// Helper methods for testing
+func (m *mockMetricsCollector) getCounterValue(name string, labels map[string]string) float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	return m.counters[key]
+}
+
+func (m *mockMetricsCollector) getGaugeValue(name string, labels map[string]string) float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	return m.gauges[key]
+}
+
+func (m *mockMetricsCollector) getHistogramValues(name string, labels map[string]string) []float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	key := m.getKey(name, labels)
+	values := make([]float64, len(m.histograms[key]))
+	copy(values, m.histograms[key])
+	return values
+}
+
+func (m *mockMetricsCollector) setPanics(panics bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.panics = panics
+}
+
+func TestDefaultPrometheusHTTPConfig(t *testing.T) {
+	config := DefaultPrometheusHTTPConfig()
+
+	assert.True(t, config.Enabled)
+	assert.True(t, config.LabelSanitization)
+	assert.True(t, config.PathNormalization)
+	assert.True(t, config.CollectRequestSize)
+	assert.True(t, config.CollectResponseSize)
+	assert.Equal(t, 1000, config.MaxPathCardinality)
+	assert.Equal(t, "unknown", config.ServiceName)
+
+	expectedExcludePaths := []string{
+		"/health",
+		"/metrics",
+		"/debug/health",
+		"/debug/metrics",
+	}
+	assert.Equal(t, expectedExcludePaths, config.ExcludePaths)
+}
+
+func TestNewPrometheusHTTPMiddleware(t *testing.T) {
+	collector := newMockMetricsCollector()
+
+	t.Run("WithConfig", func(t *testing.T) {
+		config := &PrometheusHTTPConfig{
+			Enabled:     true,
+			ServiceName: "test-service",
+		}
+
+		middleware := NewPrometheusHTTPMiddleware(collector, config)
+		assert.NotNil(t, middleware)
+		assert.Equal(t, config, middleware.config)
+		assert.Equal(t, collector, middleware.metricsCollector)
+		// Registry is no longer exposed in the middleware
+		assert.NotNil(t, middleware.pathCounter)
+	})
+
+	t.Run("WithNilConfig", func(t *testing.T) {
+		middleware := NewPrometheusHTTPMiddleware(collector, nil)
+		assert.NotNil(t, middleware)
+		assert.NotNil(t, middleware.config)
+		assert.Equal(t, DefaultPrometheusHTTPConfig(), middleware.config)
+	})
+}
+
+func TestPrometheusHTTPMiddleware_BasicMetrics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:             true,
+		ServiceName:         "test-service",
+		CollectRequestSize:  true,
+		CollectResponseSize: true,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	// Make a request
+	req := httptest.NewRequest("GET", "/api/users", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Verify metrics were collected
+	expectedLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users",
+	}
+
+	// Check request count with status
+	countLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users",
+		"status":   "200",
+	}
+	assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabels))
+
+	// Check request duration
+	durations := collector.getHistogramValues("http_request_duration_seconds", expectedLabels)
+	assert.Len(t, durations, 1)
+	assert.Greater(t, durations[0], float64(0))
+
+	// Check response size
+	responseSizes := collector.getHistogramValues("http_response_size_bytes", expectedLabels)
+	assert.Len(t, responseSizes, 1)
+	assert.Greater(t, responseSizes[0], float64(0))
+
+	// Check active requests (should be back to 0)
+	activeLabels := map[string]string{"service": "test-service"}
+	assert.Equal(t, float64(0), collector.getGaugeValue("http_active_requests", activeLabels))
+}
+
+func TestPrometheusHTTPMiddleware_DifferentHTTPMethods(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:           true,
+		ServiceName:       "test-service",
+		PathNormalization: true,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+	router.POST("/api/users", func(c *gin.Context) { c.JSON(201, gin.H{}) })
+	router.PUT("/api/users/:id", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+	router.DELETE("/api/users/:id", func(c *gin.Context) { c.JSON(204, gin.H{}) })
+
+	tests := []struct {
+		method       string
+		path         string
+		expectedPath string
+		status       int
+	}{
+		{"GET", "/api/users", "/api/users", 200},
+		{"POST", "/api/users", "/api/users", 201},
+		{"PUT", "/api/users/123", "/api/users/:id", 200},
+		{"DELETE", "/api/users/456", "/api/users/:id", 204},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+"_"+tt.path, func(t *testing.T) {
+			collector.Reset() // Reset for each test
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			countLabels := map[string]string{
+				"service":  "test-service",
+				"method":   tt.method,
+				"endpoint": tt.expectedPath,
+				"status":   fmt.Sprintf("%d", tt.status),
+			}
+
+			assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabels))
+		})
+	}
+}
+
+func TestPrometheusHTTPMiddleware_StatusCodes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	})
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/success", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+	router.GET("/created", func(c *gin.Context) { c.JSON(201, gin.H{}) })
+	router.GET("/badrequest", func(c *gin.Context) { c.JSON(400, gin.H{}) })
+	router.GET("/notfound", func(c *gin.Context) { c.JSON(404, gin.H{}) })
+	router.GET("/error", func(c *gin.Context) { c.JSON(500, gin.H{}) })
+
+	statuses := []int{200, 201, 400, 404, 500}
+
+	for _, status := range statuses {
+		path := ""
+		switch status {
+		case 200:
+			path = "/success"
+		case 201:
+			path = "/created"
+		case 400:
+			path = "/badrequest"
+		case 404:
+			path = "/notfound"
+		case 500:
+			path = "/error"
+		}
+
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		countLabels := map[string]string{
+			"service":  "test-service",
+			"method":   "GET",
+			"endpoint": path,
+			"status":   fmt.Sprintf("%d", status),
+		}
+
+		assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabels))
+	}
+}
+
+func TestPrometheusHTTPMiddleware_ExcludePaths(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:      true,
+		ServiceName:  "test-service",
+		ExcludePaths: []string{"/health", "/metrics"},
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/health", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+	router.GET("/metrics", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+	router.GET("/api/users", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	// Request excluded paths
+	req1 := httptest.NewRequest("GET", "/health", nil)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest("GET", "/metrics", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+
+	// Request non-excluded path
+	req3 := httptest.NewRequest("GET", "/api/users", nil)
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, req3)
+
+	// Verify excluded paths don't have metrics
+	excludedLabels1 := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/health",
+		"status":   "200",
+	}
+	excludedLabels2 := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/metrics",
+		"status":   "200",
+	}
+
+	assert.Equal(t, float64(0), collector.getCounterValue("http_requests_total", excludedLabels1))
+	assert.Equal(t, float64(0), collector.getCounterValue("http_requests_total", excludedLabels2))
+
+	// Verify non-excluded path has metrics
+	includedLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users",
+		"status":   "200",
+	}
+	assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", includedLabels))
+}
+
+func TestPrometheusHTTPMiddleware_PathNormalization(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:           true,
+		ServiceName:       "test-service",
+		PathNormalization: true,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	// Use a catch-all route to test manual path normalization
+	// This simulates cases where c.FullPath() doesn't return a useful pattern
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.NoRoute(func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	tests := []struct {
+		path         string
+		expectedPath string
+	}{
+		{"/api/users/123", "/api/users/:id"},
+		{"/api/users/456", "/api/users/:id"},
+		{"/api/users/abc-def-ghi", "/api/users/abc-def-ghi"}, // Not normalized (not numeric or UUID)
+		{"/api/users/f47ac10b-58cc-4372-a567-0e02b2c3d479", "/api/users/:uuid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+		})
+	}
+
+	// Count requests by normalized endpoint
+	countLabelsId := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users/:id",
+		"status":   "200",
+	}
+
+	countLabelsUuid := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users/:uuid",
+		"status":   "200",
+	}
+
+	// Should have 2 requests with :id normalization (123, 456)
+	assert.Equal(t, float64(2), collector.getCounterValue("http_requests_total", countLabelsId))
+
+	// Should have 1 request with :uuid normalization
+	assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabelsUuid))
+
+	// Should have 1 request with no normalization (abc-def-ghi)
+	countLabelsLiteral := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users/abc-def-ghi",
+		"status":   "200",
+	}
+	assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabelsLiteral))
+}
+
+func TestPrometheusHTTPMiddleware_CardinalityLimiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:            true,
+		ServiceName:        "test-service",
+		MaxPathCardinality: 2, // Low limit for testing
+		PathNormalization:  false,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/*path", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	// Make requests that would exceed cardinality
+	paths := []string{"/path1", "/path2", "/path3", "/path4"}
+	for _, path := range paths {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+
+	// First two paths should be tracked normally
+	for i := 0; i < 2; i++ {
+		labels := map[string]string{
+			"service":  "test-service",
+			"method":   "GET",
+			"endpoint": paths[i],
+			"status":   "200",
+		}
+		assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", labels))
+	}
+
+	// Remaining paths should be collapsed to "/other"
+	otherLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/other",
+		"status":   "200",
+	}
+	assert.Equal(t, float64(2), collector.getCounterValue("http_requests_total", otherLabels))
+
+	// Verify cardinality
+	assert.Equal(t, 2, middleware.GetPathCardinality())
+}
+
+func TestPrometheusHTTPMiddleware_RequestAndResponseSize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:             true,
+		ServiceName:         "test-service",
+		CollectRequestSize:  true,
+		CollectResponseSize: true,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.POST("/api/data", func(c *gin.Context) {
+		c.JSON(200, gin.H{"result": "processed", "data": "response body content"})
+	})
+
+	// Create request with body
+	body := `{"test": "data", "content": "request body content"}`
+	req := httptest.NewRequest("POST", "/api/data", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	expectedLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "POST",
+		"endpoint": "/api/data",
+	}
+
+	// Check request size was recorded
+	requestSizes := collector.getHistogramValues("http_request_size_bytes", expectedLabels)
+	assert.Len(t, requestSizes, 1)
+	assert.Equal(t, float64(len(body)), requestSizes[0])
+
+	// Check response size was recorded
+	responseSizes := collector.getHistogramValues("http_response_size_bytes", expectedLabels)
+	assert.Len(t, responseSizes, 1)
+	assert.Greater(t, responseSizes[0], float64(0))
+}
+
+func TestPrometheusHTTPMiddleware_LabelSanitization(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:           true,
+		ServiceName:       "test-service",
+		LabelSanitization: true,
+		PathNormalization: false,
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/*path", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	// Test path sanitization directly in middleware by making a valid request
+	// and checking that our sanitize function works
+	validPath := "/api/test-path"
+	req := httptest.NewRequest("GET", validPath, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Check that the path is recorded correctly
+	countLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": validPath,
+		"status":   "200",
+	}
+
+	assert.Equal(t, float64(1), collector.getCounterValue("http_requests_total", countLabels))
+
+	// Test the sanitization function directly
+	unsanitizedPath := "/api/test\"with\\quotes\nand\rreturns"
+	sanitized := middleware.sanitizePath(unsanitizedPath)
+	expected := "/api/testwithquotesandreturns"
+	assert.Equal(t, expected, sanitized)
+}
+
+func TestPrometheusHTTPMiddleware_Disabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:     false,
+		ServiceName: "test-service",
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	req := httptest.NewRequest("GET", "/api/users", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// No metrics should be collected when disabled
+	countLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users",
+		"status":   "200",
+	}
+
+	assert.Equal(t, float64(0), collector.getCounterValue("http_requests_total", countLabels))
+}
+
+func TestPrometheusHTTPMiddleware_PanicRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	// Enable panics in the collector
+	collector.setPanics(true)
+
+	// Request should still complete despite panic in metrics collection
+	req := httptest.NewRequest("GET", "/api/users", nil)
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		router.ServeHTTP(w, req)
+	})
+
+	assert.Equal(t, 200, w.Code)
+}
+
+func TestPrometheusHTTPMiddleware_UpdateConfig(t *testing.T) {
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:             false,
+		ExcludePaths:        []string{"/health"},
+		CollectRequestSize:  false,
+		CollectResponseSize: false,
+	})
+
+	newConfig := &PrometheusHTTPConfig{
+		Enabled:             true,
+		ExcludePaths:        []string{"/health", "/metrics"},
+		CollectRequestSize:  true,
+		CollectResponseSize: true,
+	}
+
+	middleware.UpdateConfig(newConfig)
+
+	config := middleware.GetConfig()
+	assert.True(t, config.Enabled)
+	assert.Equal(t, []string{"/health", "/metrics"}, config.ExcludePaths)
+	assert.True(t, config.CollectRequestSize)
+	assert.True(t, config.CollectResponseSize)
+}
+
+func TestPrometheusHTTPMiddleware_UpdateConfigNil(t *testing.T) {
+	collector := newMockMetricsCollector()
+	originalConfig := &PrometheusHTTPConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, originalConfig)
+	middleware.UpdateConfig(nil)
+
+	// Config should remain unchanged
+	assert.Equal(t, originalConfig, middleware.GetConfig())
+}
+
+func TestPrometheusHTTPMiddleware_ResetPathCounter(t *testing.T) {
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:            true,
+		ServiceName:        "test-service",
+		MaxPathCardinality: 10,
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/*path", func(c *gin.Context) { c.JSON(200, gin.H{}) })
+
+	// Make some requests to populate path counter
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", fmt.Sprintf("/path%d", i), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+
+	assert.Equal(t, 5, middleware.GetPathCardinality())
+
+	// Reset the counter
+	middleware.ResetPathCounter()
+	assert.Equal(t, 0, middleware.GetPathCardinality())
+}
+
+func TestPrometheusHTTPMiddleware_UtilityFunctions(t *testing.T) {
+	middleware := NewPrometheusHTTPMiddleware(nil, nil)
+
+	t.Run("isNumeric", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			expected bool
+		}{
+			{"123", true},
+			{"0", true},
+			{"-123", true},
+			{"abc", false},
+			{"12a", false},
+			{"", false},
+		}
+
+		for _, tt := range tests {
+			assert.Equal(t, tt.expected, middleware.isNumeric(tt.input), "input: %s", tt.input)
+		}
+	})
+
+	t.Run("isUUID", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			expected bool
+		}{
+			{"f47ac10b-58cc-4372-a567-0e02b2c3d479", true},
+			{"00000000-0000-0000-0000-000000000000", true},
+			{"not-a-uuid", false},
+			{"f47ac10b-58cc-4372-a567-0e02b2c3d47", false},   // too short
+			{"f47ac10b-58cc-4372-a567-0e02b2c3d4799", false}, // too long
+			{"", false},
+		}
+
+		for _, tt := range tests {
+			assert.Equal(t, tt.expected, middleware.isUUID(tt.input), "input: %s", tt.input)
+		}
+	})
+
+	t.Run("shouldExcludePath", func(t *testing.T) {
+		config := &PrometheusHTTPConfig{
+			ExcludePaths: []string{"/health", "/metrics", "/debug"},
+		}
+		middleware := NewPrometheusHTTPMiddleware(nil, config)
+
+		tests := []struct {
+			path     string
+			excluded bool
+		}{
+			{"/health", true},
+			{"/health/check", true},
+			{"/metrics", true},
+			{"/debug/info", true},
+			{"/api/users", false},
+			{"/healthcheck", true}, // Should be excluded due to /health prefix
+		}
+
+		for _, tt := range tests {
+			assert.Equal(t, tt.excluded, middleware.shouldExcludePath(tt.path), "path: %s", tt.path)
+		}
+	})
+}
+
+func TestPrometheusHTTPMiddleware_ConcurrentRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	config := &PrometheusHTTPConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	}
+
+	middleware := NewPrometheusHTTPMiddleware(collector, config)
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users", func(c *gin.Context) {
+		time.Sleep(10 * time.Millisecond) // Simulate some processing time
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	// Make concurrent requests
+	const numRequests = 10
+	var wg sync.WaitGroup
+
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest("GET", "/api/users", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, 200, w.Code)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all requests were counted
+	countLabels := map[string]string{
+		"service":  "test-service",
+		"method":   "GET",
+		"endpoint": "/api/users",
+		"status":   "200",
+	}
+
+	assert.Equal(t, float64(numRequests), collector.getCounterValue("http_requests_total", countLabels))
+
+	// Verify active requests gauge is back to 0
+	activeLabels := map[string]string{"service": "test-service"}
+	assert.Equal(t, float64(0), collector.getGaugeValue("http_active_requests", activeLabels))
+}
+
+// Benchmark tests to verify <5% overhead requirement
+func BenchmarkPrometheusHTTPMiddleware_Enabled(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:     true,
+		ServiceName: "test-service",
+	})
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/benchmark", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "benchmark"})
+	})
+
+	req := httptest.NewRequest("GET", "/api/benchmark", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+}
+
+func BenchmarkPrometheusHTTPMiddleware_Disabled(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:     false,
+		ServiceName: "test-service",
+	})
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/benchmark", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "benchmark"})
+	})
+
+	req := httptest.NewRequest("GET", "/api/benchmark", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+}
+
+func BenchmarkPrometheusHTTPMiddleware_WithoutMiddleware(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/api/benchmark", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "benchmark"})
+	})
+
+	req := httptest.NewRequest("GET", "/api/benchmark", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+}
+
+func BenchmarkPrometheusHTTPMiddleware_PathNormalization(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+
+	collector := newMockMetricsCollector()
+	middleware := NewPrometheusHTTPMiddleware(collector, &PrometheusHTTPConfig{
+		Enabled:           true,
+		ServiceName:       "test-service",
+		PathNormalization: true,
+	})
+
+	router := gin.New()
+	router.Use(middleware.Middleware())
+	router.GET("/api/users/*id", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "benchmark"})
+	})
+
+	requests := make([]*http.Request, 1000)
+	for i := range requests {
+		requests[i] = httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d", i), nil)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := requests[i%len(requests)]
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+}

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -1,0 +1,65 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package types
+
+// MetricsCollector defines the interface for collecting metrics
+// This interface is defined in types to avoid import cycles between middleware and server packages
+type MetricsCollector interface {
+	// Counter operations
+	IncrementCounter(name string, labels map[string]string)
+	AddToCounter(name string, value float64, labels map[string]string)
+
+	// Gauge operations
+	SetGauge(name string, value float64, labels map[string]string)
+	IncrementGauge(name string, labels map[string]string)
+	DecrementGauge(name string, labels map[string]string)
+
+	// Histogram operations
+	ObserveHistogram(name string, value float64, labels map[string]string)
+
+	// Metric retrieval
+	GetMetrics() []Metric
+	GetMetric(name string) (*Metric, bool)
+
+	// Cleanup
+	Reset()
+}
+
+// MetricType represents the type of a metric
+type MetricType string
+
+const (
+	CounterType   MetricType = "counter"
+	GaugeType     MetricType = "gauge"
+	HistogramType MetricType = "histogram"
+	SummaryType   MetricType = "summary"
+)
+
+// Metric represents a collected metric with its metadata
+type Metric struct {
+	Name        string            `json:"name"`
+	Type        MetricType        `json:"type"`
+	Value       float64           `json:"value"`
+	Labels      map[string]string `json:"labels"`
+	Timestamp   int64             `json:"timestamp"`
+	Description string            `json:"description,omitempty"`
+}


### PR DESCRIPTION
This pull request introduces comprehensive Prometheus metrics middleware for both HTTP (Gin) and gRPC servers, enabling robust, configurable observability for service endpoints. It also enhances the observability manager to support custom Prometheus handlers, improving integration flexibility.

**Prometheus Metrics Middleware Implementation**

* Added a new HTTP middleware (`prometheus_http.go`) for Gin that collects request/response metrics, supports path normalization, cardinality control, and configurable exclusion of paths. The middleware is robust against panics during metric collection and exposes runtime configuration updates.
* Added a new gRPC interceptor (`prometheus_grpc.go`) that collects unary and streaming RPC metrics, allows exclusion of specific methods, and supports runtime configuration updates. The interceptor is designed to safely handle errors and panics during metric collection.

**Observability Manager Enhancements**

* Introduced the `PrometheusHandler` interface and added support for storing and setting a custom Prometheus handler in the `ObservabilityManager` struct, allowing for flexible metrics endpoint integration. [[1]](diffhunk://#diff-dc294d94ef7f9543d2edbdba997acb89f6b6ead7b666a84524300176d54a32a2R421-R433) [[2]](diffhunk://#diff-dc294d94ef7f9543d2edbdba997acb89f6b6ead7b666a84524300176d54a32a2R456-R460)
* Updated the `/debug/metrics` endpoint to clarify its output as JSON for debugging purposes, separating it from Prometheus-formatted metrics.