### PR TITLE
feat(kafka): scaffold core adapter (kafka-go)

### DIFF
--- a/pkg/messaging/adapters/factory.go
+++ b/pkg/messaging/adapters/factory.go
@@ -160,6 +160,13 @@ func GetDefaultAdapterRegistry() BrokerAdapterRegistry {
 	return defaultAdapterRegistry
 }
 
+// init wires the default adapter registry into the messaging factory so that
+// messaging.NewMessageBroker(..) can discover adapters registered here.
+func init() {
+	// Connect global adapters registry to default factory
+	messaging.SetDefaultAdapterRegistry(GetDefaultAdapterRegistry())
+}
+
 // RegisterAdapter implements BrokerAdapterRegistry interface.
 func (r *brokerAdapterRegistryImpl) RegisterAdapter(adapter messaging.MessageBrokerAdapter) error {
 	if adapter == nil {

--- a/pkg/messaging/kafka/adapter.go
+++ b/pkg/messaging/kafka/adapter.go
@@ -85,5 +85,3 @@ func init() {
 	// Ensure adapter registry is connected (handled in adapters package init). Then register adapter.
 	_ = adapters.RegisterGlobalAdapter(newAdapter())
 }
-
-

--- a/pkg/messaging/kafka/adapter.go
+++ b/pkg/messaging/kafka/adapter.go
@@ -1,0 +1,89 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/innovationmech/swit/pkg/messaging/adapters"
+)
+
+// KafkaAdapter implements messaging.MessageBrokerAdapter based on segmentio/kafka-go.
+type KafkaAdapter struct {
+	*adapters.BaseMessageBrokerAdapter
+}
+
+// newAdapter constructs a Kafka adapter with metadata, capabilities and default config.
+func newAdapter() *KafkaAdapter {
+	info := &messaging.BrokerAdapterInfo{
+		Name:                 "kafka-go",
+		Version:              "0.1.0",
+		Description:          "Kafka adapter built on segmentio/kafka-go",
+		SupportedBrokerTypes: []messaging.BrokerType{messaging.BrokerTypeKafka},
+		Author:               "SWIT",
+		License:              "MIT",
+	}
+
+	// Use built-in capability profile for Kafka
+	caps, _ := messaging.GetCapabilityProfile(messaging.BrokerTypeKafka)
+
+	// Provide a safe default configuration template
+	defaultCfg := &messaging.BrokerConfig{
+		Type:      messaging.BrokerTypeKafka,
+		Endpoints: []string{"localhost:9092"},
+	}
+
+	return &KafkaAdapter{BaseMessageBrokerAdapter: adapters.NewBaseMessageBrokerAdapter(info, caps, defaultCfg)}
+}
+
+// CreateBroker implements MessageBrokerAdapter.CreateBroker.
+func (a *KafkaAdapter) CreateBroker(config *messaging.BrokerConfig) (messaging.MessageBroker, error) {
+	// Base validation (type/endpoints) first
+	if res := a.ValidateConfiguration(config); !res.Valid {
+		return nil, messaging.NewConfigError("kafka adapter configuration validation failed", nil)
+	}
+
+	if config.Type != messaging.BrokerTypeKafka {
+		return nil, messaging.NewConfigError(fmt.Sprintf("unsupported broker type for kafka adapter: %s", config.Type), nil)
+	}
+
+	broker := newKafkaBroker(config)
+	return broker, nil
+}
+
+// ValidateConfiguration augments base validation with Kafka specifics (timeouts defaults etc.).
+func (a *KafkaAdapter) ValidateConfiguration(config *messaging.BrokerConfig) *messaging.AdapterValidationResult {
+	res := a.BaseMessageBrokerAdapter.ValidateConfiguration(config)
+	if !res.Valid {
+		return res
+	}
+	// Suggest sensible defaults if missing
+	if config != nil {
+		if config.Connection.Timeout <= 0 {
+			res.Suggestions = append(res.Suggestions, messaging.AdapterValidationSuggestion{
+				Field:          "Connection.Timeout",
+				Message:        "use a positive timeout",
+				SuggestedValue: 10 * time.Second,
+			})
+		}
+	}
+	return res
+}
+
+// HealthCheck validates adapter wiring (not broker connectivity).
+func (a *KafkaAdapter) HealthCheck(ctx context.Context) (*messaging.HealthStatus, error) {
+	status, err := a.BaseMessageBrokerAdapter.HealthCheck(ctx)
+	if status != nil {
+		status.Details["library"] = "segmentio/kafka-go"
+	}
+	return status, err
+}
+
+// init registers the Kafka adapter and wires the adapter registry into factory.
+func init() {
+	// Ensure adapter registry is connected (handled in adapters package init). Then register adapter.
+	_ = adapters.RegisterGlobalAdapter(newAdapter())
+}
+
+

--- a/pkg/messaging/kafka/adapter.go
+++ b/pkg/messaging/kafka/adapter.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (

--- a/pkg/messaging/kafka/adapter_test.go
+++ b/pkg/messaging/kafka/adapter_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (

--- a/pkg/messaging/kafka/adapter_test.go
+++ b/pkg/messaging/kafka/adapter_test.go
@@ -1,0 +1,44 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+func TestKafkaAdapter_CreateBroker_And_Lifecycle(t *testing.T) {
+	a := newAdapter()
+
+	cfg := &messaging.BrokerConfig{
+		Type:      messaging.BrokerTypeKafka,
+		Endpoints: []string{"localhost:9092"},
+	}
+
+	// Validate config
+	res := a.ValidateConfiguration(cfg)
+	if res == nil || !res.Valid {
+		t.Fatalf("expected valid config, got %#v", res)
+	}
+
+	// Create broker
+	broker, err := a.CreateBroker(cfg)
+	if err != nil {
+		t.Fatalf("CreateBroker failed: %v", err)
+	}
+
+	// Connect / Disconnect
+	ctx := context.Background()
+	if err := broker.Connect(ctx); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if !broker.IsConnected() {
+		t.Fatalf("expected connected state")
+	}
+	if _, err := broker.HealthCheck(ctx); err != nil {
+		t.Fatalf("HealthCheck failed: %v", err)
+	}
+	if err := broker.Disconnect(ctx); err != nil {
+		t.Fatalf("Disconnect failed: %v", err)
+	}
+}

--- a/pkg/messaging/kafka/broker.go
+++ b/pkg/messaging/kafka/broker.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (

--- a/pkg/messaging/kafka/broker.go
+++ b/pkg/messaging/kafka/broker.go
@@ -11,10 +11,10 @@ import (
 // kafkaBroker is a minimal broker that satisfies messaging.MessageBroker with
 // stubbed publisher/subscriber. Connectivity check is a no-op in this scaffold.
 type kafkaBroker struct {
-	config   *messaging.BrokerConfig
-	metrics  messaging.BrokerMetrics
-	mu       sync.RWMutex
-	started  bool
+	config  *messaging.BrokerConfig
+	metrics messaging.BrokerMetrics
+	mu      sync.RWMutex
+	started bool
 }
 
 func newKafkaBroker(cfg *messaging.BrokerConfig) *kafkaBroker {
@@ -84,5 +84,3 @@ func (b *kafkaBroker) GetCapabilities() *messaging.BrokerCapabilities {
 	caps, _ := messaging.GetCapabilityProfile(messaging.BrokerTypeKafka)
 	return caps
 }
-
-

--- a/pkg/messaging/kafka/broker.go
+++ b/pkg/messaging/kafka/broker.go
@@ -1,0 +1,88 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+// kafkaBroker is a minimal broker that satisfies messaging.MessageBroker with
+// stubbed publisher/subscriber. Connectivity check is a no-op in this scaffold.
+type kafkaBroker struct {
+	config   *messaging.BrokerConfig
+	metrics  messaging.BrokerMetrics
+	mu       sync.RWMutex
+	started  bool
+}
+
+func newKafkaBroker(cfg *messaging.BrokerConfig) *kafkaBroker {
+	return &kafkaBroker{config: cfg}
+}
+
+func (b *kafkaBroker) Connect(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.started {
+		return nil
+	}
+	b.started = true
+	b.metrics.ConnectionStatus = "connected"
+	b.metrics.LastConnectionTime = time.Now()
+	return nil
+}
+
+func (b *kafkaBroker) Disconnect(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.started {
+		return nil
+	}
+	b.started = false
+	b.metrics.ConnectionStatus = "disconnected"
+	return nil
+}
+
+func (b *kafkaBroker) Close() error {
+	return nil
+}
+
+func (b *kafkaBroker) IsConnected() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.started
+}
+
+func (b *kafkaBroker) CreatePublisher(config messaging.PublisherConfig) (messaging.EventPublisher, error) {
+	return &stubPublisher{}, nil
+}
+
+func (b *kafkaBroker) CreateSubscriber(config messaging.SubscriberConfig) (messaging.EventSubscriber, error) {
+	return &stubSubscriber{}, nil
+}
+
+func (b *kafkaBroker) HealthCheck(ctx context.Context) (*messaging.HealthStatus, error) {
+	status := &messaging.HealthStatus{
+		Status:       messaging.HealthStatusHealthy,
+		Message:      "kafka broker scaffold healthy",
+		LastChecked:  time.Now(),
+		ResponseTime: 0,
+		Details: map[string]any{
+			"connected": b.IsConnected(),
+		},
+	}
+	return status, nil
+}
+
+func (b *kafkaBroker) GetMetrics() *messaging.BrokerMetrics {
+	copy := b.metrics.GetSnapshot()
+	return copy
+}
+
+func (b *kafkaBroker) GetCapabilities() *messaging.BrokerCapabilities {
+	caps, _ := messaging.GetCapabilityProfile(messaging.BrokerTypeKafka)
+	return caps
+}
+
+

--- a/pkg/messaging/kafka/stubs.go
+++ b/pkg/messaging/kafka/stubs.go
@@ -1,0 +1,59 @@
+package kafka
+
+import (
+	"context"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+// stubPublisher is a minimal no-op publisher that compiles.
+type stubPublisher struct{}
+
+func (p *stubPublisher) Publish(ctx context.Context, message *messaging.Message) error {
+	return nil
+}
+
+func (p *stubPublisher) PublishBatch(ctx context.Context, messages []*messaging.Message) error {
+	return nil
+}
+
+func (p *stubPublisher) PublishWithConfirm(ctx context.Context, message *messaging.Message) (*messaging.PublishConfirmation, error) {
+	return &messaging.PublishConfirmation{MessageID: message.ID, Timestamp: time.Now()}, nil
+}
+
+func (p *stubPublisher) PublishAsync(ctx context.Context, message *messaging.Message, callback messaging.PublishCallback) error {
+	go func() { callback(&messaging.PublishConfirmation{MessageID: message.ID, Timestamp: time.Now()}, nil) }()
+	return nil
+}
+
+func (p *stubPublisher) BeginTransaction(ctx context.Context) (messaging.Transaction, error) {
+	return nil, messaging.ErrTransactionsNotSupported
+}
+
+func (p *stubPublisher) Flush(ctx context.Context) error { return nil }
+func (p *stubPublisher) Close() error { return nil }
+func (p *stubPublisher) GetMetrics() *messaging.PublisherMetrics { return &messaging.PublisherMetrics{} }
+
+// stubSubscriber is a minimal no-op subscriber that compiles.
+type stubSubscriber struct{}
+
+func (s *stubSubscriber) Subscribe(ctx context.Context, handler messaging.MessageHandler) error { return nil }
+
+func (s *stubSubscriber) SubscribeWithMiddleware(ctx context.Context, handler messaging.MessageHandler, middleware ...messaging.Middleware) error {
+	return nil
+}
+
+func (s *stubSubscriber) Unsubscribe(ctx context.Context) error { return nil }
+func (s *stubSubscriber) Pause(ctx context.Context) error        { return nil }
+func (s *stubSubscriber) Resume(ctx context.Context) error       { return nil }
+
+func (s *stubSubscriber) Seek(ctx context.Context, position messaging.SeekPosition) error {
+	return messaging.NewConfigError("seek not supported in stub", nil)
+}
+
+func (s *stubSubscriber) GetLag(ctx context.Context) (int64, error) { return -1, nil }
+func (s *stubSubscriber) Close() error                              { return nil }
+func (s *stubSubscriber) GetMetrics() *messaging.SubscriberMetrics  { return &messaging.SubscriberMetrics{} }
+
+

--- a/pkg/messaging/kafka/stubs.go
+++ b/pkg/messaging/kafka/stubs.go
@@ -32,21 +32,25 @@ func (p *stubPublisher) BeginTransaction(ctx context.Context) (messaging.Transac
 }
 
 func (p *stubPublisher) Flush(ctx context.Context) error { return nil }
-func (p *stubPublisher) Close() error { return nil }
-func (p *stubPublisher) GetMetrics() *messaging.PublisherMetrics { return &messaging.PublisherMetrics{} }
+func (p *stubPublisher) Close() error                    { return nil }
+func (p *stubPublisher) GetMetrics() *messaging.PublisherMetrics {
+	return &messaging.PublisherMetrics{}
+}
 
 // stubSubscriber is a minimal no-op subscriber that compiles.
 type stubSubscriber struct{}
 
-func (s *stubSubscriber) Subscribe(ctx context.Context, handler messaging.MessageHandler) error { return nil }
+func (s *stubSubscriber) Subscribe(ctx context.Context, handler messaging.MessageHandler) error {
+	return nil
+}
 
 func (s *stubSubscriber) SubscribeWithMiddleware(ctx context.Context, handler messaging.MessageHandler, middleware ...messaging.Middleware) error {
 	return nil
 }
 
 func (s *stubSubscriber) Unsubscribe(ctx context.Context) error { return nil }
-func (s *stubSubscriber) Pause(ctx context.Context) error        { return nil }
-func (s *stubSubscriber) Resume(ctx context.Context) error       { return nil }
+func (s *stubSubscriber) Pause(ctx context.Context) error       { return nil }
+func (s *stubSubscriber) Resume(ctx context.Context) error      { return nil }
 
 func (s *stubSubscriber) Seek(ctx context.Context, position messaging.SeekPosition) error {
 	return messaging.NewConfigError("seek not supported in stub", nil)
@@ -54,6 +58,6 @@ func (s *stubSubscriber) Seek(ctx context.Context, position messaging.SeekPositi
 
 func (s *stubSubscriber) GetLag(ctx context.Context) (int64, error) { return -1, nil }
 func (s *stubSubscriber) Close() error                              { return nil }
-func (s *stubSubscriber) GetMetrics() *messaging.SubscriberMetrics  { return &messaging.SubscriberMetrics{} }
-
-
+func (s *stubSubscriber) GetMetrics() *messaging.SubscriberMetrics {
+	return &messaging.SubscriberMetrics{}
+}

--- a/pkg/messaging/kafka/stubs.go
+++ b/pkg/messaging/kafka/stubs.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (


### PR DESCRIPTION
Implements issue #294: Kafka core adapter scaffold using segmentio/kafka-go.

Scope:
- Config struct alignment via messaging.BrokerConfig
- Shared lifecycle: Connect/Disconnect/Close
- Minimal Publisher/Subscriber stubs compiling
- Adapter registry wired into default factory
- Basic health check hook

Notes:
- Follow-up issues (#295-#299) will extend producer pool, consumer group, partition routing, transactions, and schema registry.

Closes #294.