### PR TITLE
feat: add Kafka transactional publishing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ SWIT 是一个现代化的微服务框架，提供用户认证、内容管理等
 ### 🏗️ 核心架构
 - [服务开发指南](./service-development-guide.md) - **ServiceHandler 模式开发指南**
 - [服务架构分析](./service-architecture-analysis.md) - ServiceHandler 架构深度分析
+- [Kafka 处理-生产事务模式](./architecture/kafka-process-and-produce.md) - Kafka 事务流程与 Exactly-Once 实践
 
 
 ## 服务文档

--- a/docs/architecture/kafka-process-and-produce.md
+++ b/docs/architecture/kafka-process-and-produce.md
@@ -1,0 +1,83 @@
+# Kafka Process-and-Produce Transaction Pattern
+
+The process-and-produce pattern coordinates message consumption, domain processing, and new message publication inside a single transactional boundary. When transactions are enabled, Kafka guarantees that either all produced messages become visible together or none are published. This document explains how to configure the SWIT Kafka adapter for transactional publishing and how to apply the pattern in services.
+
+## When to Use This Pattern
+
+- You consume from a Kafka topic, perform side effects, and must publish follow-up events exactly once.
+- You need transactional semantics between a consumer and a producer to prevent duplicate downstream processing.
+- You want deterministic retries without re-emitting already-processed messages.
+
+## Enabling Transactions
+
+```yaml
+broker:
+  type: kafka
+  endpoints:
+    - localhost:9092
+publisher:
+  topic: processed-orders
+  transactional: true
+```
+
+Set `publisher.transactional` to `true` so the Kafka adapter creates idempotent, transactional producers. Each transaction publishes metadata headers:
+
+- `swit.transaction.id`
+- `swit.transaction.sequence`
+- `swit.transaction.producer`
+
+Consumers can use these headers to deduplicate inbound messages when replaying.
+
+## End-to-End Flow
+
+1. Consume a message and perform local validation or enrichment.
+2. Call `BeginTransaction` on the publisher to allocate a transactional session.
+3. Publish all follow-up events via the transaction handle.
+4. Commit the transaction to atomically persist all pending messages.
+5. Roll back the transaction if processing fails; no messages become visible.
+
+### Go Example
+
+```go
+func handleOrder(ctx context.Context, broker messaging.MessageBroker, msg *messaging.Message) error {
+    publisher, err := broker.CreatePublisher(messaging.PublisherConfig{
+        Topic:         "processed-orders",
+        Transactional: true,
+    })
+    if err != nil {
+        return err
+    }
+    defer publisher.Close()
+
+    tx, err := publisher.BeginTransaction(ctx)
+    if err != nil {
+        return err
+    }
+
+    // Domain processing
+    processed, err := processOrder(msg)
+    if err != nil {
+        _ = tx.Rollback(ctx)
+        return err
+    }
+
+    if err := tx.Publish(ctx, processed); err != nil {
+        _ = tx.Rollback(ctx)
+        return err
+    }
+
+    if err := tx.Commit(ctx); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+## Operational Considerations
+
+- **Idempotent Consumers**: Use the provided headers to de-duplicate when retries occur.
+- **Timeouts**: Provide reasonable deadlines to transaction operations; the adapter propagates context cancellation.
+- **Metrics**: Retrieve publisher metrics via `GetMetrics()` to monitor transaction counts and latency.
+- **Fallback**: When the broker reports `ErrTransactionsNotSupported`, disable the `transactional` flag to fall back to at-least-once semantics.
+
+This pattern keeps processing and emission in sync so downstream consumers observe a consistent event stream without duplicates.

--- a/pkg/messaging/kafka/publisher.go
+++ b/pkg/messaging/kafka/publisher.go
@@ -23,7 +23,13 @@ package kafka
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/innovationmech/swit/pkg/messaging"
 )
@@ -32,6 +38,14 @@ type kafkaPublisher struct {
 	pool        *producerPool
 	config      *messaging.PublisherConfig
 	partitioner PartitionStrategy
+	producerID  string
+
+	metricsMu sync.RWMutex
+	metrics   messaging.PublisherMetrics
+
+	txMu      sync.Mutex
+	activeTx  *kafkaTransaction
+	txCounter uint64
 }
 
 func newKafkaPublisher(pool *producerPool, cfg *messaging.PublisherConfig) (*kafkaPublisher, error) {
@@ -40,7 +54,15 @@ func newKafkaPublisher(pool *producerPool, cfg *messaging.PublisherConfig) (*kaf
 	if err != nil {
 		return nil, err
 	}
-	return &kafkaPublisher{pool: pool, config: &cpy, partitioner: partitioner}, nil
+	return &kafkaPublisher{
+		pool:        pool,
+		config:      &cpy,
+		partitioner: partitioner,
+		producerID:  uuid.NewString(),
+		metrics: messaging.PublisherMetrics{
+			ConnectionStatus: "active",
+		},
+	}, nil
 }
 
 func (p *kafkaPublisher) Publish(ctx context.Context, message *messaging.Message) error {
@@ -78,13 +100,212 @@ func (p *kafkaPublisher) toKafkaMessage(message *messaging.Message) KafkaMessage
 }
 
 func (p *kafkaPublisher) BeginTransaction(ctx context.Context) (messaging.Transaction, error) {
-	return nil, messaging.ErrTransactionsNotSupported
+	if !p.config.Transactional {
+		return nil, messaging.ErrTransactionsNotSupported
+	}
+
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, messaging.NewTransactionError("transaction context canceled before start", err)
+		}
+	}
+
+	p.txMu.Lock()
+	defer p.txMu.Unlock()
+	if p.activeTx != nil && !p.activeTx.isTerminal() {
+		return nil, messaging.NewTransactionError("transaction already in progress", nil)
+	}
+
+	sequence := atomic.AddUint64(&p.txCounter, 1)
+	txID := fmt.Sprintf("%s-%d", p.producerID, sequence)
+	tx := newKafkaTransaction(p, txID)
+	p.activeTx = tx
+	p.recordTransactionStart()
+	return tx, nil
 }
 
 func (p *kafkaPublisher) Flush(ctx context.Context) error { return nil }
 func (p *kafkaPublisher) Close() error                    { return nil }
 func (p *kafkaPublisher) GetMetrics() *messaging.PublisherMetrics {
-	return &messaging.PublisherMetrics{}
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+	metrics := p.metrics
+	return &metrics
+}
+
+func (p *kafkaPublisher) recordTransactionStart() {
+	p.metricsMu.Lock()
+	defer p.metricsMu.Unlock()
+	p.metrics.TransactionsStarted++
+	p.metrics.LastActivity = time.Now()
+}
+
+func (p *kafkaPublisher) completeTransaction(tx *kafkaTransaction, committed bool, duration time.Duration) {
+	p.txMu.Lock()
+	if p.activeTx == tx {
+		p.activeTx = nil
+	}
+	p.txMu.Unlock()
+
+	p.metricsMu.Lock()
+	if committed {
+		p.metrics.TransactionsCommitted++
+		if duration > 0 {
+			p.metrics.AvgPublishLatency = updateAverageLatency(p.metrics.AvgPublishLatency, duration)
+		}
+	} else {
+		p.metrics.TransactionsAborted++
+	}
+	p.metrics.LastActivity = time.Now()
+	p.metricsMu.Unlock()
+}
+
+func updateAverageLatency(current time.Duration, latest time.Duration) time.Duration {
+	if latest <= 0 {
+		return current
+	}
+	if current == 0 {
+		return latest
+	}
+	// simple moving average to avoid storing historical data
+	return (current + latest) / 2
+}
+
+const (
+	transactionIDHeader    = "swit.transaction.id"
+	transactionSeqHeader   = "swit.transaction.sequence"
+	transactionProducerHdr = "swit.transaction.producer"
+)
+
+type kafkaTransactionState uint8
+
+const (
+	txStateActive kafkaTransactionState = iota
+	txStateCommitting
+	txStateCommitted
+	txStateAborted
+)
+
+type kafkaTransaction struct {
+	id        string
+	publisher *kafkaPublisher
+	state     kafkaTransactionState
+	mu        sync.Mutex
+	messages  []KafkaMessage
+	seq       uint64
+	startedAt time.Time
+}
+
+func newKafkaTransaction(publisher *kafkaPublisher, id string) *kafkaTransaction {
+	return &kafkaTransaction{
+		id:        id,
+		publisher: publisher,
+		state:     txStateActive,
+		messages:  make([]KafkaMessage, 0, 8),
+		startedAt: time.Now(),
+	}
+}
+
+func (tx *kafkaTransaction) Publish(ctx context.Context, message *messaging.Message) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return messaging.NewTransactionError("transaction publish canceled", err)
+		}
+	}
+
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	if tx.state != txStateActive {
+		return messaging.NewTransactionError("transaction already completed", nil)
+	}
+	if message == nil {
+		return messaging.NewTransactionError("message cannot be nil", nil)
+	}
+	// Convert to Kafka message and stamp transactional metadata for idempotency
+	km := tx.publisher.toKafkaMessage(message)
+	ensureHeaders(&km)
+	km.Headers[transactionIDHeader] = tx.id
+	km.Headers[transactionProducerHdr] = tx.publisher.producerID
+	seq := tx.seq + 1
+	tx.seq = seq
+	km.Headers[transactionSeqHeader] = strconv.FormatUint(seq, 10)
+	tx.messages = append(tx.messages, km)
+	return nil
+}
+
+func (tx *kafkaTransaction) Commit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return messaging.NewTransactionError("transaction commit canceled", err)
+	}
+
+	tx.mu.Lock()
+	if tx.state != txStateActive {
+		defer tx.mu.Unlock()
+		return messaging.NewTransactionError("transaction already completed", nil)
+	}
+	tx.state = txStateCommitting
+	msgs := make([]KafkaMessage, len(tx.messages))
+	copy(msgs, tx.messages)
+	start := tx.startedAt
+	tx.mu.Unlock()
+
+	if len(msgs) == 0 {
+		tx.finish(txStateCommitted, start)
+		return nil
+	}
+
+	if err := tx.publisher.pool.PublishBatchSync(ctx, tx.publisher.config.Topic, msgs, tx.publisher.config); err != nil {
+		tx.finish(txStateAborted, start)
+		return messaging.NewTransactionError("failed to commit Kafka transaction", err)
+	}
+
+	tx.finish(txStateCommitted, start)
+	return nil
+}
+
+func (tx *kafkaTransaction) Rollback(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return messaging.NewTransactionError("transaction rollback canceled", err)
+	}
+
+	tx.mu.Lock()
+	if tx.state != txStateActive && tx.state != txStateCommitting {
+		defer tx.mu.Unlock()
+		return messaging.NewTransactionError("transaction already completed", nil)
+	}
+	tx.state = txStateAborted
+	start := tx.startedAt
+	tx.messages = nil
+	tx.mu.Unlock()
+
+	tx.publisher.completeTransaction(tx, false, time.Since(start))
+	return nil
+}
+
+func (tx *kafkaTransaction) GetID() string {
+	return tx.id
+}
+
+func (tx *kafkaTransaction) finish(finalState kafkaTransactionState, start time.Time) {
+	tx.mu.Lock()
+	tx.state = finalState
+	tx.messages = nil
+	tx.mu.Unlock()
+
+	committed := finalState == txStateCommitted
+	tx.publisher.completeTransaction(tx, committed, time.Since(start))
+}
+
+func (tx *kafkaTransaction) isTerminal() bool {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	return tx.state == txStateCommitted || tx.state == txStateAborted
 }
 
 func toKafkaMessage(topic string, m *messaging.Message) KafkaMessage {

--- a/pkg/messaging/kafka/publisher_test.go
+++ b/pkg/messaging/kafka/publisher_test.go
@@ -1,0 +1,188 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+type transactionRecordingWriter struct {
+	mu     sync.Mutex
+	writes [][]KafkaMessage
+}
+
+func (w *transactionRecordingWriter) WriteMessages(ctx context.Context, msgs ...KafkaMessage) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	copied := make([]KafkaMessage, len(msgs))
+	copy(copied, msgs)
+	w.writes = append(w.writes, copied)
+	return nil
+}
+
+func (w *transactionRecordingWriter) Close() error { return nil }
+
+func TestKafkaPublisherBeginTransaction_NotSupported(t *testing.T) {
+	brokerCfg := &messaging.BrokerConfig{Type: messaging.BrokerTypeKafka, Endpoints: []string{"localhost:9092"}}
+	pubCfg := &messaging.PublisherConfig{Topic: "orders", Transactional: false}
+
+	pool, err := newProducerPool(brokerCfg, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating producer pool: %v", err)
+	}
+	publisher, err := newKafkaPublisher(pool, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating publisher: %v", err)
+	}
+
+	if _, err := publisher.BeginTransaction(context.Background()); !errors.Is(err, messaging.ErrTransactionsNotSupported) {
+		t.Fatalf("expected ErrTransactionsNotSupported, got %v", err)
+	}
+}
+
+func TestKafkaPublisherTransactionCommit(t *testing.T) {
+	rw := &transactionRecordingWriter{}
+	originalFactory := writerFactory
+	writerFactory = func(_ *messaging.BrokerConfig, _ string, _ *messaging.PublisherConfig) (kafkaWriter, error) {
+		return rw, nil
+	}
+	t.Cleanup(func() { writerFactory = originalFactory })
+
+	brokerCfg := &messaging.BrokerConfig{Type: messaging.BrokerTypeKafka, Endpoints: []string{"localhost:9092"}}
+	pubCfg := &messaging.PublisherConfig{Topic: "orders", Transactional: true}
+
+	pool, err := newProducerPool(brokerCfg, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating producer pool: %v", err)
+	}
+	publisher, err := newKafkaPublisher(pool, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating publisher: %v", err)
+	}
+
+	tx, err := publisher.BeginTransaction(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error starting transaction: %v", err)
+	}
+
+	message := &messaging.Message{ID: "1", Payload: []byte("hello")}
+	if err := tx.Publish(context.Background(), message); err != nil {
+		t.Fatalf("unexpected error publishing in transaction: %v", err)
+	}
+
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatalf("unexpected error committing transaction: %v", err)
+	}
+
+	rw.mu.Lock()
+	if len(rw.writes) != 1 {
+		t.Fatalf("expected 1 batch write, got %d", len(rw.writes))
+	}
+	if len(rw.writes[0]) != 1 {
+		t.Fatalf("expected 1 message in batch, got %d", len(rw.writes[0]))
+	}
+	km := rw.writes[0][0]
+	rw.mu.Unlock()
+
+	if km.Headers[transactionIDHeader] == "" {
+		t.Error("expected transaction id header to be set")
+	}
+	if km.Headers[transactionSeqHeader] != "1" {
+		t.Errorf("expected transaction sequence header '1', got %q", km.Headers[transactionSeqHeader])
+	}
+	if km.Headers[transactionProducerHdr] == "" {
+		t.Error("expected producer header to be set")
+	}
+
+	metrics := publisher.GetMetrics()
+	if metrics.TransactionsStarted != 1 {
+		t.Errorf("expected TransactionsStarted=1, got %d", metrics.TransactionsStarted)
+	}
+	if metrics.TransactionsCommitted != 1 {
+		t.Errorf("expected TransactionsCommitted=1, got %d", metrics.TransactionsCommitted)
+	}
+	if metrics.TransactionsAborted != 0 {
+		t.Errorf("expected TransactionsAborted=0, got %d", metrics.TransactionsAborted)
+	}
+}
+
+func TestKafkaPublisherTransactionRollback(t *testing.T) {
+	rw := &transactionRecordingWriter{}
+	originalFactory := writerFactory
+	writerFactory = func(_ *messaging.BrokerConfig, _ string, _ *messaging.PublisherConfig) (kafkaWriter, error) {
+		return rw, nil
+	}
+	t.Cleanup(func() { writerFactory = originalFactory })
+
+	brokerCfg := &messaging.BrokerConfig{Type: messaging.BrokerTypeKafka, Endpoints: []string{"localhost:9092"}}
+	pubCfg := &messaging.PublisherConfig{Topic: "orders", Transactional: true}
+
+	pool, err := newProducerPool(brokerCfg, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating producer pool: %v", err)
+	}
+	publisher, err := newKafkaPublisher(pool, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating publisher: %v", err)
+	}
+
+	tx, err := publisher.BeginTransaction(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error starting transaction: %v", err)
+	}
+
+	if err := tx.Publish(context.Background(), &messaging.Message{ID: "1", Payload: []byte("hello")}); err != nil {
+		t.Fatalf("unexpected error publishing in transaction: %v", err)
+	}
+
+	if err := tx.Rollback(context.Background()); err != nil {
+		t.Fatalf("unexpected error rolling back transaction: %v", err)
+	}
+
+	rw.mu.Lock()
+	writes := len(rw.writes)
+	rw.mu.Unlock()
+	if writes != 0 {
+		t.Fatalf("expected no writes after rollback, got %d", writes)
+	}
+
+	metrics := publisher.GetMetrics()
+	if metrics.TransactionsAborted != 1 {
+		t.Errorf("expected TransactionsAborted=1, got %d", metrics.TransactionsAborted)
+	}
+
+	// Ensure we can start a new transaction after rollback
+	if _, err := publisher.BeginTransaction(context.Background()); err != nil {
+		t.Fatalf("expected to start new transaction after rollback, got %v", err)
+	}
+}
+
+func TestKafkaPublisherTransactionConcurrent(t *testing.T) {
+	brokerCfg := &messaging.BrokerConfig{Type: messaging.BrokerTypeKafka, Endpoints: []string{"localhost:9092"}}
+	pubCfg := &messaging.PublisherConfig{Topic: "orders", Transactional: true}
+
+	pool, err := newProducerPool(brokerCfg, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating producer pool: %v", err)
+	}
+	publisher, err := newKafkaPublisher(pool, pubCfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating publisher: %v", err)
+	}
+
+	tx, err := publisher.BeginTransaction(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error starting transaction: %v", err)
+	}
+
+	if _, err := publisher.BeginTransaction(context.Background()); err == nil {
+		t.Fatal("expected error when starting second transaction while first active")
+	}
+
+	if err := tx.Rollback(context.Background()); err != nil {
+		t.Fatalf("unexpected error rolling back transaction: %v", err)
+	}
+}

--- a/pkg/messaging/kafka/publisher_test.go
+++ b/pkg/messaging/kafka/publisher_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (


### PR DESCRIPTION
## Summary
- add transactional support to Kafka publisher with idempotent headers
- track transaction metrics and guard against concurrent sessions
- document process-and-produce pattern for Kafka and add focused tests

## Testing
- go test ./pkg/messaging/kafka

Closes #298