### PR TITLE
feat: Design Core Message Structure and Routing (#189)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getsentry/sentry-go v0.35.1
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.9.1
+	github.com/go-playground/validator/v10 v10.27.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0
@@ -50,7 +51,7 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
+github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/getsentry/sentry-go v0.35.1 h1:iopow6UVLE2aXu46xKVIs8Z9D/YZkJrHkgozrxa+tOQ=
 github.com/getsentry/sentry-go v0.35.1/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQw=
@@ -93,6 +95,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBExVwjEviJTixqxL8=
 github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/validator/v10 v10.27.0 h1:w8+XrWVMhGkxOaaowyKH35gFydVHOvC0/uWoy2Fzwn4=
+github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -62,15 +63,29 @@ func validateTopicName(fl validator.FieldLevel) bool {
 		return false
 	}
 
-	// Topic name pattern: alphanumeric, dots, hyphens, underscores
-	// Cannot start or end with special characters
-	pattern := `^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`
-	if len(topic) == 1 {
-		pattern = `^[a-zA-Z0-9]$`
+	// Topic name pattern: must start and end with alphanumeric
+	// Middle can contain alphanumeric, dots, hyphens, underscores
+	// No consecutive special characters
+	
+	// Check if starts/ends with alphanumeric
+	if !regexp.MustCompile(`^[a-zA-Z0-9]`).MatchString(topic) {
+		return false
 	}
-
-	matched, _ := regexp.MatchString(pattern, topic)
-	return matched
+	if !regexp.MustCompile(`[a-zA-Z0-9]$`).MatchString(topic) {
+		return false
+	}
+	
+	// Check for valid characters in middle
+	if !regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).MatchString(topic) {
+		return false
+	}
+	
+	// Check for consecutive special characters
+	if strings.Contains(topic, "..") || strings.Contains(topic, "--") || strings.Contains(topic, "__") {
+		return false
+	}
+	
+	return true
 }
 
 // validateCorrelationID validates correlation ID format.

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -1,0 +1,441 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StructMessageValidator provides comprehensive validation for Message structs.
+// It uses struct tags for declarative validation rules and supports
+// custom validation logic for complex business rules.
+type StructMessageValidator struct {
+	validator *validator.Validate
+}
+
+// NewStructMessageValidator creates a new message validator with standard rules.
+// The validator includes built-in validations for message fields and
+// can be extended with custom validation functions.
+func NewStructMessageValidator() *StructMessageValidator {
+	v := validator.New()
+
+	// Register custom validation for topic names
+	v.RegisterValidation("topic", validateTopicName)
+
+	// Register custom validation for correlation IDs
+	v.RegisterValidation("correlation_id", validateCorrelationID)
+
+	return &StructMessageValidator{validator: v}
+}
+
+// validateTopicName validates that topic names follow naming conventions.
+// Topic names must be alphanumeric with dots, hyphens, and underscores allowed.
+// They cannot start or end with special characters.
+func validateTopicName(fl validator.FieldLevel) bool {
+	topic := fl.Field().String()
+	if topic == "" {
+		return false
+	}
+
+	// Topic name pattern: alphanumeric, dots, hyphens, underscores
+	// Cannot start or end with special characters
+	pattern := `^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`
+	if len(topic) == 1 {
+		pattern = `^[a-zA-Z0-9]$`
+	}
+
+	matched, _ := regexp.MatchString(pattern, topic)
+	return matched
+}
+
+// validateCorrelationID validates correlation ID format.
+// Correlation IDs should be UUIDs or other structured identifiers.
+func validateCorrelationID(fl validator.FieldLevel) bool {
+	corrID := fl.Field().String()
+	if corrID == "" {
+		return true // Optional field
+	}
+
+	// UUID pattern or alphanumeric with hyphens
+	pattern := `^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$`
+	if len(corrID) == 1 {
+		pattern = `^[a-zA-Z0-9]$`
+	}
+
+	matched, _ := regexp.MatchString(pattern, corrID)
+	return matched
+}
+
+// ValidatedMessage extends the base Message struct with validation tags
+// and additional metadata for enhanced message processing capabilities.
+type ValidatedMessage struct {
+	// ID is the unique message identifier (required)
+	ID string `json:"id" validate:"required,uuid4"`
+
+	// Topic is the destination topic/queue name (required)
+	Topic string `json:"topic" validate:"required,topic"`
+
+	// Key is an optional routing/partition key for message ordering
+	Key []byte `json:"key,omitempty" validate:"omitempty,max=1024"`
+
+	// Payload is the actual message content (required)
+	Payload []byte `json:"payload" validate:"required,min=1,max=1048576"` // Max 1MB
+
+	// Headers contains message metadata as key-value pairs
+	Headers MessageHeaders `json:"headers,omitempty"`
+
+	// Timestamp indicates when the message was created (required)
+	Timestamp time.Time `json:"timestamp" validate:"required"`
+
+	// CorrelationID is used for request-response patterns and distributed tracing
+	CorrelationID string `json:"correlation_id,omitempty" validate:"omitempty,correlation_id"`
+
+	// ReplyTo specifies the topic for responses in request-response patterns
+	ReplyTo string `json:"reply_to,omitempty" validate:"omitempty,topic"`
+
+	// Priority sets the message priority (0-9, where 9 is highest priority)
+	Priority int `json:"priority,omitempty" validate:"min=0,max=9"`
+
+	// TTL specifies the time-to-live in seconds
+	TTL int `json:"ttl,omitempty" validate:"min=0,max=86400"` // Max 24 hours
+
+	// DeliveryAttempt tracks how many times delivery has been attempted
+	DeliveryAttempt int `json:"delivery_attempt,omitempty" validate:"min=0"`
+
+	// TraceContext contains OpenTelemetry trace context for distributed tracing
+	TraceContext TraceContext `json:"trace_context,omitempty"`
+
+	// Routing contains message routing information
+	Routing RoutingInfo `json:"routing,omitempty"`
+
+	// BrokerMetadata contains broker-specific metadata (not serialized)
+	BrokerMetadata interface{} `json:"-"`
+}
+
+// MessageHeaders provides a structured way to handle message headers
+// with support for tracing, correlation, and custom metadata.
+type MessageHeaders struct {
+	// Standard headers for distributed tracing and correlation
+	TraceID      string            `json:"trace_id,omitempty"`
+	SpanID       string            `json:"span_id,omitempty"`
+	ParentSpanID string            `json:"parent_span_id,omitempty"`
+	TraceFlags   string            `json:"trace_flags,omitempty"`
+	Baggage      map[string]string `json:"baggage,omitempty"`
+
+	// Message correlation and routing headers
+	CorrelationID   string `json:"correlation_id,omitempty"`
+	CausationID     string `json:"causation_id,omitempty"`
+	MessageType     string `json:"message_type,omitempty"`
+	ContentType     string `json:"content_type,omitempty"`
+	ContentEncoding string `json:"content_encoding,omitempty"`
+
+	// Timing and retry headers
+	CreatedAt  time.Time  `json:"created_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	RetryCount int        `json:"retry_count,omitempty"`
+	MaxRetries int        `json:"max_retries,omitempty"`
+
+	// Custom headers for application-specific metadata
+	Custom map[string]string `json:"custom,omitempty"`
+}
+
+// TraceContext encapsulates OpenTelemetry trace context information
+// for distributed tracing support across message boundaries.
+type TraceContext struct {
+	// TraceID uniquely identifies the trace
+	TraceID trace.TraceID `json:"trace_id"`
+
+	// SpanID uniquely identifies the span within the trace
+	SpanID trace.SpanID `json:"span_id"`
+
+	// TraceFlags contains trace sampling and other flags
+	TraceFlags trace.TraceFlags `json:"trace_flags"`
+
+	// TraceState holds vendor-specific trace state
+	TraceState trace.TraceState `json:"trace_state,omitempty"`
+
+	// Baggage contains cross-cutting concerns data
+	Baggage map[string]string `json:"baggage,omitempty"`
+}
+
+// Validate performs comprehensive validation on the ValidatedMessage.
+// It checks both struct-level validation rules and business logic constraints.
+func (v *StructMessageValidator) Validate(msg *ValidatedMessage) error {
+	if msg == nil {
+		return fmt.Errorf("message cannot be nil")
+	}
+
+	// Perform struct validation using tags
+	if err := v.validator.Struct(msg); err != nil {
+		return &MessageValidationError{
+			Field:   getFieldName(err),
+			Message: formatValidationError(err),
+			Cause:   err,
+		}
+	}
+
+	// Additional business logic validation
+	if err := v.validateBusinessRules(msg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateBusinessRules performs complex validation that cannot be expressed
+// through struct tags alone.
+func (v *StructMessageValidator) validateBusinessRules(msg *ValidatedMessage) error {
+	// Validate timestamp is not in the future
+	if msg.Timestamp.After(time.Now().Add(5 * time.Minute)) {
+		return &MessageValidationError{
+			Field:   "timestamp",
+			Message: "message timestamp cannot be more than 5 minutes in the future",
+		}
+	}
+
+	// Validate TTL expiry time
+	if msg.TTL > 0 {
+		expiryTime := msg.Timestamp.Add(time.Duration(msg.TTL) * time.Second)
+		if expiryTime.Before(time.Now()) {
+			return &MessageValidationError{
+				Field:   "ttl",
+				Message: "message has already expired based on TTL",
+			}
+		}
+	}
+
+	// Validate correlation ID consistency with headers
+	if msg.CorrelationID != "" && msg.Headers.CorrelationID != "" {
+		if msg.CorrelationID != msg.Headers.CorrelationID {
+			return &MessageValidationError{
+				Field:   "correlation_id",
+				Message: "correlation ID in message and headers must match",
+			}
+		}
+	}
+
+	return nil
+}
+
+// MessageValidationError represents a message validation failure with detailed information.
+type MessageValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+	Cause   error  `json:"-"`
+}
+
+// Error implements the error interface for MessageValidationError.
+func (e *MessageValidationError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("validation failed for field '%s': %s", e.Field, e.Message)
+	}
+	return fmt.Sprintf("validation failed: %s", e.Message)
+}
+
+// Unwrap returns the underlying cause of the validation error.
+func (e *MessageValidationError) Unwrap() error {
+	return e.Cause
+}
+
+// getFieldName extracts the field name from a validation error.
+func getFieldName(err error) string {
+	if validationErrors, ok := err.(validator.ValidationErrors); ok {
+		for _, fieldError := range validationErrors {
+			return fieldError.Field()
+		}
+	}
+	return ""
+}
+
+// formatValidationError creates a human-readable validation error message.
+func formatValidationError(err error) string {
+	if validationErrors, ok := err.(validator.ValidationErrors); ok {
+		for _, fieldError := range validationErrors {
+			switch fieldError.Tag() {
+			case "required":
+				return "field is required"
+			case "uuid4":
+				return "field must be a valid UUID v4"
+			case "topic":
+				return "field must be a valid topic name"
+			case "correlation_id":
+				return "field must be a valid correlation ID"
+			case "min":
+				return fmt.Sprintf("field must be at least %s", fieldError.Param())
+			case "max":
+				return fmt.Sprintf("field must be at most %s", fieldError.Param())
+			default:
+				return fmt.Sprintf("field validation failed: %s", fieldError.Tag())
+			}
+		}
+	}
+	return err.Error()
+}
+
+// MessageBuilder provides a fluent interface for constructing validated messages
+// with proper defaults and validation.
+type MessageBuilder struct {
+	message *ValidatedMessage
+}
+
+// NewMessageBuilder creates a new message builder with sensible defaults.
+func NewMessageBuilder() *MessageBuilder {
+	return &MessageBuilder{
+		message: &ValidatedMessage{
+			Headers:   MessageHeaders{Custom: make(map[string]string)},
+			Timestamp: time.Now(),
+			Priority:  5, // Default priority
+		},
+	}
+}
+
+// WithID sets the message ID.
+func (b *MessageBuilder) WithID(id string) *MessageBuilder {
+	b.message.ID = id
+	return b
+}
+
+// WithTopic sets the destination topic.
+func (b *MessageBuilder) WithTopic(topic string) *MessageBuilder {
+	b.message.Topic = topic
+	return b
+}
+
+// WithPayload sets the message payload.
+func (b *MessageBuilder) WithPayload(payload []byte) *MessageBuilder {
+	b.message.Payload = payload
+	return b
+}
+
+// WithCorrelationID sets the correlation ID for request-response patterns.
+func (b *MessageBuilder) WithCorrelationID(correlationID string) *MessageBuilder {
+	b.message.CorrelationID = correlationID
+	b.message.Headers.CorrelationID = correlationID
+	return b
+}
+
+// WithHeader adds a custom header to the message.
+func (b *MessageBuilder) WithHeader(key, value string) *MessageBuilder {
+	if b.message.Headers.Custom == nil {
+		b.message.Headers.Custom = make(map[string]string)
+	}
+	b.message.Headers.Custom[key] = value
+	return b
+}
+
+// WithTraceContext sets the distributed tracing context.
+func (b *MessageBuilder) WithTraceContext(ctx context.Context) *MessageBuilder {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		b.message.TraceContext = TraceContext{
+			TraceID:    span.SpanContext().TraceID(),
+			SpanID:     span.SpanContext().SpanID(),
+			TraceFlags: span.SpanContext().TraceFlags(),
+			TraceState: span.SpanContext().TraceState(),
+		}
+
+		// Set trace headers
+		b.message.Headers.TraceID = span.SpanContext().TraceID().String()
+		b.message.Headers.SpanID = span.SpanContext().SpanID().String()
+		b.message.Headers.TraceFlags = span.SpanContext().TraceFlags().String()
+	}
+	return b
+}
+
+// WithPriority sets the message priority (0-9, where 9 is highest).
+func (b *MessageBuilder) WithPriority(priority int) *MessageBuilder {
+	b.message.Priority = priority
+	return b
+}
+
+// WithTTL sets the time-to-live in seconds.
+func (b *MessageBuilder) WithTTL(ttlSeconds int) *MessageBuilder {
+	b.message.TTL = ttlSeconds
+	if ttlSeconds > 0 {
+		expiryTime := b.message.Timestamp.Add(time.Duration(ttlSeconds) * time.Second)
+		b.message.Headers.ExpiresAt = &expiryTime
+	}
+	return b
+}
+
+// WithRouting sets the routing information.
+func (b *MessageBuilder) WithRouting(routing RoutingInfo) *MessageBuilder {
+	b.message.Routing = routing
+	return b
+}
+
+// Build creates and validates the final message.
+func (b *MessageBuilder) Build() (*ValidatedMessage, error) {
+	validator := NewStructMessageValidator()
+	if err := validator.Validate(b.message); err != nil {
+		return nil, err
+	}
+
+	// Create a copy to prevent modification after build
+	result := *b.message
+	return &result, nil
+}
+
+// InjectTraceContext injects trace context into message headers using OpenTelemetry propagation.
+func (msg *ValidatedMessage) InjectTraceContext(ctx context.Context, propagator propagation.TextMapPropagator) {
+	carrier := &HeaderCarrier{headers: msg.Headers.Custom}
+	propagator.Inject(ctx, carrier)
+}
+
+// ExtractTraceContext extracts trace context from message headers using OpenTelemetry propagation.
+func (msg *ValidatedMessage) ExtractTraceContext(ctx context.Context, propagator propagation.TextMapPropagator) context.Context {
+	carrier := &HeaderCarrier{headers: msg.Headers.Custom}
+	return propagator.Extract(ctx, carrier)
+}
+
+// HeaderCarrier implements propagation.TextMapCarrier for message headers.
+type HeaderCarrier struct {
+	headers map[string]string
+}
+
+// Get returns the value associated with the key.
+func (hc *HeaderCarrier) Get(key string) string {
+	return hc.headers[key]
+}
+
+// Set sets the key-value pair.
+func (hc *HeaderCarrier) Set(key, value string) {
+	if hc.headers == nil {
+		hc.headers = make(map[string]string)
+	}
+	hc.headers[key] = value
+}
+
+// Keys lists the keys stored in the carrier.
+func (hc *HeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(hc.headers))
+	for k := range hc.headers {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/messaging/message_test.go
+++ b/pkg/messaging/message_test.go
@@ -1,0 +1,495 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package messaging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestStructMessageValidator tests the message validation functionality.
+func TestStructMessageValidator(t *testing.T) {
+	validator := NewStructMessageValidator()
+
+	tests := []struct {
+		name       string
+		message    *ValidatedMessage
+		wantError  bool
+		errorField string
+	}{
+		{
+			name: "valid message",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     "test.topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now(),
+			},
+			wantError: false,
+		},
+		{
+			name: "missing ID",
+			message: &ValidatedMessage{
+				Topic:     "test.topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now(),
+			},
+			wantError:  true,
+			errorField: "ID",
+		},
+		{
+			name: "missing topic",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now(),
+			},
+			wantError:  true,
+			errorField: "Topic",
+		},
+		{
+			name: "missing payload",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     "test.topic",
+				Timestamp: time.Now(),
+			},
+			wantError:  true,
+			errorField: "Payload",
+		},
+		{
+			name: "invalid topic name",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     ".invalid-topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now(),
+			},
+			wantError:  true,
+			errorField: "Topic",
+		},
+		{
+			name: "invalid priority",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     "test.topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now(),
+				Priority:  15, // Invalid: should be 0-9
+			},
+			wantError:  true,
+			errorField: "Priority",
+		},
+		{
+			name: "future timestamp",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     "test.topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now().Add(10 * time.Minute), // Too far in future
+			},
+			wantError:  true,
+			errorField: "timestamp",
+		},
+		{
+			name: "expired TTL",
+			message: &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     "test.topic",
+				Payload:   []byte("test payload"),
+				Timestamp: time.Now().Add(-2 * time.Hour), // Old timestamp
+				TTL:       3600,                           // 1 hour TTL, already expired
+			},
+			wantError:  true,
+			errorField: "ttl",
+		},
+		{
+			name: "correlation ID mismatch",
+			message: &ValidatedMessage{
+				ID:            uuid.New().String(),
+				Topic:         "test.topic",
+				Payload:       []byte("test payload"),
+				Timestamp:     time.Now(),
+				CorrelationID: "corr-123",
+				Headers: MessageHeaders{
+					CorrelationID: "corr-456", // Different from message level
+				},
+			},
+			wantError:  true,
+			errorField: "correlation_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(tt.message)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected validation error, got nil")
+					return
+				}
+
+				if validErr, ok := err.(*MessageValidationError); ok {
+					if tt.errorField != "" && validErr.Field != tt.errorField {
+						t.Errorf("expected error field %s, got %s", tt.errorField, validErr.Field)
+					}
+				} else {
+					t.Errorf("expected MessageValidationError, got %T", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected validation error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateTopicName tests the topic name validation function.
+func TestValidateTopicName(t *testing.T) {
+	validator := NewStructMessageValidator()
+
+	validTopics := []string{
+		"topic",
+		"test.topic",
+		"user-events",
+		"system_events",
+		"order.payment.completed",
+		"service-1.events",
+		"a",
+		"123",
+	}
+
+	for _, topic := range validTopics {
+		t.Run("valid_"+topic, func(t *testing.T) {
+			msg := &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     topic,
+				Payload:   []byte("test"),
+				Timestamp: time.Now(),
+			}
+
+			if err := validator.Validate(msg); err != nil {
+				t.Errorf("topic %s should be valid, got error: %v", topic, err)
+			}
+		})
+	}
+
+	invalidTopics := []string{
+		"",
+		".topic",
+		"topic.",
+		"topic..name",
+		"topic-",
+		"-topic",
+		"topic_",
+		"_topic",
+	}
+
+	for _, topic := range invalidTopics {
+		t.Run("invalid_"+topic, func(t *testing.T) {
+			msg := &ValidatedMessage{
+				ID:        uuid.New().String(),
+				Topic:     topic,
+				Payload:   []byte("test"),
+				Timestamp: time.Now(),
+			}
+
+			if err := validator.Validate(msg); err == nil {
+				t.Errorf("topic %s should be invalid", topic)
+			}
+		})
+	}
+}
+
+// TestMessageBuilder tests the message builder functionality.
+func TestMessageBuilder(t *testing.T) {
+	t.Run("build valid message", func(t *testing.T) {
+		msg, err := NewMessageBuilder().
+			WithID(uuid.New().String()).
+			WithTopic("test.topic").
+			WithPayload([]byte("test payload")).
+			WithCorrelationID("corr-123").
+			WithPriority(5).
+			WithTTL(3600).
+			WithHeader("custom-header", "custom-value").
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if msg.Topic != "test.topic" {
+			t.Errorf("expected topic 'test.topic', got %s", msg.Topic)
+		}
+
+		if msg.CorrelationID != "corr-123" {
+			t.Errorf("expected correlation ID 'corr-123', got %s", msg.CorrelationID)
+		}
+
+		if msg.Headers.CorrelationID != "corr-123" {
+			t.Errorf("expected header correlation ID 'corr-123', got %s", msg.Headers.CorrelationID)
+		}
+
+		if msg.Priority != 5 {
+			t.Errorf("expected priority 5, got %d", msg.Priority)
+		}
+
+		if msg.TTL != 3600 {
+			t.Errorf("expected TTL 3600, got %d", msg.TTL)
+		}
+
+		if msg.Headers.Custom["custom-header"] != "custom-value" {
+			t.Errorf("expected custom header 'custom-value', got %s", msg.Headers.Custom["custom-header"])
+		}
+
+		if msg.Headers.ExpiresAt == nil {
+			t.Error("expected ExpiresAt to be set when TTL is provided")
+		}
+	})
+
+	t.Run("build with trace context", func(t *testing.T) {
+		// Create a mock trace context
+		traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		spanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		})
+
+		ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+
+		msg, err := NewMessageBuilder().
+			WithID(uuid.New().String()).
+			WithTopic("test.topic").
+			WithPayload([]byte("test payload")).
+			WithTraceContext(ctx).
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if msg.TraceContext.TraceID != traceID {
+			t.Errorf("expected trace ID %v, got %v", traceID, msg.TraceContext.TraceID)
+		}
+
+		if msg.TraceContext.SpanID != spanID {
+			t.Errorf("expected span ID %v, got %v", spanID, msg.TraceContext.SpanID)
+		}
+
+		if msg.Headers.TraceID != traceID.String() {
+			t.Errorf("expected header trace ID %s, got %s", traceID.String(), msg.Headers.TraceID)
+		}
+	})
+
+	t.Run("build invalid message", func(t *testing.T) {
+		// Missing required fields
+		_, err := NewMessageBuilder().
+			WithTopic("test.topic").
+			Build()
+
+		if err == nil {
+			t.Error("expected validation error for missing ID")
+		}
+
+		if validErr, ok := err.(*MessageValidationError); ok {
+			if validErr.Field != "ID" {
+				t.Errorf("expected error field 'ID', got %s", validErr.Field)
+			}
+		} else {
+			t.Errorf("expected MessageValidationError, got %T", err)
+		}
+	})
+}
+
+// TestTraceContextInjectionExtraction tests trace context propagation.
+func TestTraceContextInjectionExtraction(t *testing.T) {
+	msg := &ValidatedMessage{
+		Headers: MessageHeaders{
+			Custom: make(map[string]string),
+		},
+	}
+
+	// Create a mock trace context
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	originalCtx := trace.ContextWithSpanContext(context.Background(), spanContext)
+
+	// Use TraceContext propagator for testing
+	propagator := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{})
+
+	// Inject trace context into message headers
+	msg.InjectTraceContext(originalCtx, propagator)
+
+	// Verify that headers were set
+	if len(msg.Headers.Custom) == 0 {
+		t.Error("expected trace headers to be set")
+	}
+
+	// Extract trace context from message headers
+	extractedCtx := msg.ExtractTraceContext(context.Background(), propagator)
+
+	// Verify the extracted context contains the same trace information
+	extractedSpanContext := trace.SpanFromContext(extractedCtx).SpanContext()
+	if extractedSpanContext.TraceID() != traceID {
+		t.Errorf("expected extracted trace ID %v, got %v", traceID, extractedSpanContext.TraceID())
+	}
+}
+
+// TestHeaderCarrier tests the HeaderCarrier implementation.
+func TestHeaderCarrier(t *testing.T) {
+	carrier := &HeaderCarrier{headers: make(map[string]string)}
+
+	// Test Set and Get
+	carrier.Set("test-key", "test-value")
+	value := carrier.Get("test-key")
+	if value != "test-value" {
+		t.Errorf("expected 'test-value', got '%s'", value)
+	}
+
+	// Test Keys
+	carrier.Set("key1", "value1")
+	carrier.Set("key2", "value2")
+	keys := carrier.Keys()
+
+	if len(keys) != 3 {
+		t.Errorf("expected 3 keys, got %d", len(keys))
+	}
+
+	// Test Get non-existent key
+	value = carrier.Get("non-existent")
+	if value != "" {
+		t.Errorf("expected empty string for non-existent key, got '%s'", value)
+	}
+}
+
+// TestMessageValidationError tests the MessageValidationError type.
+func TestMessageValidationError(t *testing.T) {
+	t.Run("error with field", func(t *testing.T) {
+		err := &MessageValidationError{
+			Field:   "test_field",
+			Message: "test message",
+		}
+
+		expected := "validation failed for field 'test_field': test message"
+		if err.Error() != expected {
+			t.Errorf("expected '%s', got '%s'", expected, err.Error())
+		}
+	})
+
+	t.Run("error without field", func(t *testing.T) {
+		err := &MessageValidationError{
+			Message: "test message",
+		}
+
+		expected := "validation failed: test message"
+		if err.Error() != expected {
+			t.Errorf("expected '%s', got '%s'", expected, err.Error())
+		}
+	})
+
+	t.Run("unwrap error", func(t *testing.T) {
+		cause := &MessageValidationError{Message: "cause"}
+		err := &MessageValidationError{
+			Message: "wrapper",
+			Cause:   cause,
+		}
+
+		unwrapped := err.Unwrap()
+		if unwrapped != cause {
+			t.Errorf("expected unwrapped error to be cause, got %v", unwrapped)
+		}
+	})
+}
+
+// TestMessageHeaders tests the MessageHeaders structure.
+func TestMessageHeaders(t *testing.T) {
+	headers := MessageHeaders{
+		TraceID:       "trace-123",
+		SpanID:        "span-456",
+		CorrelationID: "corr-789",
+		MessageType:   "UserCreated",
+		ContentType:   "application/json",
+		CreatedAt:     time.Now(),
+		RetryCount:    0,
+		MaxRetries:    3,
+		Custom:        make(map[string]string),
+	}
+
+	headers.Custom["custom-key"] = "custom-value"
+
+	// Test that all fields are accessible
+	if headers.TraceID != "trace-123" {
+		t.Errorf("expected trace ID 'trace-123', got %s", headers.TraceID)
+	}
+
+	if headers.Custom["custom-key"] != "custom-value" {
+		t.Errorf("expected custom value 'custom-value', got %s", headers.Custom["custom-key"])
+	}
+}
+
+// BenchmarkMessageValidation benchmarks message validation performance.
+func BenchmarkMessageValidation(b *testing.B) {
+	validator := NewStructMessageValidator()
+	msg := &ValidatedMessage{
+		ID:        uuid.New().String(),
+		Topic:     "test.topic",
+		Payload:   []byte("test payload"),
+		Timestamp: time.Now(),
+		Headers:   MessageHeaders{Custom: make(map[string]string)},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = validator.Validate(msg)
+	}
+}
+
+// BenchmarkMessageBuilder benchmarks message building performance.
+func BenchmarkMessageBuilder(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewMessageBuilder().
+			WithID(uuid.New().String()).
+			WithTopic("test.topic").
+			WithPayload([]byte("test payload")).
+			Build()
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}

--- a/pkg/messaging/routing.go
+++ b/pkg/messaging/routing.go
@@ -1,0 +1,572 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package messaging
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"regexp"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// RoutingInfo contains comprehensive routing information for message delivery.
+// It provides abstractions for different routing strategies including topics,
+// partitions, queues, and exchanges, enabling support for various message brokers.
+type RoutingInfo struct {
+	// Topic specifies the logical destination for the message
+	Topic string `json:"topic" validate:"required,topic"`
+
+	// Partition specifies the partition within the topic (for partitioned topics)
+	Partition *int32 `json:"partition,omitempty" validate:"omitempty,min=0"`
+
+	// PartitionKey is used for deterministic partition assignment
+	PartitionKey string `json:"partition_key,omitempty"`
+
+	// Queue specifies the queue name for queue-based routing
+	Queue string `json:"queue,omitempty" validate:"omitempty,topic"`
+
+	// Exchange specifies the exchange name for exchange-based routing (RabbitMQ)
+	Exchange string `json:"exchange,omitempty"`
+
+	// RoutingKey specifies the routing key for exchange routing
+	RoutingKey string `json:"routing_key,omitempty"`
+
+	// Headers contains routing headers for header-based routing
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// Strategy specifies the routing strategy to use
+	Strategy RoutingStrategy `json:"strategy"`
+
+	// Options contains broker-specific routing options
+	Options map[string]interface{} `json:"options,omitempty"`
+}
+
+// RoutingStrategy defines different message routing strategies.
+type RoutingStrategy int
+
+const (
+	// RoutingStrategyDirect routes messages directly to a specific topic/queue
+	RoutingStrategyDirect RoutingStrategy = iota
+
+	// RoutingStrategyPartitioned routes messages to partitions within a topic
+	RoutingStrategyPartitioned
+
+	// RoutingStrategyRoundRobin distributes messages evenly across available partitions
+	RoutingStrategyRoundRobin
+
+	// RoutingStrategyKeyBased routes messages based on partition key hash
+	RoutingStrategyKeyBased
+
+	// RoutingStrategyExchange routes messages through an exchange (RabbitMQ style)
+	RoutingStrategyExchange
+
+	// RoutingStrategyHeaderBased routes messages based on header values
+	RoutingStrategyHeaderBased
+
+	// RoutingStrategyMulticast sends messages to multiple destinations
+	RoutingStrategyMulticast
+
+	// RoutingStrategyCustom allows for custom routing logic
+	RoutingStrategyCustom
+)
+
+// String returns the string representation of RoutingStrategy.
+func (rs RoutingStrategy) String() string {
+	switch rs {
+	case RoutingStrategyDirect:
+		return "direct"
+	case RoutingStrategyPartitioned:
+		return "partitioned"
+	case RoutingStrategyRoundRobin:
+		return "round_robin"
+	case RoutingStrategyKeyBased:
+		return "key_based"
+	case RoutingStrategyExchange:
+		return "exchange"
+	case RoutingStrategyHeaderBased:
+		return "header_based"
+	case RoutingStrategyMulticast:
+		return "multicast"
+	case RoutingStrategyCustom:
+		return "custom"
+	default:
+		return "unknown"
+	}
+}
+
+// TopicConfig provides configuration for topic-based routing with
+// support for partitioning and naming conventions.
+type TopicConfig struct {
+	// Name is the topic name
+	Name string `json:"name" validate:"required,topic"`
+
+	// Partitions specifies the number of partitions for the topic
+	Partitions int32 `json:"partitions" validate:"min=1,max=1000"`
+
+	// ReplicationFactor specifies replication level (Kafka)
+	ReplicationFactor int16 `json:"replication_factor,omitempty" validate:"omitempty,min=1,max=10"`
+
+	// RetentionMS specifies message retention time in milliseconds
+	RetentionMS int64 `json:"retention_ms,omitempty" validate:"omitempty,min=3600000"` // Min 1 hour
+
+	// CleanupPolicy specifies how to clean up old messages
+	CleanupPolicy CleanupPolicy `json:"cleanup_policy"`
+
+	// Config contains additional topic configuration properties
+	Config map[string]string `json:"config,omitempty"`
+}
+
+// QueueConfig provides configuration for queue-based routing with
+// durability and delivery options.
+type QueueConfig struct {
+	// Name is the queue name
+	Name string `json:"name" validate:"required,topic"`
+
+	// Durable specifies if the queue survives broker restarts
+	Durable bool `json:"durable"`
+
+	// AutoDelete specifies if the queue is deleted when not in use
+	AutoDelete bool `json:"auto_delete"`
+
+	// Exclusive specifies if only one consumer can access the queue
+	Exclusive bool `json:"exclusive"`
+
+	// MessageTTL specifies default message TTL in milliseconds
+	MessageTTL int64 `json:"message_ttl,omitempty" validate:"omitempty,min=0"`
+
+	// MaxLength specifies maximum number of messages in the queue
+	MaxLength int64 `json:"max_length,omitempty" validate:"omitempty,min=1"`
+
+	// DeadLetterExchange specifies dead letter exchange for failed messages
+	DeadLetterExchange string `json:"dead_letter_exchange,omitempty"`
+
+	// Arguments contains additional queue arguments
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+// ExchangeConfig provides configuration for exchange-based routing (RabbitMQ).
+type ExchangeConfig struct {
+	// Name is the exchange name
+	Name string `json:"name" validate:"required"`
+
+	// Type specifies the exchange type (direct, fanout, topic, headers)
+	Type ExchangeType `json:"type"`
+
+	// Durable specifies if the exchange survives broker restarts
+	Durable bool `json:"durable"`
+
+	// AutoDelete specifies if the exchange is deleted when not in use
+	AutoDelete bool `json:"auto_delete"`
+
+	// Internal specifies if the exchange is internal (used by broker)
+	Internal bool `json:"internal"`
+
+	// Arguments contains additional exchange arguments
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+// CleanupPolicy defines how old messages are cleaned up from topics.
+type CleanupPolicy int
+
+const (
+	// CleanupPolicyDelete deletes old messages based on retention
+	CleanupPolicyDelete CleanupPolicy = iota
+
+	// CleanupPolicyCompact keeps only the latest value for each key
+	CleanupPolicyCompact
+
+	// CleanupPolicyDeleteAndCompact combines both policies
+	CleanupPolicyDeleteAndCompact
+)
+
+// String returns the string representation of CleanupPolicy.
+func (cp CleanupPolicy) String() string {
+	switch cp {
+	case CleanupPolicyDelete:
+		return "delete"
+	case CleanupPolicyCompact:
+		return "compact"
+	case CleanupPolicyDeleteAndCompact:
+		return "delete,compact"
+	default:
+		return "unknown"
+	}
+}
+
+// ExchangeType defines different exchange types for RabbitMQ-style routing.
+type ExchangeType int
+
+const (
+	// ExchangeTypeDirect routes messages with exact routing key match
+	ExchangeTypeDirect ExchangeType = iota
+
+	// ExchangeTypeFanout routes messages to all bound queues
+	ExchangeTypeFanout
+
+	// ExchangeTypeTopic routes messages based on routing key patterns
+	ExchangeTypeTopic
+
+	// ExchangeTypeHeaders routes messages based on header values
+	ExchangeTypeHeaders
+)
+
+// String returns the string representation of ExchangeType.
+func (et ExchangeType) String() string {
+	switch et {
+	case ExchangeTypeDirect:
+		return "direct"
+	case ExchangeTypeFanout:
+		return "fanout"
+	case ExchangeTypeTopic:
+		return "topic"
+	case ExchangeTypeHeaders:
+		return "headers"
+	default:
+		return "unknown"
+	}
+}
+
+// PartitionResolver defines the interface for partition resolution strategies.
+// Different brokers can implement custom partition resolution logic.
+type PartitionResolver interface {
+	// ResolvePartition determines the partition number for a given message
+	ResolvePartition(routing *RoutingInfo, totalPartitions int32) (int32, error)
+
+	// GetStrategyName returns the name of the partition strategy
+	GetStrategyName() string
+}
+
+// DefaultPartitionResolver provides standard partition resolution strategies.
+type DefaultPartitionResolver struct{}
+
+// ResolvePartition implements partition resolution based on the routing strategy.
+func (dpr *DefaultPartitionResolver) ResolvePartition(routing *RoutingInfo, totalPartitions int32) (int32, error) {
+	if totalPartitions <= 0 {
+		return 0, fmt.Errorf("total partitions must be positive, got: %d", totalPartitions)
+	}
+
+	switch routing.Strategy {
+	case RoutingStrategyDirect:
+		if routing.Partition != nil {
+			if *routing.Partition >= totalPartitions {
+				return 0, fmt.Errorf("partition %d exceeds total partitions %d", *routing.Partition, totalPartitions)
+			}
+			return *routing.Partition, nil
+		}
+		return 0, nil
+
+	case RoutingStrategyKeyBased:
+		if routing.PartitionKey == "" {
+			return 0, fmt.Errorf("partition key is required for key-based routing")
+		}
+		return dpr.hashPartition(routing.PartitionKey, totalPartitions), nil
+
+	case RoutingStrategyRoundRobin:
+		// For round-robin, the caller should maintain state
+		// This returns a hash-based partition as fallback
+		return dpr.hashPartition(routing.Topic, totalPartitions), nil
+
+	default:
+		return 0, fmt.Errorf("unsupported routing strategy: %s", routing.Strategy.String())
+	}
+}
+
+// GetStrategyName returns the name of this partition resolver.
+func (dpr *DefaultPartitionResolver) GetStrategyName() string {
+	return "default"
+}
+
+// hashPartition calculates a partition number based on a consistent hash of the key.
+func (dpr *DefaultPartitionResolver) hashPartition(key string, totalPartitions int32) int32 {
+	hasher := fnv.New32a()
+	hasher.Write([]byte(key))
+	return int32(hasher.Sum32()) % totalPartitions
+}
+
+// RoutingValidator provides validation for routing information.
+type RoutingValidator struct {
+	validator *validator.Validate
+}
+
+// NewRoutingValidator creates a new routing validator with custom validation rules.
+func NewRoutingValidator() *RoutingValidator {
+	v := validator.New()
+
+	// Register custom validations
+	v.RegisterValidation("topic", validateTopicName)
+
+	return &RoutingValidator{validator: v}
+}
+
+// Validate performs comprehensive validation on routing information.
+func (rv *RoutingValidator) Validate(routing *RoutingInfo) error {
+	if routing == nil {
+		return fmt.Errorf("routing info cannot be nil")
+	}
+
+	// Perform struct validation
+	if err := rv.validator.Struct(routing); err != nil {
+		return &MessageValidationError{
+			Field:   getFieldName(err),
+			Message: formatValidationError(err),
+			Cause:   err,
+		}
+	}
+
+	// Validate strategy-specific requirements
+	return rv.validateStrategyRequirements(routing)
+}
+
+// validateStrategyRequirements validates that required fields are present for each strategy.
+func (rv *RoutingValidator) validateStrategyRequirements(routing *RoutingInfo) error {
+	switch routing.Strategy {
+	case RoutingStrategyDirect:
+		if routing.Topic == "" && routing.Queue == "" {
+			return &MessageValidationError{
+				Field:   "topic",
+				Message: "either topic or queue is required for direct routing",
+			}
+		}
+
+	case RoutingStrategyPartitioned:
+		if routing.Topic == "" {
+			return &MessageValidationError{
+				Field:   "topic",
+				Message: "topic is required for partitioned routing",
+			}
+		}
+
+	case RoutingStrategyKeyBased:
+		if routing.PartitionKey == "" {
+			return &MessageValidationError{
+				Field:   "partition_key",
+				Message: "partition key is required for key-based routing",
+			}
+		}
+
+	case RoutingStrategyExchange:
+		if routing.Exchange == "" {
+			return &MessageValidationError{
+				Field:   "exchange",
+				Message: "exchange is required for exchange-based routing",
+			}
+		}
+
+	case RoutingStrategyHeaderBased:
+		if len(routing.Headers) == 0 {
+			return &MessageValidationError{
+				Field:   "headers",
+				Message: "routing headers are required for header-based routing",
+			}
+		}
+	}
+
+	return nil
+}
+
+// RoutingBuilder provides a fluent interface for constructing routing information.
+type RoutingBuilder struct {
+	routing *RoutingInfo
+}
+
+// NewRoutingBuilder creates a new routing builder with defaults.
+func NewRoutingBuilder() *RoutingBuilder {
+	return &RoutingBuilder{
+		routing: &RoutingInfo{
+			Strategy: RoutingStrategyDirect,
+			Headers:  make(map[string]string),
+			Options:  make(map[string]interface{}),
+		},
+	}
+}
+
+// WithTopic sets the destination topic.
+func (rb *RoutingBuilder) WithTopic(topic string) *RoutingBuilder {
+	rb.routing.Topic = topic
+	return rb
+}
+
+// WithPartition sets a specific partition number.
+func (rb *RoutingBuilder) WithPartition(partition int32) *RoutingBuilder {
+	rb.routing.Partition = &partition
+	rb.routing.Strategy = RoutingStrategyPartitioned
+	return rb
+}
+
+// WithPartitionKey sets the partition key for key-based routing.
+func (rb *RoutingBuilder) WithPartitionKey(key string) *RoutingBuilder {
+	rb.routing.PartitionKey = key
+	rb.routing.Strategy = RoutingStrategyKeyBased
+	return rb
+}
+
+// WithQueue sets the destination queue.
+func (rb *RoutingBuilder) WithQueue(queue string) *RoutingBuilder {
+	rb.routing.Queue = queue
+	return rb
+}
+
+// WithExchange sets the exchange and routing key for exchange-based routing.
+func (rb *RoutingBuilder) WithExchange(exchange, routingKey string) *RoutingBuilder {
+	rb.routing.Exchange = exchange
+	rb.routing.RoutingKey = routingKey
+	rb.routing.Strategy = RoutingStrategyExchange
+	return rb
+}
+
+// WithHeader adds a routing header for header-based routing.
+func (rb *RoutingBuilder) WithHeader(key, value string) *RoutingBuilder {
+	if rb.routing.Headers == nil {
+		rb.routing.Headers = make(map[string]string)
+	}
+	rb.routing.Headers[key] = value
+	rb.routing.Strategy = RoutingStrategyHeaderBased
+	return rb
+}
+
+// WithStrategy explicitly sets the routing strategy.
+func (rb *RoutingBuilder) WithStrategy(strategy RoutingStrategy) *RoutingBuilder {
+	rb.routing.Strategy = strategy
+	return rb
+}
+
+// WithOption adds a broker-specific routing option.
+func (rb *RoutingBuilder) WithOption(key string, value interface{}) *RoutingBuilder {
+	if rb.routing.Options == nil {
+		rb.routing.Options = make(map[string]interface{})
+	}
+	rb.routing.Options[key] = value
+	return rb
+}
+
+// Build creates and validates the routing information.
+func (rb *RoutingBuilder) Build() (*RoutingInfo, error) {
+	validator := NewRoutingValidator()
+	if err := validator.Validate(rb.routing); err != nil {
+		return nil, err
+	}
+
+	// Create a copy to prevent modification after build
+	result := *rb.routing
+	return &result, nil
+}
+
+// TopicMatcher provides pattern matching for topic-based routing.
+type TopicMatcher struct {
+	patterns map[string]*regexp.Regexp
+}
+
+// NewTopicMatcher creates a new topic matcher with compiled patterns.
+func NewTopicMatcher() *TopicMatcher {
+	return &TopicMatcher{
+		patterns: make(map[string]*regexp.Regexp),
+	}
+}
+
+// AddPattern adds a topic pattern for matching.
+// Patterns support wildcards: * matches any single level, # matches multiple levels.
+func (tm *TopicMatcher) AddPattern(pattern string) error {
+	regexPattern := tm.convertTopicPatternToRegex(pattern)
+	compiled, err := regexp.Compile(regexPattern)
+	if err != nil {
+		return fmt.Errorf("invalid topic pattern '%s': %w", pattern, err)
+	}
+
+	tm.patterns[pattern] = compiled
+	return nil
+}
+
+// Matches checks if a topic matches any of the registered patterns.
+func (tm *TopicMatcher) Matches(topic string) []string {
+	var matches []string
+	for pattern, regex := range tm.patterns {
+		if regex.MatchString(topic) {
+			matches = append(matches, pattern)
+		}
+	}
+	return matches
+}
+
+// convertTopicPatternToRegex converts topic wildcard patterns to regular expressions.
+// * matches exactly one level (e.g., "user.*" matches "user.created" but not "user.profile.updated")
+// # matches one or more levels (e.g., "user.#" matches "user.created" and "user.profile.updated")
+func (tm *TopicMatcher) convertTopicPatternToRegex(pattern string) string {
+	// Escape regex special characters except * and #
+	escaped := regexp.QuoteMeta(pattern)
+
+	// Replace escaped wildcards with regex equivalents
+	escaped = strings.ReplaceAll(escaped, `\*`, `[^.]+`) // * matches one level
+	escaped = strings.ReplaceAll(escaped, `\#`, `.+`)    // # matches multiple levels
+
+	// Anchor the pattern to match the entire topic
+	return "^" + escaped + "$"
+}
+
+// ConsistentHashPartitioner implements consistent hashing for partition assignment.
+type ConsistentHashPartitioner struct {
+	hashFunction func([]byte) uint64
+}
+
+// NewConsistentHashPartitioner creates a new consistent hash partitioner.
+func NewConsistentHashPartitioner() *ConsistentHashPartitioner {
+	return &ConsistentHashPartitioner{
+		hashFunction: func(data []byte) uint64 {
+			hasher := fnv.New64a()
+			hasher.Write(data)
+			return hasher.Sum64()
+		},
+	}
+}
+
+// GetPartition calculates the partition for a given key using consistent hashing.
+func (chp *ConsistentHashPartitioner) GetPartition(key []byte, totalPartitions int32) int32 {
+	if totalPartitions <= 0 {
+		return 0
+	}
+
+	hash := chp.hashFunction(key)
+	return int32(hash % uint64(totalPartitions))
+}
+
+// MD5HashPartitioner implements MD5-based partitioning for compatibility.
+type MD5HashPartitioner struct{}
+
+// NewMD5HashPartitioner creates a new MD5-based partitioner.
+func NewMD5HashPartitioner() *MD5HashPartitioner {
+	return &MD5HashPartitioner{}
+}
+
+// GetPartition calculates the partition using MD5 hash.
+func (m5p *MD5HashPartitioner) GetPartition(key []byte, totalPartitions int32) int32 {
+	if totalPartitions <= 0 {
+		return 0
+	}
+
+	hash := md5.Sum(key)
+
+	// Use the first 8 bytes of the hash as uint64
+	hashValue := binary.BigEndian.Uint64(hash[:8])
+	return int32(hashValue % uint64(totalPartitions))
+}

--- a/pkg/messaging/routing_test.go
+++ b/pkg/messaging/routing_test.go
@@ -1,0 +1,688 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package messaging
+
+import (
+	"testing"
+)
+
+// TestRoutingValidator tests the routing validation functionality.
+func TestRoutingValidator(t *testing.T) {
+	validator := NewRoutingValidator()
+
+	tests := []struct {
+		name       string
+		routing    *RoutingInfo
+		wantError  bool
+		errorField string
+	}{
+		{
+			name: "valid direct routing",
+			routing: &RoutingInfo{
+				Topic:    "test.topic",
+				Strategy: RoutingStrategyDirect,
+				Headers:  make(map[string]string),
+				Options:  make(map[string]interface{}),
+			},
+			wantError: false,
+		},
+		{
+			name: "valid partitioned routing",
+			routing: &RoutingInfo{
+				Topic:     "test.topic",
+				Partition: int32Ptr(0),
+				Strategy:  RoutingStrategyPartitioned,
+				Headers:   make(map[string]string),
+				Options:   make(map[string]interface{}),
+			},
+			wantError: false,
+		},
+		{
+			name: "valid key-based routing",
+			routing: &RoutingInfo{
+				Topic:        "test.topic",
+				PartitionKey: "user-123",
+				Strategy:     RoutingStrategyKeyBased,
+				Headers:      make(map[string]string),
+				Options:      make(map[string]interface{}),
+			},
+			wantError: false,
+		},
+		{
+			name: "valid exchange routing",
+			routing: &RoutingInfo{
+				Exchange:   "user.exchange",
+				RoutingKey: "user.created",
+				Strategy:   RoutingStrategyExchange,
+				Headers:    make(map[string]string),
+				Options:    make(map[string]interface{}),
+			},
+			wantError: false,
+		},
+		{
+			name: "valid header-based routing",
+			routing: &RoutingInfo{
+				Headers: map[string]string{
+					"user-type": "premium",
+					"region":    "us-east",
+				},
+				Strategy: RoutingStrategyHeaderBased,
+				Options:  make(map[string]interface{}),
+			},
+			wantError: false,
+		},
+		{
+			name: "direct routing without topic or queue",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyDirect,
+				Headers:  make(map[string]string),
+				Options:  make(map[string]interface{}),
+			},
+			wantError:  true,
+			errorField: "topic",
+		},
+		{
+			name: "partitioned routing without topic",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyPartitioned,
+				Headers:  make(map[string]string),
+				Options:  make(map[string]interface{}),
+			},
+			wantError:  true,
+			errorField: "topic",
+		},
+		{
+			name: "key-based routing without partition key",
+			routing: &RoutingInfo{
+				Topic:    "test.topic",
+				Strategy: RoutingStrategyKeyBased,
+				Headers:  make(map[string]string),
+				Options:  make(map[string]interface{}),
+			},
+			wantError:  true,
+			errorField: "partition_key",
+		},
+		{
+			name: "exchange routing without exchange",
+			routing: &RoutingInfo{
+				RoutingKey: "user.created",
+				Strategy:   RoutingStrategyExchange,
+				Headers:    make(map[string]string),
+				Options:    make(map[string]interface{}),
+			},
+			wantError:  true,
+			errorField: "exchange",
+		},
+		{
+			name: "header-based routing without headers",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyHeaderBased,
+				Headers:  make(map[string]string), // Empty headers
+				Options:  make(map[string]interface{}),
+			},
+			wantError:  true,
+			errorField: "headers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(tt.routing)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected validation error, got nil")
+					return
+				}
+
+				if validErr, ok := err.(*MessageValidationError); ok {
+					if tt.errorField != "" && validErr.Field != tt.errorField {
+						t.Errorf("expected error field %s, got %s", tt.errorField, validErr.Field)
+					}
+				} else {
+					t.Errorf("expected MessageValidationError, got %T", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected validation error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestRoutingStrategy tests the RoutingStrategy string representation.
+func TestRoutingStrategy(t *testing.T) {
+	tests := []struct {
+		strategy RoutingStrategy
+		expected string
+	}{
+		{RoutingStrategyDirect, "direct"},
+		{RoutingStrategyPartitioned, "partitioned"},
+		{RoutingStrategyRoundRobin, "round_robin"},
+		{RoutingStrategyKeyBased, "key_based"},
+		{RoutingStrategyExchange, "exchange"},
+		{RoutingStrategyHeaderBased, "header_based"},
+		{RoutingStrategyMulticast, "multicast"},
+		{RoutingStrategyCustom, "custom"},
+		{RoutingStrategy(999), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := tt.strategy.String()
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestCleanupPolicy tests the CleanupPolicy string representation.
+func TestCleanupPolicy(t *testing.T) {
+	tests := []struct {
+		policy   CleanupPolicy
+		expected string
+	}{
+		{CleanupPolicyDelete, "delete"},
+		{CleanupPolicyCompact, "compact"},
+		{CleanupPolicyDeleteAndCompact, "delete,compact"},
+		{CleanupPolicy(999), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := tt.policy.String()
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestExchangeType tests the ExchangeType string representation.
+func TestExchangeType(t *testing.T) {
+	tests := []struct {
+		exchangeType ExchangeType
+		expected     string
+	}{
+		{ExchangeTypeDirect, "direct"},
+		{ExchangeTypeFanout, "fanout"},
+		{ExchangeTypeTopic, "topic"},
+		{ExchangeTypeHeaders, "headers"},
+		{ExchangeType(999), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := tt.exchangeType.String()
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestDefaultPartitionResolver tests the default partition resolution.
+func TestDefaultPartitionResolver(t *testing.T) {
+	resolver := &DefaultPartitionResolver{}
+
+	tests := []struct {
+		name              string
+		routing           *RoutingInfo
+		totalPartitions   int32
+		expectedPartition int32
+		wantError         bool
+	}{
+		{
+			name: "direct routing with specific partition",
+			routing: &RoutingInfo{
+				Strategy:  RoutingStrategyDirect,
+				Partition: int32Ptr(2),
+			},
+			totalPartitions:   5,
+			expectedPartition: 2,
+			wantError:         false,
+		},
+		{
+			name: "direct routing without partition",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyDirect,
+			},
+			totalPartitions:   5,
+			expectedPartition: 0,
+			wantError:         false,
+		},
+		{
+			name: "key-based routing",
+			routing: &RoutingInfo{
+				Strategy:     RoutingStrategyKeyBased,
+				PartitionKey: "user-123",
+			},
+			totalPartitions: 5,
+			wantError:       false,
+			// We can't predict exact partition due to hashing, just verify no error
+		},
+		{
+			name: "partition exceeds total",
+			routing: &RoutingInfo{
+				Strategy:  RoutingStrategyDirect,
+				Partition: int32Ptr(10),
+			},
+			totalPartitions: 5,
+			wantError:       true,
+		},
+		{
+			name: "key-based without partition key",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyKeyBased,
+			},
+			totalPartitions: 5,
+			wantError:       true,
+		},
+		{
+			name: "invalid total partitions",
+			routing: &RoutingInfo{
+				Strategy: RoutingStrategyDirect,
+			},
+			totalPartitions: 0,
+			wantError:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			partition, err := resolver.ResolvePartition(tt.routing, tt.totalPartitions)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+
+				// For direct routing with specific partition, verify exact match
+				if tt.routing.Strategy == RoutingStrategyDirect && tt.routing.Partition != nil {
+					if partition != tt.expectedPartition {
+						t.Errorf("expected partition %d, got %d", tt.expectedPartition, partition)
+					}
+				}
+
+				// For all strategies, verify partition is within valid range
+				if partition < 0 || partition >= tt.totalPartitions {
+					t.Errorf("partition %d is out of range [0, %d)", partition, tt.totalPartitions)
+				}
+			}
+		})
+	}
+}
+
+// TestRoutingBuilder tests the routing builder functionality.
+func TestRoutingBuilder(t *testing.T) {
+	t.Run("build direct routing", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithTopic("test.topic").
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.Topic != "test.topic" {
+			t.Errorf("expected topic 'test.topic', got %s", routing.Topic)
+		}
+
+		if routing.Strategy != RoutingStrategyDirect {
+			t.Errorf("expected strategy %v, got %v", RoutingStrategyDirect, routing.Strategy)
+		}
+	})
+
+	t.Run("build partitioned routing", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithTopic("test.topic").
+			WithPartition(3).
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.Partition == nil || *routing.Partition != 3 {
+			t.Errorf("expected partition 3, got %v", routing.Partition)
+		}
+
+		if routing.Strategy != RoutingStrategyPartitioned {
+			t.Errorf("expected strategy %v, got %v", RoutingStrategyPartitioned, routing.Strategy)
+		}
+	})
+
+	t.Run("build key-based routing", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithTopic("test.topic").
+			WithPartitionKey("user-123").
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.PartitionKey != "user-123" {
+			t.Errorf("expected partition key 'user-123', got %s", routing.PartitionKey)
+		}
+
+		if routing.Strategy != RoutingStrategyKeyBased {
+			t.Errorf("expected strategy %v, got %v", RoutingStrategyKeyBased, routing.Strategy)
+		}
+	})
+
+	t.Run("build exchange routing", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithExchange("user.exchange", "user.created").
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.Exchange != "user.exchange" {
+			t.Errorf("expected exchange 'user.exchange', got %s", routing.Exchange)
+		}
+
+		if routing.RoutingKey != "user.created" {
+			t.Errorf("expected routing key 'user.created', got %s", routing.RoutingKey)
+		}
+
+		if routing.Strategy != RoutingStrategyExchange {
+			t.Errorf("expected strategy %v, got %v", RoutingStrategyExchange, routing.Strategy)
+		}
+	})
+
+	t.Run("build header-based routing", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithHeader("user-type", "premium").
+			WithHeader("region", "us-east").
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.Headers["user-type"] != "premium" {
+			t.Errorf("expected header 'premium', got %s", routing.Headers["user-type"])
+		}
+
+		if routing.Headers["region"] != "us-east" {
+			t.Errorf("expected header 'us-east', got %s", routing.Headers["region"])
+		}
+
+		if routing.Strategy != RoutingStrategyHeaderBased {
+			t.Errorf("expected strategy %v, got %v", RoutingStrategyHeaderBased, routing.Strategy)
+		}
+	})
+
+	t.Run("build with options", func(t *testing.T) {
+		routing, err := NewRoutingBuilder().
+			WithTopic("test.topic").
+			WithOption("timeout", 5000).
+			WithOption("retry", true).
+			Build()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if routing.Options["timeout"] != 5000 {
+			t.Errorf("expected option 5000, got %v", routing.Options["timeout"])
+		}
+
+		if routing.Options["retry"] != true {
+			t.Errorf("expected option true, got %v", routing.Options["retry"])
+		}
+	})
+}
+
+// TestTopicMatcher tests the topic pattern matching functionality.
+func TestTopicMatcher(t *testing.T) {
+	matcher := NewTopicMatcher()
+
+	// Add patterns
+	patterns := []string{
+		"user.*",
+		"user.#",
+		"order.payment.*",
+		"system.*.critical",
+		"*.events",
+	}
+
+	for _, pattern := range patterns {
+		if err := matcher.AddPattern(pattern); err != nil {
+			t.Fatalf("failed to add pattern %s: %v", pattern, err)
+		}
+	}
+
+	tests := []struct {
+		topic           string
+		expectedMatches []string
+	}{
+		{
+			topic:           "user.created",
+			expectedMatches: []string{"user.*", "user.#"},
+		},
+		{
+			topic:           "user.profile.updated",
+			expectedMatches: []string{"user.#"},
+		},
+		{
+			topic:           "order.payment.completed",
+			expectedMatches: []string{"order.payment.*"},
+		},
+		{
+			topic:           "system.database.critical",
+			expectedMatches: []string{"system.*.critical"},
+		},
+		{
+			topic:           "notification.events",
+			expectedMatches: []string{"*.events"},
+		},
+		{
+			topic:           "unmatched.topic",
+			expectedMatches: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.topic, func(t *testing.T) {
+			matches := matcher.Matches(tt.topic)
+
+			if len(matches) != len(tt.expectedMatches) {
+				t.Errorf("expected %d matches, got %d: %v", len(tt.expectedMatches), len(matches), matches)
+				return
+			}
+
+			// Check that all expected patterns are present
+			for _, expected := range tt.expectedMatches {
+				found := false
+				for _, match := range matches {
+					if match == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected pattern %s not found in matches: %v", expected, matches)
+				}
+			}
+		})
+	}
+}
+
+// TestConsistentHashPartitioner tests the consistent hash partitioner.
+func TestConsistentHashPartitioner(t *testing.T) {
+	partitioner := NewConsistentHashPartitioner()
+
+	tests := []struct {
+		name            string
+		key             []byte
+		totalPartitions int32
+		expectedValid   bool
+	}{
+		{
+			name:            "valid partitioning",
+			key:             []byte("user-123"),
+			totalPartitions: 5,
+			expectedValid:   true,
+		},
+		{
+			name:            "single partition",
+			key:             []byte("test"),
+			totalPartitions: 1,
+			expectedValid:   true,
+		},
+		{
+			name:            "zero partitions",
+			key:             []byte("test"),
+			totalPartitions: 0,
+			expectedValid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			partition := partitioner.GetPartition(tt.key, tt.totalPartitions)
+
+			if tt.expectedValid {
+				if partition < 0 || partition >= tt.totalPartitions {
+					t.Errorf("partition %d is out of range [0, %d)", partition, tt.totalPartitions)
+				}
+			} else {
+				if partition != 0 {
+					t.Errorf("expected partition 0 for invalid input, got %d", partition)
+				}
+			}
+		})
+	}
+
+	// Test consistency: same key should always map to same partition
+	key := []byte("consistent-test")
+	totalPartitions := int32(10)
+
+	firstResult := partitioner.GetPartition(key, totalPartitions)
+	for i := 0; i < 100; i++ {
+		result := partitioner.GetPartition(key, totalPartitions)
+		if result != firstResult {
+			t.Errorf("inconsistent partitioning: first=%d, iteration %d=%d", firstResult, i, result)
+			break
+		}
+	}
+}
+
+// TestMD5HashPartitioner tests the MD5 hash partitioner.
+func TestMD5HashPartitioner(t *testing.T) {
+	partitioner := NewMD5HashPartitioner()
+
+	tests := []struct {
+		name            string
+		key             []byte
+		totalPartitions int32
+		expectedValid   bool
+	}{
+		{
+			name:            "valid partitioning",
+			key:             []byte("user-456"),
+			totalPartitions: 8,
+			expectedValid:   true,
+		},
+		{
+			name:            "single partition",
+			key:             []byte("test"),
+			totalPartitions: 1,
+			expectedValid:   true,
+		},
+		{
+			name:            "zero partitions",
+			key:             []byte("test"),
+			totalPartitions: 0,
+			expectedValid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			partition := partitioner.GetPartition(tt.key, tt.totalPartitions)
+
+			if tt.expectedValid {
+				if partition < 0 || partition >= tt.totalPartitions {
+					t.Errorf("partition %d is out of range [0, %d)", partition, tt.totalPartitions)
+				}
+			} else {
+				if partition != 0 {
+					t.Errorf("expected partition 0 for invalid input, got %d", partition)
+				}
+			}
+		})
+	}
+
+	// Test consistency: same key should always map to same partition
+	key := []byte("md5-test")
+	totalPartitions := int32(16)
+
+	firstResult := partitioner.GetPartition(key, totalPartitions)
+	for i := 0; i < 100; i++ {
+		result := partitioner.GetPartition(key, totalPartitions)
+		if result != firstResult {
+			t.Errorf("inconsistent partitioning: first=%d, iteration %d=%d", firstResult, i, result)
+			break
+		}
+	}
+}
+
+// BenchmarkDefaultPartitionResolver benchmarks partition resolution.
+func BenchmarkDefaultPartitionResolver(b *testing.B) {
+	resolver := &DefaultPartitionResolver{}
+	routing := &RoutingInfo{
+		Strategy:     RoutingStrategyKeyBased,
+		PartitionKey: "benchmark-key",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = resolver.ResolvePartition(routing, 16)
+	}
+}
+
+// BenchmarkConsistentHashPartitioner benchmarks consistent hash partitioning.
+func BenchmarkConsistentHashPartitioner(b *testing.B) {
+	partitioner := NewConsistentHashPartitioner()
+	key := []byte("benchmark-key")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = partitioner.GetPartition(key, 16)
+	}
+}
+
+// Helper function to create int32 pointer
+func int32Ptr(v int32) *int32 {
+	return &v
+}


### PR DESCRIPTION
## Summary
Implements comprehensive message structure and routing system for event-driven architecture as specified in issue #189.

- Enhanced message validation with struct tags and custom validators
- Message headers system with distributed tracing support  
- Routing abstractions supporting topics, partitions, queues, and exchanges
- Message metadata handling with correlation IDs and tracing context
- Builder pattern for fluent message construction

## Implementation Details

### Core Message System (`pkg/messaging/message.go`)
- `StructMessageValidator`: Comprehensive validation using go-playground/validator with custom rules
- `ValidatedMessage`: Core message struct with validation tags for all fields
- `MessageHeaders`: Structured headers with tracing, correlation, and custom metadata
- `TraceContext`: OpenTelemetry integration for distributed tracing
- `MessageBuilder`: Fluent interface for constructing validated messages

### Routing System (`pkg/messaging/routing.go`)
- `RoutingInfo`: Message routing configuration with multiple strategies
- `RoutingStrategy`: Support for Direct, Partitioned, KeyBased, Exchange, and HeaderBased routing
- `PartitionResolver`: Consistent hashing and MD5-based partition resolution
- `TopicMatcher`: Pattern matching with wildcard support for topic subscriptions

### Key Features
- UUID validation for message IDs
- Topic name validation with regex patterns
- TTL validation and expiry checking
- Correlation ID consistency validation
- OpenTelemetry context injection/extraction
- Comprehensive error handling with detailed validation messages

## Test Coverage
- Message validation scenarios (valid/invalid cases)
- Builder pattern functionality
- Trace context propagation
- Routing strategy validation
- Partition resolution algorithms
- Topic pattern matching

## Dependencies Added
- `github.com/go-playground/validator/v10` for struct validation
- Enhanced OpenTelemetry integration for tracing

Closes #189

🤖 Generated with [Claude Code](https://claude.ai/code)