### PR TITLE
fix(messaging): improve health check interfaces

### DIFF
--- a/pkg/messaging/coordinator.go
+++ b/pkg/messaging/coordinator.go
@@ -138,6 +138,11 @@ type MessagingHealthStatus struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// GetOverall returns the overall health status.
+func (s *MessagingHealthStatus) GetOverall() string {
+	return s.Overall
+}
+
 // MessagingCoordinatorError represents errors specific to messaging coordinator operations.
 type MessagingCoordinatorError struct {
 	Operation string


### PR DESCRIPTION
## Summary
- guard messaging subsystem failure counters with mutex
- expose `GetOverall` for messaging health status
- replace `interface{}` usage in server messaging health integration with minimal interfaces

## Testing
- `make quality` *(fails: protobuf code generation server unavailable)*
- `make test` *(fails: multiple packages setup failed)*
- `go test ./pkg/messaging ./pkg/server` *(fails: pkg/server tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c230d81fd0832a8881953cd111a6fd