### PR TITLE
feat(transport): integrate MessagingCoordinator with TransportCoordinator

### DIFF
--- a/pkg/transport/registry_manager.go
+++ b/pkg/transport/registry_manager.go
@@ -107,6 +107,11 @@ func (srm *MultiTransportRegistry) RegisterGRPCService(handler TransportServiceH
 	return srm.RegisterHandler("grpc", handler)
 }
 
+// RegisterMessagingService registers a service handler with the messaging transport
+func (srm *MultiTransportRegistry) RegisterMessagingService(handler TransportServiceHandler) error {
+	return srm.RegisterHandler("messaging", handler)
+}
+
 // BindAllHTTPEndpoints registers HTTP routes for services in the HTTP transport registry
 func (srm *MultiTransportRegistry) BindAllHTTPEndpoints(router *gin.Engine) error {
 	srm.mu.RLock()

--- a/pkg/transport/transport_test.go
+++ b/pkg/transport/transport_test.go
@@ -39,6 +39,11 @@ import (
 	"github.com/innovationmech/swit/pkg/types"
 )
 
+const (
+	testServiceVersion = "1.0.0"
+	testHealthTTL      = time.Hour
+)
+
 func init() {
 	// Initialize logger for tests
 	logger.Logger, _ = zap.NewDevelopment()
@@ -1074,13 +1079,13 @@ func (s *simpleServiceHandler) RegisterGRPC(server *grpc.Server) error { return 
 func (s *simpleServiceHandler) GetMetadata() *HandlerMetadata {
 	return &HandlerMetadata{
 		Name:        s.name,
-		Version:     "1.0.0",
+		Version:     testServiceVersion,
 		Description: "Simple test service",
 	}
 }
 func (s *simpleServiceHandler) GetHealthEndpoint() string { return "/health" }
 func (s *simpleServiceHandler) IsHealthy(ctx context.Context) (*types.HealthStatus, error) {
-	return types.NewHealthStatus(types.HealthStatusHealthy, "1.0.0", time.Hour), nil
+	return types.NewHealthStatus(types.HealthStatusHealthy, testServiceVersion, testHealthTTL), nil
 }
 func (s *simpleServiceHandler) Initialize(ctx context.Context) error { return nil }
 func (s *simpleServiceHandler) Shutdown(ctx context.Context) error   { return nil }


### PR DESCRIPTION
## Summary
- Extends TransportCoordinator to support messaging protocols alongside HTTP and gRPC
- Implements messaging-specific methods for broker and event handler management
- Adds comprehensive integration tests for messaging support
- Maintains backward compatibility while enabling unified transport management

## Implementation Details
- Added MessagingCoordinator field to TransportCoordinator struct
- Implemented messaging lifecycle management (Start/Stop integration)
- Extended MultiTransportRegistry to support messaging transport type
- Defined local interfaces to avoid import cycle with messaging package
- Added RegisterMessageBroker, RegisterEventHandler, and related methods
- Created comprehensive test coverage for messaging integration scenarios

## Test Coverage
- Messaging enablement and coordinator management
- Service registration with messaging transport
- Registry support for messaging services
- Lifecycle integration testing

## Breaking Changes
None. All changes are backward compatible with messaging disabled by default.

Closes #219

🤖 Generated with [Claude Code](https://claude.ai/code)