### PR TITLE
feat: Implement Phase 3 Prometheus metrics integration

### DIFF
--- a/pkg/middleware/prometheus_grpc_test.go
+++ b/pkg/middleware/prometheus_grpc_test.go
@@ -887,7 +887,7 @@ func TestMetricsServerStream_SendRecvMsg(t *testing.T) {
 	t.Run("RecvMsg", func(t *testing.T) {
 		collector.Reset()
 		atomic.StoreInt64(&wrappedStream.receivedCount, 0) // Reset receivedCount from previous tests
-		mockStream.setSendError(nil)    // Reset error
+		mockStream.setSendError(nil)                       // Reset error
 
 		mockStream.addRecvMsg("message")
 
@@ -1262,7 +1262,7 @@ func TestPrometheusGRPCInterceptor_AtomicMessageCounting(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				
+
 				// Each goroutine gets its own mock to avoid race conditions in test mock
 				mockStream := newMockServerStream(ctx)
 				wrappedStream := &metricsServerStream{
@@ -1272,12 +1272,12 @@ func TestPrometheusGRPCInterceptor_AtomicMessageCounting(t *testing.T) {
 					sentCount:     0,
 					receivedCount: 0,
 				}
-				
+
 				// Send messages
 				for j := 0; j < numOperations/10; j++ {
 					wrappedStream.SendMsg(&struct{}{})
 				}
-				
+
 				// Atomically add to total
 				atomic.AddInt64(&totalSent, atomic.LoadInt64(&wrappedStream.sentCount))
 			}()
@@ -1298,15 +1298,15 @@ func TestPrometheusGRPCInterceptor_AtomicMessageCounting(t *testing.T) {
 			wg.Add(1)
 			go func(goroutineID int) {
 				defer wg.Done()
-				
+
 				// Each goroutine gets its own mock to avoid race conditions in test mock
 				mockStream := newMockServerStream(ctx)
-				
+
 				// Pre-populate with messages for this goroutine
 				for k := 0; k < numOperations/10; k++ {
 					mockStream.addRecvMsg(fmt.Sprintf("msg-%d-%d", goroutineID, k))
 				}
-				
+
 				wrappedStream := &metricsServerStream{
 					ServerStream:  mockStream,
 					method:        "/test.TestService/AtomicTest",
@@ -1314,13 +1314,13 @@ func TestPrometheusGRPCInterceptor_AtomicMessageCounting(t *testing.T) {
 					sentCount:     0,
 					receivedCount: 0,
 				}
-				
+
 				// Receive messages
 				for j := 0; j < numOperations/10; j++ {
 					var msg interface{}
 					wrappedStream.RecvMsg(&msg)
 				}
-				
+
 				// Atomically add to total
 				atomic.AddInt64(&totalReceived, atomic.LoadInt64(&wrappedStream.receivedCount))
 			}(i)

--- a/pkg/server/business_metrics.go
+++ b/pkg/server/business_metrics.go
@@ -1,0 +1,403 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/innovationmech/swit/pkg/logger"
+)
+
+// BusinessMetricsHook defines the interface for custom business metrics hooks
+type BusinessMetricsHook interface {
+	// OnMetricRecorded is called when a business metric is recorded
+	OnMetricRecorded(event BusinessMetricEvent)
+
+	// GetHookName returns a unique name for this hook
+	GetHookName() string
+}
+
+// BusinessMetricEvent represents a business metric event
+type BusinessMetricEvent struct {
+	Name      string            `json:"name"`
+	Type      MetricType        `json:"type"`
+	Value     interface{}       `json:"value"`
+	Labels    map[string]string `json:"labels"`
+	Timestamp time.Time         `json:"timestamp"`
+	Source    string            `json:"source"` // Service or component that recorded the metric
+}
+
+// BusinessMetricsManager manages custom business metrics and hooks
+type BusinessMetricsManager struct {
+	collector   MetricsCollector
+	registry    *MetricsRegistry
+	hooks       []BusinessMetricsHook
+	serviceName string
+
+	// Hook management
+	mu          sync.RWMutex
+	hooksByName map[string]BusinessMetricsHook
+}
+
+// NewBusinessMetricsManager creates a new business metrics manager
+func NewBusinessMetricsManager(serviceName string, collector MetricsCollector, registry *MetricsRegistry) *BusinessMetricsManager {
+	if collector == nil {
+		collector = NewSimpleMetricsCollector()
+	}
+	if registry == nil {
+		registry = NewMetricsRegistry()
+	}
+
+	return &BusinessMetricsManager{
+		collector:   collector,
+		registry:    registry,
+		serviceName: serviceName,
+		hooks:       make([]BusinessMetricsHook, 0),
+		hooksByName: make(map[string]BusinessMetricsHook),
+	}
+}
+
+// RegisterHook registers a business metrics hook
+func (bmm *BusinessMetricsManager) RegisterHook(hook BusinessMetricsHook) error {
+	if hook == nil {
+		return fmt.Errorf("hook cannot be nil")
+	}
+
+	hookName := hook.GetHookName()
+	if hookName == "" {
+		return fmt.Errorf("hook name cannot be empty")
+	}
+
+	bmm.mu.Lock()
+	defer bmm.mu.Unlock()
+
+	// Check if hook already exists
+	if _, exists := bmm.hooksByName[hookName]; exists {
+		return fmt.Errorf("hook with name %s already registered", hookName)
+	}
+
+	bmm.hooks = append(bmm.hooks, hook)
+	bmm.hooksByName[hookName] = hook
+
+	logger.Logger.Debug("Business metrics hook registered",
+		zap.String("hook_name", hookName))
+
+	return nil
+}
+
+// UnregisterHook removes a business metrics hook by name
+func (bmm *BusinessMetricsManager) UnregisterHook(hookName string) error {
+	bmm.mu.Lock()
+	defer bmm.mu.Unlock()
+
+	hook, exists := bmm.hooksByName[hookName]
+	if !exists {
+		return fmt.Errorf("hook with name %s not found", hookName)
+	}
+
+	// Remove from hooks slice
+	for i, h := range bmm.hooks {
+		if h == hook {
+			bmm.hooks = append(bmm.hooks[:i], bmm.hooks[i+1:]...)
+			break
+		}
+	}
+
+	// Remove from map
+	delete(bmm.hooksByName, hookName)
+
+	logger.Logger.Debug("Business metrics hook unregistered",
+		zap.String("hook_name", hookName))
+
+	return nil
+}
+
+// GetRegisteredHooks returns the names of all registered hooks
+func (bmm *BusinessMetricsManager) GetRegisteredHooks() []string {
+	bmm.mu.RLock()
+	defer bmm.mu.RUnlock()
+
+	names := make([]string, 0, len(bmm.hooksByName))
+	for name := range bmm.hooksByName {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// RecordCounter records a counter metric and triggers hooks
+func (bmm *BusinessMetricsManager) RecordCounter(name string, value float64, labels map[string]string) {
+	// Add service label if not present
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, exists := labels["service"]; !exists {
+		labels["service"] = bmm.serviceName
+	}
+
+	// Record in collector
+	if value == 1.0 {
+		bmm.collector.IncrementCounter(name, labels)
+	} else {
+		bmm.collector.AddToCounter(name, value, labels)
+	}
+
+	// Create and trigger event
+	event := BusinessMetricEvent{
+		Name:      name,
+		Type:      MetricTypeCounter,
+		Value:     value,
+		Labels:    labels,
+		Timestamp: time.Now(),
+		Source:    bmm.serviceName,
+	}
+
+	bmm.triggerHooks(event)
+}
+
+// RecordGauge records a gauge metric and triggers hooks
+func (bmm *BusinessMetricsManager) RecordGauge(name string, value float64, labels map[string]string) {
+	// Add service label if not present
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, exists := labels["service"]; !exists {
+		labels["service"] = bmm.serviceName
+	}
+
+	// Record in collector
+	bmm.collector.SetGauge(name, value, labels)
+
+	// Create and trigger event
+	event := BusinessMetricEvent{
+		Name:      name,
+		Type:      MetricTypeGauge,
+		Value:     value,
+		Labels:    labels,
+		Timestamp: time.Now(),
+		Source:    bmm.serviceName,
+	}
+
+	bmm.triggerHooks(event)
+}
+
+// RecordHistogram records a histogram metric and triggers hooks
+func (bmm *BusinessMetricsManager) RecordHistogram(name string, value float64, labels map[string]string) {
+	// Add service label if not present
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, exists := labels["service"]; !exists {
+		labels["service"] = bmm.serviceName
+	}
+
+	// Record in collector
+	bmm.collector.ObserveHistogram(name, value, labels)
+
+	// Create and trigger event
+	event := BusinessMetricEvent{
+		Name:      name,
+		Type:      MetricTypeHistogram,
+		Value:     value,
+		Labels:    labels,
+		Timestamp: time.Now(),
+		Source:    bmm.serviceName,
+	}
+
+	bmm.triggerHooks(event)
+}
+
+// RegisterCustomMetric registers a custom metric definition
+func (bmm *BusinessMetricsManager) RegisterCustomMetric(definition MetricDefinition) error {
+	return bmm.registry.RegisterMetric(definition)
+}
+
+// GetCustomMetric retrieves a custom metric definition
+func (bmm *BusinessMetricsManager) GetCustomMetric(name string) (*MetricDefinition, bool) {
+	return bmm.registry.GetMetricDefinition(name)
+}
+
+// GetAllMetrics returns all metric definitions (predefined + custom)
+func (bmm *BusinessMetricsManager) GetAllMetrics() map[string]MetricDefinition {
+	// Since MetricsRegistry doesn't have GetAllMetrics, we'll build it
+	allMetrics := make(map[string]MetricDefinition)
+
+	// Get predefined metrics
+	predefinedNames := bmm.registry.GetPredefinedMetricNames()
+	for _, name := range predefinedNames {
+		if def, exists := bmm.registry.GetMetricDefinition(name); exists {
+			allMetrics[name] = *def
+		}
+	}
+
+	// Get custom metrics
+	customNames := bmm.registry.GetCustomMetricNames()
+	for _, name := range customNames {
+		if def, exists := bmm.registry.GetMetricDefinition(name); exists {
+			allMetrics[name] = *def
+		}
+	}
+
+	return allMetrics
+}
+
+// GetCollector returns the underlying metrics collector
+func (bmm *BusinessMetricsManager) GetCollector() MetricsCollector {
+	return bmm.collector
+}
+
+// GetRegistry returns the metrics registry
+func (bmm *BusinessMetricsManager) GetRegistry() *MetricsRegistry {
+	return bmm.registry
+}
+
+// triggerHooks safely triggers all registered hooks
+func (bmm *BusinessMetricsManager) triggerHooks(event BusinessMetricEvent) {
+	bmm.mu.RLock()
+	hooks := make([]BusinessMetricsHook, len(bmm.hooks))
+	copy(hooks, bmm.hooks)
+	bmm.mu.RUnlock()
+
+	// Trigger hooks concurrently to avoid blocking
+	for _, hook := range hooks {
+		go func(h BusinessMetricsHook) {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Logger.Error("Business metrics hook panicked",
+						zap.String("hook_name", h.GetHookName()),
+						zap.String("metric_name", event.Name),
+						zap.Any("panic", r))
+				}
+			}()
+
+			h.OnMetricRecorded(event)
+		}(hook)
+	}
+}
+
+// DefaultBusinessMetricsHooks provides common hook implementations
+
+// LoggingBusinessMetricsHook logs all business metric events
+type LoggingBusinessMetricsHook struct {
+	name string
+}
+
+// NewLoggingBusinessMetricsHook creates a new logging hook
+func NewLoggingBusinessMetricsHook() *LoggingBusinessMetricsHook {
+	return &LoggingBusinessMetricsHook{
+		name: "logging_hook",
+	}
+}
+
+// OnMetricRecorded logs the metric event
+func (lbmh *LoggingBusinessMetricsHook) OnMetricRecorded(event BusinessMetricEvent) {
+	logger.Logger.Debug("Business metric recorded",
+		zap.String("name", event.Name),
+		zap.String("type", string(event.Type)),
+		zap.Any("value", event.Value),
+		zap.Any("labels", event.Labels),
+		zap.String("source", event.Source),
+		zap.Time("timestamp", event.Timestamp))
+}
+
+// GetHookName returns the hook name
+func (lbmh *LoggingBusinessMetricsHook) GetHookName() string {
+	return lbmh.name
+}
+
+// AggregationBusinessMetricsHook aggregates metrics for summary reporting
+type AggregationBusinessMetricsHook struct {
+	name     string
+	counters map[string]float64
+	gauges   map[string]float64
+	mu       sync.RWMutex
+}
+
+// NewAggregationBusinessMetricsHook creates a new aggregation hook
+func NewAggregationBusinessMetricsHook() *AggregationBusinessMetricsHook {
+	return &AggregationBusinessMetricsHook{
+		name:     "aggregation_hook",
+		counters: make(map[string]float64),
+		gauges:   make(map[string]float64),
+	}
+}
+
+// OnMetricRecorded aggregates the metric value
+func (abmh *AggregationBusinessMetricsHook) OnMetricRecorded(event BusinessMetricEvent) {
+	abmh.mu.Lock()
+	defer abmh.mu.Unlock()
+
+	key := fmt.Sprintf("%s_%s", event.Source, event.Name)
+
+	switch event.Type {
+	case MetricTypeCounter:
+		if value, ok := event.Value.(float64); ok {
+			abmh.counters[key] += value
+		}
+	case MetricTypeGauge:
+		if value, ok := event.Value.(float64); ok {
+			abmh.gauges[key] = value // Gauges are set, not added
+		}
+	}
+}
+
+// GetHookName returns the hook name
+func (abmh *AggregationBusinessMetricsHook) GetHookName() string {
+	return abmh.name
+}
+
+// GetCounterTotals returns the aggregated counter totals
+func (abmh *AggregationBusinessMetricsHook) GetCounterTotals() map[string]float64 {
+	abmh.mu.RLock()
+	defer abmh.mu.RUnlock()
+
+	totals := make(map[string]float64)
+	for k, v := range abmh.counters {
+		totals[k] = v
+	}
+	return totals
+}
+
+// GetGaugeValues returns the current gauge values
+func (abmh *AggregationBusinessMetricsHook) GetGaugeValues() map[string]float64 {
+	abmh.mu.RLock()
+	defer abmh.mu.RUnlock()
+
+	values := make(map[string]float64)
+	for k, v := range abmh.gauges {
+		values[k] = v
+	}
+	return values
+}
+
+// Reset clears all aggregated data
+func (abmh *AggregationBusinessMetricsHook) Reset() {
+	abmh.mu.Lock()
+	defer abmh.mu.Unlock()
+
+	abmh.counters = make(map[string]float64)
+	abmh.gauges = make(map[string]float64)
+}

--- a/pkg/server/business_metrics_test.go
+++ b/pkg/server/business_metrics_test.go
@@ -1,0 +1,469 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBusinessMetricsManager(t *testing.T) {
+	t.Run("with custom collector and registry", func(t *testing.T) {
+		collector := NewSimpleMetricsCollector()
+		registry := NewMetricsRegistry()
+
+		bmm := NewBusinessMetricsManager("test-service", collector, registry)
+
+		assert.NotNil(t, bmm)
+		assert.Equal(t, "test-service", bmm.serviceName)
+		assert.Same(t, collector, bmm.collector)
+		assert.Same(t, registry, bmm.registry)
+		assert.Empty(t, bmm.GetRegisteredHooks())
+	})
+
+	t.Run("with nil collector and registry", func(t *testing.T) {
+		bmm := NewBusinessMetricsManager("test-service", nil, nil)
+
+		assert.NotNil(t, bmm)
+		assert.Equal(t, "test-service", bmm.serviceName)
+		assert.NotNil(t, bmm.collector)
+		assert.NotNil(t, bmm.registry)
+	})
+}
+
+func TestBusinessMetricsManager_RegisterHook(t *testing.T) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+
+	t.Run("register valid hook", func(t *testing.T) {
+		hook := NewLoggingBusinessMetricsHook()
+
+		err := bmm.RegisterHook(hook)
+
+		assert.NoError(t, err)
+		assert.Contains(t, bmm.GetRegisteredHooks(), hook.GetHookName())
+	})
+
+	t.Run("register nil hook", func(t *testing.T) {
+		err := bmm.RegisterHook(nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "hook cannot be nil")
+	})
+
+	t.Run("register hook with empty name", func(t *testing.T) {
+		hook := &testBusinessMetricsHook{name: ""}
+
+		err := bmm.RegisterHook(hook)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "hook name cannot be empty")
+	})
+
+	t.Run("register duplicate hook", func(t *testing.T) {
+		hook1 := &testBusinessMetricsHook{name: "test_hook"}
+		hook2 := &testBusinessMetricsHook{name: "test_hook"}
+
+		err1 := bmm.RegisterHook(hook1)
+		err2 := bmm.RegisterHook(hook2)
+
+		assert.NoError(t, err1)
+		assert.Error(t, err2)
+		assert.Contains(t, err2.Error(), "already registered")
+	})
+}
+
+func TestBusinessMetricsManager_UnregisterHook(t *testing.T) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+	hook := NewLoggingBusinessMetricsHook()
+
+	t.Run("unregister existing hook", func(t *testing.T) {
+		_ = bmm.RegisterHook(hook)
+
+		err := bmm.UnregisterHook(hook.GetHookName())
+
+		assert.NoError(t, err)
+		assert.NotContains(t, bmm.GetRegisteredHooks(), hook.GetHookName())
+	})
+
+	t.Run("unregister non-existent hook", func(t *testing.T) {
+		err := bmm.UnregisterHook("non-existent")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestBusinessMetricsManager_RecordMetrics(t *testing.T) {
+	collector := NewSimpleMetricsCollector()
+	bmm := NewBusinessMetricsManager("test-service", collector, nil)
+
+	// Add a test hook to verify events are triggered
+	testHook := &testBusinessMetricsHook{name: "test_hook"}
+	_ = bmm.RegisterHook(testHook)
+
+	t.Run("record counter metric", func(t *testing.T) {
+		labels := map[string]string{"endpoint": "/api/test"}
+
+		bmm.RecordCounter("api_requests_total", 1.0, labels)
+
+		// Allow time for goroutine to execute
+		time.Sleep(10 * time.Millisecond)
+
+		// Verify metric was recorded in collector
+		metrics := collector.GetMetrics()
+		var found bool
+		for _, metric := range metrics {
+			if metric.Name == "api_requests_total" {
+				found = true
+				assert.Equal(t, MetricTypeCounter, metric.Type)
+				assert.Equal(t, int64(1), metric.Value)
+				assert.Equal(t, "test-service", metric.Labels["service"])
+				assert.Equal(t, "/api/test", metric.Labels["endpoint"])
+				break
+			}
+		}
+		assert.True(t, found, "Counter metric not found")
+
+		// Verify hook was triggered
+		testHook.mu.RLock()
+		assert.True(t, len(testHook.events) > 0)
+		lastEvent := testHook.events[len(testHook.events)-1]
+		assert.Equal(t, "api_requests_total", lastEvent.Name)
+		assert.Equal(t, MetricTypeCounter, lastEvent.Type)
+		testHook.mu.RUnlock()
+	})
+
+	t.Run("record gauge metric", func(t *testing.T) {
+		labels := map[string]string{"queue": "processing"}
+
+		bmm.RecordGauge("queue_size", 42.0, labels)
+
+		// Allow time for goroutine to execute
+		time.Sleep(10 * time.Millisecond)
+
+		// Verify metric was recorded in collector
+		metrics := collector.GetMetrics()
+		var found bool
+		for _, metric := range metrics {
+			if metric.Name == "queue_size" {
+				found = true
+				assert.Equal(t, MetricTypeGauge, metric.Type)
+				assert.Equal(t, 42.0, metric.Value)
+				assert.Equal(t, "test-service", metric.Labels["service"])
+				assert.Equal(t, "processing", metric.Labels["queue"])
+				break
+			}
+		}
+		assert.True(t, found, "Gauge metric not found")
+	})
+
+	t.Run("record histogram metric", func(t *testing.T) {
+		labels := map[string]string{"method": "GET"}
+
+		bmm.RecordHistogram("http_request_duration_seconds", 0.123, labels)
+
+		// Allow time for goroutine to execute
+		time.Sleep(10 * time.Millisecond)
+
+		// Verify metric was recorded in collector
+		metrics := collector.GetMetrics()
+		var found bool
+		for _, metric := range metrics {
+			if metric.Name == "http_request_duration_seconds" {
+				found = true
+				assert.Equal(t, MetricTypeHistogram, metric.Type)
+				assert.Equal(t, "test-service", metric.Labels["service"])
+				assert.Equal(t, "GET", metric.Labels["method"])
+				break
+			}
+		}
+		assert.True(t, found, "Histogram metric not found")
+	})
+
+	t.Run("automatic service label addition", func(t *testing.T) {
+		// Test with nil labels
+		bmm.RecordCounter("test_metric_nil", 1.0, nil)
+
+		// Test with empty labels
+		bmm.RecordCounter("test_metric_empty", 1.0, map[string]string{})
+
+		// Test with existing service label
+		bmm.RecordCounter("test_metric_existing", 1.0, map[string]string{"service": "other-service"})
+
+		time.Sleep(10 * time.Millisecond)
+
+		metrics := collector.GetMetrics()
+
+		for _, metric := range metrics {
+			switch metric.Name {
+			case "test_metric_nil", "test_metric_empty":
+				assert.Equal(t, "test-service", metric.Labels["service"])
+			case "test_metric_existing":
+				// Should not override existing service label
+				assert.Equal(t, "other-service", metric.Labels["service"])
+			}
+		}
+	})
+}
+
+func TestBusinessMetricsManager_CustomMetrics(t *testing.T) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+
+	t.Run("register and retrieve custom metric", func(t *testing.T) {
+		definition := MetricDefinition{
+			Name:        "custom_business_metric",
+			Type:        MetricTypeGauge,
+			Description: "Custom business metric for testing",
+			Labels:      []string{"department", "region"},
+		}
+
+		err := bmm.RegisterCustomMetric(definition)
+
+		assert.NoError(t, err)
+
+		retrieved, found := bmm.GetCustomMetric("custom_business_metric")
+		assert.True(t, found)
+		assert.Equal(t, definition.Name, retrieved.Name)
+		assert.Equal(t, definition.Type, retrieved.Type)
+		assert.Equal(t, definition.Description, retrieved.Description)
+	})
+
+	t.Run("get all metrics includes predefined and custom", func(t *testing.T) {
+		allMetrics := bmm.GetAllMetrics()
+
+		// Should include predefined server metrics
+		_, hasServerUptime := allMetrics["server_uptime_seconds"]
+		assert.True(t, hasServerUptime)
+
+		// Should include the custom metric we registered
+		_, hasCustom := allMetrics["custom_business_metric"]
+		assert.True(t, hasCustom)
+
+		// Should have a reasonable number of metrics
+		assert.GreaterOrEqual(t, len(allMetrics), 20) // At least 20+ predefined metrics
+	})
+}
+
+func TestBusinessMetricsManager_ConcurrentAccess(t *testing.T) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+
+	const numGoroutines = 10
+	const operationsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+
+	// Test concurrent hook registration/unregistration
+	t.Run("concurrent hook management", func(t *testing.T) {
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				defer wg.Done()
+
+				for j := 0; j < operationsPerGoroutine; j++ {
+					hookName := fmt.Sprintf("hook_%d_%d", id, j)
+					hook := &testBusinessMetricsHook{name: hookName}
+
+					err := bmm.RegisterHook(hook)
+					if err == nil {
+						_ = bmm.UnregisterHook(hookName)
+					}
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Should not crash and should have consistent state
+		hooks := bmm.GetRegisteredHooks()
+		assert.NotNil(t, hooks) // Should not be nil
+	})
+
+	// Test concurrent metric recording
+	t.Run("concurrent metric recording", func(t *testing.T) {
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				defer wg.Done()
+
+				for j := 0; j < operationsPerGoroutine; j++ {
+					labels := map[string]string{"goroutine": fmt.Sprintf("%d", id)}
+
+					bmm.RecordCounter("concurrent_counter", 1.0, labels)
+					bmm.RecordGauge("concurrent_gauge", float64(j), labels)
+					bmm.RecordHistogram("concurrent_histogram", float64(j)*0.1, labels)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Should not crash and metrics should be recorded
+		metrics := bmm.GetCollector().GetMetrics()
+		assert.NotEmpty(t, metrics)
+	})
+}
+
+// Test hook implementations
+
+func TestLoggingBusinessMetricsHook(t *testing.T) {
+	hook := NewLoggingBusinessMetricsHook()
+
+	assert.Equal(t, "logging_hook", hook.GetHookName())
+
+	event := BusinessMetricEvent{
+		Name:      "test_metric",
+		Type:      MetricTypeCounter,
+		Value:     1.0,
+		Labels:    map[string]string{"test": "value"},
+		Timestamp: time.Now(),
+		Source:    "test-service",
+	}
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		hook.OnMetricRecorded(event)
+	})
+}
+
+func TestAggregationBusinessMetricsHook(t *testing.T) {
+	hook := NewAggregationBusinessMetricsHook()
+
+	assert.Equal(t, "aggregation_hook", hook.GetHookName())
+
+	t.Run("aggregate counters", func(t *testing.T) {
+		event1 := BusinessMetricEvent{
+			Name:   "test_counter",
+			Type:   MetricTypeCounter,
+			Value:  5.0,
+			Source: "service1",
+		}
+		event2 := BusinessMetricEvent{
+			Name:   "test_counter",
+			Type:   MetricTypeCounter,
+			Value:  3.0,
+			Source: "service1",
+		}
+
+		hook.OnMetricRecorded(event1)
+		hook.OnMetricRecorded(event2)
+
+		totals := hook.GetCounterTotals()
+		expected := "service1_test_counter"
+		assert.Equal(t, 8.0, totals[expected])
+	})
+
+	t.Run("set gauges", func(t *testing.T) {
+		event1 := BusinessMetricEvent{
+			Name:   "test_gauge",
+			Type:   MetricTypeGauge,
+			Value:  42.0,
+			Source: "service1",
+		}
+		event2 := BusinessMetricEvent{
+			Name:   "test_gauge",
+			Type:   MetricTypeGauge,
+			Value:  84.0,
+			Source: "service1",
+		}
+
+		hook.OnMetricRecorded(event1)
+		hook.OnMetricRecorded(event2)
+
+		values := hook.GetGaugeValues()
+		expected := "service1_test_gauge"
+		assert.Equal(t, 84.0, values[expected]) // Latest value for gauge
+	})
+
+	t.Run("reset aggregation", func(t *testing.T) {
+		hook.Reset()
+
+		assert.Empty(t, hook.GetCounterTotals())
+		assert.Empty(t, hook.GetGaugeValues())
+	})
+}
+
+// Helper types for testing
+
+type testBusinessMetricsHook struct {
+	name   string
+	events []BusinessMetricEvent
+	mu     sync.RWMutex
+}
+
+func (t *testBusinessMetricsHook) OnMetricRecorded(event BusinessMetricEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+func (t *testBusinessMetricsHook) GetHookName() string {
+	return t.name
+}
+
+// Benchmark tests
+
+func BenchmarkBusinessMetricsManager_RecordCounter(b *testing.B) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+	labels := map[string]string{"endpoint": "/api/test"}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bmm.RecordCounter("api_requests_total", 1.0, labels)
+		}
+	})
+}
+
+func BenchmarkBusinessMetricsManager_RecordGauge(b *testing.B) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+	labels := map[string]string{"queue": "processing"}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bmm.RecordGauge("queue_size", float64(b.N), labels)
+		}
+	})
+}
+
+func BenchmarkBusinessMetricsManager_WithHooks(b *testing.B) {
+	bmm := NewBusinessMetricsManager("test-service", nil, nil)
+
+	// Add multiple hooks
+	_ = bmm.RegisterHook(NewLoggingBusinessMetricsHook())
+	_ = bmm.RegisterHook(NewAggregationBusinessMetricsHook())
+
+	labels := map[string]string{"test": "benchmark"}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bmm.RecordCounter("benchmark_counter", 1.0, labels)
+		}
+	})
+}

--- a/pkg/server/end_to_end_integration_test.go
+++ b/pkg/server/end_to_end_integration_test.go
@@ -210,12 +210,6 @@ func (suite *EndToEndTestSuite) createTestServer(serviceName string, httpPort, g
 			"service": serviceName,
 		})
 	})
-	httpHandler.AddRoute("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{
-			"status":  "healthy",
-			"service": serviceName,
-		})
-	})
 	service.AddHTTPHandler(httpHandler)
 
 	// Add gRPC service

--- a/pkg/server/integration_test.go
+++ b/pkg/server/integration_test.go
@@ -343,9 +343,6 @@ func (suite *IntegrationTestSuite) SetupTest() {
 	httpHandler.AddRoute("/test", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "test response"})
 	})
-	httpHandler.AddRoute("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "healthy"})
-	})
 	suite.testService.AddHTTPHandler(httpHandler)
 
 	// Add test gRPC service

--- a/pkg/server/metrics_registry.go
+++ b/pkg/server/metrics_registry.go
@@ -339,6 +339,13 @@ func (mr *MetricsRegistry) registerPredefinedMetrics() {
 		Labels:      []string{"service"},
 	}
 
+	mr.predefinedMetrics["server_start_time"] = MetricDefinition{
+		Name:        "server_start_time",
+		Type:        MetricTypeGauge,
+		Description: "Server start time as unix timestamp",
+		Labels:      []string{"service"},
+	}
+
 	// Transport Metrics
 	mr.predefinedMetrics["transport_status"] = MetricDefinition{
 		Name:        "transport_status",
@@ -359,6 +366,27 @@ func (mr *MetricsRegistry) registerPredefinedMetrics() {
 		Type:        MetricTypeCounter,
 		Description: "Total number of connections",
 		Labels:      []string{"transport"},
+	}
+
+	mr.predefinedMetrics["transport_starts_total"] = MetricDefinition{
+		Name:        "transport_starts_total",
+		Type:        MetricTypeCounter,
+		Description: "Total number of transport starts",
+		Labels:      []string{"service", "transport"},
+	}
+
+	mr.predefinedMetrics["transport_stops_total"] = MetricDefinition{
+		Name:        "transport_stops_total",
+		Type:        MetricTypeCounter,
+		Description: "Total number of transport stops",
+		Labels:      []string{"service", "transport"},
+	}
+
+	mr.predefinedMetrics["active_transports"] = MetricDefinition{
+		Name:        "active_transports",
+		Type:        MetricTypeGauge,
+		Description: "Number of active transports",
+		Labels:      []string{"service", "transport"},
 	}
 
 	// Service Registration Metrics

--- a/pkg/server/phase3_integration_test.go
+++ b/pkg/server/phase3_integration_test.go
@@ -1,0 +1,290 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPhase3Integration_ServerWithPrometheusMetrics(t *testing.T) {
+	// Create test configuration
+	config := &ServerConfig{
+		ServiceName: "test-phase3-service",
+		HTTP: HTTPConfig{
+			Port:        "0", // Dynamic port allocation
+			Enabled:     true,
+			TestMode:    true,
+			EnableReady: true,
+		},
+		GRPC: GRPCConfig{
+			Port:    "0",   // Dynamic port allocation
+			Enabled: false, // Disable gRPC for this test
+		},
+		Discovery: DiscoveryConfig{
+			Enabled: false, // Disable for testing
+		},
+		ShutdownTimeout: 5 * time.Second,
+	}
+
+	// Create test service registrar
+	registrar := &Phase3TestServiceRegistrar{}
+
+	// Create server
+	server, err := NewBusinessServerCore(config, registrar, nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	// Verify observability manager is initialized
+	observabilityManager := server.GetObservabilityManager()
+	assert.NotNil(t, observabilityManager)
+
+	// Verify Prometheus collector is available
+	prometheusCollector := server.GetPrometheusCollector()
+	assert.NotNil(t, prometheusCollector)
+
+	// Verify business metrics manager is available
+	businessMetrics := server.GetBusinessMetricsManager()
+	assert.NotNil(t, businessMetrics)
+
+	t.Run("server startup records metrics", func(t *testing.T) {
+		// Start server
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := server.Start(ctx)
+		require.NoError(t, err)
+
+		// Give the server a moment to record metrics
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify HTTP address is available
+		httpAddr := server.GetHTTPAddress()
+		assert.NotEmpty(t, httpAddr)
+
+		// Test Prometheus metrics endpoint
+		resp, err := http.Get("http://localhost" + httpAddr + "/metrics")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
+
+		// Test debug endpoints
+		debugResp, err := http.Get("http://localhost" + httpAddr + "/debug/status")
+		require.NoError(t, err)
+		defer debugResp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, debugResp.StatusCode)
+		assert.Contains(t, debugResp.Header.Get("Content-Type"), "application/json")
+
+		// Test health endpoint
+		healthResp, err := http.Get("http://localhost" + httpAddr + "/health")
+		require.NoError(t, err)
+		defer healthResp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, healthResp.StatusCode)
+
+		// Shutdown server
+		err = server.Shutdown()
+		assert.NoError(t, err)
+	})
+
+	t.Run("business metrics recording", func(t *testing.T) {
+		// Test business metrics functionality
+		hook := NewAggregationBusinessMetricsHook()
+		err := businessMetrics.RegisterHook(hook)
+		require.NoError(t, err)
+
+		// Record some business metrics
+		businessMetrics.RecordCounter("test_api_calls", 5, map[string]string{"endpoint": "/test"})
+		businessMetrics.RecordGauge("test_active_users", 42, map[string]string{"region": "us-west"})
+		businessMetrics.RecordHistogram("test_request_duration", 0.123, map[string]string{"method": "GET"})
+
+		// Allow hooks to process
+		time.Sleep(50 * time.Millisecond)
+
+		// Verify metrics were recorded
+		collector := businessMetrics.GetCollector()
+		metrics := collector.GetMetrics()
+		assert.NotEmpty(t, metrics)
+
+		// Check aggregation hook received events
+		counterTotals := hook.GetCounterTotals()
+		gaugeValues := hook.GetGaugeValues()
+
+		assert.Contains(t, counterTotals, "test-phase3-service_test_api_calls")
+		assert.Equal(t, 5.0, counterTotals["test-phase3-service_test_api_calls"])
+
+		assert.Contains(t, gaugeValues, "test-phase3-service_test_active_users")
+		assert.Equal(t, 42.0, gaugeValues["test-phase3-service_test_active_users"])
+	})
+
+	t.Run("system metrics collection", func(t *testing.T) {
+		// Trigger system metrics update
+		observabilityManager.UpdateSystemMetrics()
+
+		// Get Prometheus collector metrics
+		collector := observabilityManager.GetPrometheusCollector()
+		metrics := collector.GetMetrics()
+
+		// Verify system metrics are present
+		var foundMemory, foundGoroutines, foundUptime bool
+
+		for _, metric := range metrics {
+			switch metric.Name {
+			case "swit_server_memory_bytes":
+				foundMemory = true
+				assert.Equal(t, MetricTypeGauge, metric.Type)
+				assert.Contains(t, metric.Labels, "service")
+				assert.Contains(t, metric.Labels, "type")
+			case "swit_server_goroutines":
+				foundGoroutines = true
+				assert.Equal(t, MetricTypeGauge, metric.Type)
+				assert.Contains(t, metric.Labels, "service")
+			case "swit_server_uptime_seconds":
+				foundUptime = true
+				assert.Equal(t, MetricTypeGauge, metric.Type)
+				assert.Contains(t, metric.Labels, "service")
+			}
+		}
+
+		assert.True(t, foundMemory, "server_memory_bytes metric not found")
+		assert.True(t, foundGoroutines, "server_goroutines metric not found")
+		assert.True(t, foundUptime, "server_uptime_seconds metric not found")
+	})
+}
+
+func TestPhase3Integration_MetricsRegistry(t *testing.T) {
+	registry := NewMetricsRegistry()
+
+	t.Run("predefined server metrics are available", func(t *testing.T) {
+		expectedMetrics := []string{
+			"server_uptime_seconds",
+			"server_startup_duration_seconds",
+			"server_shutdown_duration_seconds",
+			"server_goroutines",
+			"server_memory_bytes",
+			"server_gc_duration_seconds",
+		}
+
+		for _, metricName := range expectedMetrics {
+			definition, found := registry.GetMetricDefinition(metricName)
+			assert.True(t, found, "Metric %s not found", metricName)
+			assert.Equal(t, metricName, definition.Name)
+			assert.NotEmpty(t, definition.Description)
+			assert.Contains(t, definition.Labels, "service")
+		}
+	})
+
+	t.Run("transport and service metrics are available", func(t *testing.T) {
+		transportMetrics := []string{
+			"transport_starts_total",
+			"transport_stops_total",
+			"active_transports",
+			"service_registrations_total",
+			"registered_services",
+			"transport_status",
+			"transport_connections_active",
+			"transport_connections_total",
+		}
+
+		for _, metricName := range transportMetrics {
+			definition, found := registry.GetMetricDefinition(metricName)
+			assert.True(t, found, "Transport metric %s not found", metricName)
+			assert.Equal(t, metricName, definition.Name)
+			assert.NotEmpty(t, definition.Description)
+		}
+	})
+}
+
+// Test helper for custom service registration
+type Phase3TestServiceRegistrar struct{}
+
+func (t *Phase3TestServiceRegistrar) RegisterServices(registry BusinessServiceRegistry) error {
+	// Register a simple test handler
+	handler := &Phase3TestHTTPHandler{}
+	return registry.RegisterBusinessHTTPHandler(handler)
+}
+
+type Phase3TestHTTPHandler struct{}
+
+func (t *Phase3TestHTTPHandler) RegisterRoutes(router interface{}) error {
+	// No routes needed for this test
+	return nil
+}
+
+func (t *Phase3TestHTTPHandler) GetServiceName() string {
+	return "phase3-test-handler"
+}
+
+// Benchmark test for Phase 3 integration
+func BenchmarkPhase3_MetricsCollection(b *testing.B) {
+	config := &ServerConfig{
+		ServiceName: "benchmark-service",
+		HTTP:        HTTPConfig{Enabled: false},
+		GRPC:        GRPCConfig{Enabled: false},
+		Discovery:   DiscoveryConfig{Enabled: false},
+	}
+
+	registrar := &Phase3TestServiceRegistrar{}
+	server, err := NewBusinessServerCore(config, registrar, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	observabilityManager := server.GetObservabilityManager()
+	businessMetrics := server.GetBusinessMetricsManager()
+
+	b.ResetTimer()
+
+	b.Run("system_metrics_update", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				observabilityManager.UpdateSystemMetrics()
+			}
+		})
+	})
+
+	b.Run("business_metrics_recording", func(b *testing.B) {
+		labels := map[string]string{"endpoint": "/api/test"}
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				businessMetrics.RecordCounter("benchmark_counter", 1.0, labels)
+			}
+		})
+	})
+
+	b.Run("prometheus_metrics_export", func(b *testing.B) {
+		collector := observabilityManager.GetPrometheusCollector()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = collector.GetMetrics()
+			}
+		})
+	})
+}

--- a/pkg/server/phase3_integration_test.go
+++ b/pkg/server/phase3_integration_test.go
@@ -23,6 +23,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -36,10 +37,13 @@ func TestPhase3Integration_ServerWithPrometheusMetrics(t *testing.T) {
 	config := &ServerConfig{
 		ServiceName: "test-phase3-service",
 		HTTP: HTTPConfig{
-			Port:        "0", // Dynamic port allocation
-			Enabled:     true,
-			TestMode:    true,
-			EnableReady: true,
+			Port:         "0", // Dynamic port allocation
+			Enabled:      true,
+			TestMode:     true,
+			EnableReady:  true,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
 		},
 		GRPC: GRPCConfig{
 			Port:    "0",   // Dynamic port allocation
@@ -87,7 +91,7 @@ func TestPhase3Integration_ServerWithPrometheusMetrics(t *testing.T) {
 		assert.NotEmpty(t, httpAddr)
 
 		// Test Prometheus metrics endpoint
-		resp, err := http.Get("http://localhost" + httpAddr + "/metrics")
+		resp, err := http.Get(fmt.Sprintf("http://%s/metrics", httpAddr))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -95,7 +99,7 @@ func TestPhase3Integration_ServerWithPrometheusMetrics(t *testing.T) {
 		assert.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
 
 		// Test debug endpoints
-		debugResp, err := http.Get("http://localhost" + httpAddr + "/debug/status")
+		debugResp, err := http.Get(fmt.Sprintf("http://%s/debug/status", httpAddr))
 		require.NoError(t, err)
 		defer debugResp.Body.Close()
 
@@ -103,7 +107,7 @@ func TestPhase3Integration_ServerWithPrometheusMetrics(t *testing.T) {
 		assert.Contains(t, debugResp.Header.Get("Content-Type"), "application/json")
 
 		// Test health endpoint
-		healthResp, err := http.Get("http://localhost" + httpAddr + "/health")
+		healthResp, err := http.Get(fmt.Sprintf("http://%s/health", httpAddr))
 		require.NoError(t, err)
 		defer healthResp.Body.Close()
 


### PR DESCRIPTION
## Summary

This PR implements **Phase 3** of the Prometheus metrics integration for the swit microservices framework, addressing GitHub issue #121.

### Phase 3 Implementation Details

#### 🚀 Server Lifecycle Metrics
- **Startup/Shutdown Timing**: Records server startup and shutdown durations via enhanced `ObservabilityManager`
- **Transport Lifecycle**: Tracks HTTP and gRPC transport start/stop events with proper service identification
- **System Integration**: Seamless integration with existing `BusinessServerImpl` lifecycle management

#### 📊 Performance Metrics Export  
- **Memory Usage Tracking**: Automatic collection of heap allocation and memory statistics
- **Goroutine Monitoring**: Real-time tracking of active goroutine counts
- **GC Statistics**: Garbage collection timing and performance metrics
- **Periodic Collection**: Configurable intervals for system metrics updates (30s default)

#### 🔌 Business Metrics Hooks
- **Hook Architecture**: Extensible `BusinessMetricsHook` interface for custom metric processing
- **Default Implementations**: 
  - `LoggingBusinessMetricsHook`: Structured logging of all metric events
  - `AggregationBusinessMetricsHook`: In-memory aggregation for summary reporting
- **Thread-Safe Operations**: Concurrent hook registration/execution with proper synchronization
- **Custom Metrics Support**: Registration and management of application-specific metrics

### Key Components Added/Enhanced

#### New Files
- `pkg/server/business_metrics.go`: Complete business metrics management system
- `pkg/server/business_metrics_test.go`: Comprehensive test suite (470+ lines)
- `pkg/server/phase3_integration_test.go`: End-to-end integration tests

#### Enhanced Files
- `pkg/server/base.go`: Integrated ObservabilityManager with server lifecycle
- `pkg/server/observability.go`: Enhanced Prometheus integration with system metrics
- `pkg/server/metrics_registry.go`: Added missing metric definitions (transport lifecycle, server timing)

### Integration with Existing Framework

#### Backward Compatibility
- ✅ All existing Phase 1 functionality preserved
- ✅ Existing `PerformanceMetrics` and monitoring infrastructure maintained
- ✅ No breaking changes to public APIs

#### Framework Integration
- **Transport Coordination**: Metrics automatically recorded during transport start/stop
- **Service Discovery**: Compatible with existing service registration patterns
- **Observability Endpoints**: Automatic `/metrics` endpoint registration for Prometheus scraping
- **Configuration**: Uses existing `ServerConfig` structure without additional config requirements

### Testing & Quality

#### Test Coverage
- **Unit Tests**: Complete coverage for `BusinessMetricsManager` functionality
- **Integration Tests**: End-to-end validation of Phase 3 implementation
- **Concurrent Testing**: Race condition detection and thread-safety validation
- **Performance Tests**: Benchmark testing for metric recording operations

#### Code Quality
- ✅ All tests passing (`make test`)
- ✅ Code formatting applied (`make quality`)
- ✅ No linting issues detected
- ✅ Thread-safe implementation with proper mutex usage

### Usage Example

```go
// Server automatically includes Phase 3 metrics
server, err := server.NewBusinessServerCore(config, registrar, deps)

// Access business metrics manager
bmm := server.GetBusinessMetricsManager()

// Register custom hook
hook := &MyCustomMetricsHook{}
bmm.RegisterHook(hook)

// Record business metrics
bmm.RecordCounter("orders_processed_total", 1.0, map[string]string{
    "department": "sales",
    "region": "us-west",
})

// Access Prometheus collector
collector := server.GetPrometheusCollector()
metrics := collector.GetMetrics() // All metrics including Phase 3
```

### Metrics Available

#### Server Lifecycle Metrics
- `server_startup_duration_seconds`: Server startup time histogram
- `server_shutdown_duration_seconds`: Server shutdown time histogram  
- `server_uptime_seconds`: Current server uptime gauge
- `server_start_time`: Server start timestamp gauge

#### Performance Metrics
- `server_memory_bytes`: Memory usage by type (heap, stack, etc.)
- `server_goroutines`: Active goroutine count gauge
- `server_gc_duration_seconds`: Garbage collection duration gauge

#### Transport Metrics
- `transport_starts_total`: Transport start events counter
- `transport_stops_total`: Transport stop events counter
- `active_transports`: Active transport count gauge

### Closes #121

This implementation completes the Phase 3 requirements:
- [x] Server lifecycle metrics (startup, shutdown, uptime)
- [x] Performance metrics export (memory, goroutines, GC)  
- [x] Business metrics hooks interface
- [x] Comprehensive test coverage
- [x] Integration with existing Prometheus infrastructure

🤖 Generated with [Claude Code](https://claude.ai/code)