### PR TITLE
feat: add kafka schema registry support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/consul/api v1.29.4
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2
+	github.com/riferrei/srclient v0.7.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
@@ -63,6 +64,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
@@ -80,6 +82,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/linkedin/goavro/v2 v2.13.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -95,6 +98,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
@@ -111,6 +115,7 @@ require (
 	golang.org/x/arch v0.7.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,9 @@ github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVI
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
+github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
@@ -197,6 +200,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/linkedin/goavro/v2 v2.13.1 h1:4qZ5M0QzQFDRqccsroJlgOJznqAS/TpdvXg55h429+I=
+github.com/linkedin/goavro/v2 v2.13.1/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -274,6 +279,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/riferrei/srclient v0.7.3 h1:JRR6jgfINWUcYZhBRHEg/NAFv7giVmjkoouRbWbakgw=
+github.com/riferrei/srclient v0.7.3/go.mod h1:byIzLF4UNZzclmzQXXr++Oe1GEH/hNFahUOSTXc7uSc=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -282,6 +289,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -311,6 +320,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -379,6 +389,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/messaging/config.go
+++ b/pkg/messaging/config.go
@@ -606,6 +606,9 @@ type PublisherConfig struct {
 	// Routing configuration
 	Routing RoutingConfig `yaml:"routing" json:"routing"`
 
+	// Serialization controls payload encoding and schema registry integration.
+	Serialization *SerializationOptions `yaml:"serialization,omitempty" json:"serialization,omitempty"`
+
 	// Batching configuration
 	Batching BatchingConfig `yaml:"batching" json:"batching"`
 
@@ -691,6 +694,9 @@ type SubscriberConfig struct {
 
 	// ConsumerGroup name
 	ConsumerGroup string `yaml:"consumer_group" json:"consumer_group" validate:"required"`
+
+	// Serialization configures how payloads should be decoded and validated.
+	Serialization *SerializationOptions `yaml:"serialization,omitempty" json:"serialization,omitempty"`
 
 	// Subscription type (shared, exclusive, failover)
 	Type SubscriptionType `yaml:"type" json:"type" default:"shared"`
@@ -1068,6 +1074,12 @@ func (cm *ConfigManager) validatePublisherConfig(config *PublisherConfig) error 
 		return NewConfigError("publisher queue_size must be positive", nil)
 	}
 
+	if config.Serialization != nil {
+		if err := config.Serialization.Validate(); err != nil {
+			return fmt.Errorf("serialization config validation failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1079,6 +1091,12 @@ func (cm *ConfigManager) validateSubscriberConfig(config *SubscriberConfig) erro
 
 	if config.ConsumerGroup == "" {
 		return NewConfigError("subscriber consumer_group is required", nil)
+	}
+
+	if config.Serialization != nil {
+		if err := config.Serialization.Validate(); err != nil {
+			return fmt.Errorf("serialization config validation failed: %w", err)
+		}
 	}
 
 	validTypes := []SubscriptionType{SubscriptionShared, SubscriptionExclusive, SubscriptionFailover}

--- a/pkg/messaging/kafka/broker.go
+++ b/pkg/messaging/kafka/broker.go
@@ -39,10 +39,12 @@ type kafkaBroker struct {
 
 	// producerPool provides high-throughput publishing shared across topic publishers
 	producerPool *producerPool
+
+	registries *schemaRegistryManager
 }
 
 func newKafkaBroker(cfg *messaging.BrokerConfig) *kafkaBroker {
-	return &kafkaBroker{config: cfg}
+	return &kafkaBroker{config: cfg, registries: newSchemaRegistryManager()}
 }
 
 func (b *kafkaBroker) Connect(ctx context.Context) error {
@@ -102,7 +104,7 @@ func (b *kafkaBroker) CreatePublisher(config messaging.PublisherConfig) (messagi
 		b.producerPool = pool
 	}
 
-	pub, err := newKafkaPublisher(b.producerPool, &config)
+	pub, err := newKafkaPublisher(b.producerPool, &config, b.registries)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +125,7 @@ func (b *kafkaBroker) CreateSubscriber(config messaging.SubscriberConfig) (messa
 		return nil, messaging.NewConfigError("subscriber consumer_group is required", nil)
 	}
 
-	sub, err := newKafkaSubscriber(b.config, &config)
+	sub, err := newKafkaSubscriber(b.config, &config, b.registries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messaging/kafka/consumer_test.go
+++ b/pkg/messaging/kafka/consumer_test.go
@@ -73,7 +73,7 @@ func TestKafkaSubscriber_Subscribe_And_Commit(t *testing.T) {
 
 	cfg := &messaging.BrokerConfig{Type: messaging.BrokerTypeKafka, Endpoints: []string{"localhost:9092"}}
 	subCfg := &messaging.SubscriberConfig{Topics: []string{"orders"}, ConsumerGroup: "cg"}
-	sub, err := newKafkaSubscriber(cfg, subCfg)
+	sub, err := newKafkaSubscriber(cfg, subCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("newKafkaSubscriber: %v", err)
 	}

--- a/pkg/messaging/kafka/partitioner_test.go
+++ b/pkg/messaging/kafka/partitioner_test.go
@@ -191,7 +191,7 @@ func TestKafkaPublisher_HashPartitioningConsistentKey(t *testing.T) {
 	}
 	defer pool.Close()
 
-	publisher, err := newKafkaPublisher(pool, pubCfg)
+	publisher, err := newKafkaPublisher(pool, pubCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("newKafkaPublisher error: %v", err)
 	}

--- a/pkg/messaging/kafka/publisher_test.go
+++ b/pkg/messaging/kafka/publisher_test.go
@@ -54,7 +54,7 @@ func TestKafkaPublisherBeginTransaction_NotSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating producer pool: %v", err)
 	}
-	publisher, err := newKafkaPublisher(pool, pubCfg)
+	publisher, err := newKafkaPublisher(pool, pubCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("unexpected error creating publisher: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestKafkaPublisherTransactionCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating producer pool: %v", err)
 	}
-	publisher, err := newKafkaPublisher(pool, pubCfg)
+	publisher, err := newKafkaPublisher(pool, pubCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("unexpected error creating publisher: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestKafkaPublisherTransactionRollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating producer pool: %v", err)
 	}
-	publisher, err := newKafkaPublisher(pool, pubCfg)
+	publisher, err := newKafkaPublisher(pool, pubCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("unexpected error creating publisher: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestKafkaPublisherTransactionConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating producer pool: %v", err)
 	}
-	publisher, err := newKafkaPublisher(pool, pubCfg)
+	publisher, err := newKafkaPublisher(pool, pubCfg, newSchemaRegistryManager())
 	if err != nil {
 		t.Fatalf("unexpected error creating publisher: %v", err)
 	}

--- a/pkg/messaging/kafka/schema_registry_client.go
+++ b/pkg/messaging/kafka/schema_registry_client.go
@@ -1,0 +1,283 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package kafka
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/riferrei/srclient"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+type schemaRegistryManager struct {
+	mu      sync.RWMutex
+	clients map[string]*schemaRegistryClient
+}
+
+func newSchemaRegistryManager() *schemaRegistryManager {
+	return &schemaRegistryManager{clients: make(map[string]*schemaRegistryClient)}
+}
+
+func (m *schemaRegistryManager) getClient(cfg *messaging.SchemaRegistryConfig) (*schemaRegistryClient, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("schema registry configuration is required")
+	}
+
+	key := registryCacheKey(cfg)
+
+	m.mu.RLock()
+	if client, ok := m.clients[key]; ok {
+		m.mu.RUnlock()
+		return client, nil
+	}
+	m.mu.RUnlock()
+
+	client, err := newSchemaRegistryClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	if existing, ok := m.clients[key]; ok {
+		m.mu.Unlock()
+		return existing, nil
+	}
+	m.clients[key] = client
+	m.mu.Unlock()
+
+	return client, nil
+}
+
+func registryCacheKey(cfg *messaging.SchemaRegistryConfig) string {
+	if cfg.Authentication == nil {
+		return cfg.URL
+	}
+
+	var secret string
+	switch cfg.Authentication.Type {
+	case "basic":
+		secret = cfg.Authentication.Password
+	case "bearer":
+		secret = cfg.Authentication.Token
+	case "api-key":
+		secret = cfg.Authentication.APIKey
+	}
+
+	digest := sha256.Sum256([]byte(secret))
+	return strings.Join([]string{cfg.URL, cfg.Authentication.Type, cfg.Authentication.Username, hex.EncodeToString(digest[:])}, "|")
+}
+
+type schemaRegistryClient struct {
+	client    srclient.ISchemaRegistryClient
+	cacheSize int
+
+	mu           sync.RWMutex
+	subjectCache map[string]*schemaDescriptor
+	idCache      map[int]*schemaDescriptor
+}
+
+type schemaDescriptor struct {
+	subject string
+	version int
+	id      int
+	format  messaging.SerializationFormat
+	schema  *srclient.Schema
+}
+
+func newSchemaRegistryClient(cfg *messaging.SchemaRegistryConfig) (*schemaRegistryClient, error) {
+	client := srclient.NewSchemaRegistryClient(cfg.URL)
+	client.CodecCreationEnabled(true)
+	client.CodecJsonEnabled(true)
+
+	if cfg.Authentication != nil {
+		switch cfg.Authentication.Type {
+		case "basic":
+			client.SetCredentials(cfg.Authentication.Username, cfg.Authentication.Password)
+		case "bearer":
+			client.SetBearerToken(cfg.Authentication.Token)
+		case "api-key":
+			client.SetCredentials(cfg.Authentication.APIKey, cfg.Authentication.APIKey)
+		}
+	}
+
+	return &schemaRegistryClient{
+		client:       client,
+		cacheSize:    cfg.CacheSize,
+		subjectCache: make(map[string]*schemaDescriptor),
+		idCache:      make(map[int]*schemaDescriptor),
+	}, nil
+}
+
+func (c *schemaRegistryClient) getSchemaForSubject(_ context.Context, subject, version string) (*schemaDescriptor, error) {
+	if subject == "" {
+		return nil, fmt.Errorf("schema registry subject is required")
+	}
+
+	cacheKey := cacheKey(subject, normalizeVersion(version))
+
+	c.mu.RLock()
+	if descriptor, ok := c.subjectCache[cacheKey]; ok {
+		c.mu.RUnlock()
+		return descriptor, nil
+	}
+	c.mu.RUnlock()
+
+	schema, err := c.loadSchema(subject, version)
+	if err != nil {
+		return nil, err
+	}
+
+	descriptor, err := c.buildDescriptor(subject, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	c.storeDescriptor(cacheKey, descriptor)
+	return descriptor, nil
+}
+
+func (c *schemaRegistryClient) getSchemaByID(_ context.Context, id int) (*schemaDescriptor, error) {
+	if id <= 0 {
+		return nil, fmt.Errorf("schema id must be positive")
+	}
+
+	c.mu.RLock()
+	if descriptor, ok := c.idCache[id]; ok {
+		c.mu.RUnlock()
+		return descriptor, nil
+	}
+	c.mu.RUnlock()
+
+	schema, err := c.client.GetSchema(id)
+	if err != nil {
+		return nil, fmt.Errorf("schema registry lookup by id %d failed: %w", id, err)
+	}
+
+	descriptor, err := c.buildDescriptor("", schema)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := cacheKey(descriptor.subject, normalizeVersion(strconv.Itoa(descriptor.version)))
+	c.storeDescriptor(cacheKey, descriptor)
+	return descriptor, nil
+}
+
+func (c *schemaRegistryClient) loadSchema(subject, version string) (*srclient.Schema, error) {
+	var (
+		schema *srclient.Schema
+		err    error
+	)
+
+	normVersion := normalizeVersion(version)
+	if normVersion == "latest" {
+		schema, err = c.client.GetLatestSchema(subject)
+	} else {
+		ver, convErr := strconv.Atoi(normVersion)
+		if convErr != nil {
+			return nil, fmt.Errorf("invalid schema version %q: %w", version, convErr)
+		}
+		schema, err = c.client.GetSchemaByVersion(subject, ver)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("schema registry lookup for subject %q version %q failed: %w", subject, version, err)
+	}
+
+	return schema, nil
+}
+
+func (c *schemaRegistryClient) buildDescriptor(subject string, schema *srclient.Schema) (*schemaDescriptor, error) {
+	format, err := mapSchemaType(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &schemaDescriptor{
+		subject: subject,
+		version: schema.Version(),
+		id:      schema.ID(),
+		format:  format,
+		schema:  schema,
+	}
+
+	return d, nil
+}
+
+func (c *schemaRegistryClient) storeDescriptor(cacheKey string, descriptor *schemaDescriptor) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cacheSize > 0 && len(c.subjectCache) >= c.cacheSize {
+		for key, cached := range c.subjectCache {
+			delete(c.subjectCache, key)
+			delete(c.idCache, cached.id)
+			if len(c.subjectCache) < c.cacheSize {
+				break
+			}
+		}
+	}
+
+	if descriptor.subject != "" && cacheKey != "" {
+		c.subjectCache[cacheKey] = descriptor
+	}
+	c.idCache[descriptor.id] = descriptor
+}
+
+func mapSchemaType(schema *srclient.Schema) (messaging.SerializationFormat, error) {
+	schemaType := schema.SchemaType()
+	if schemaType == nil {
+		return messaging.FormatAvro, nil
+	}
+
+	switch *schemaType {
+	case srclient.Avro:
+		return messaging.FormatAvro, nil
+	case srclient.Json:
+		return messaging.FormatJSON, nil
+	case srclient.Protobuf:
+		return messaging.FormatProtobuf, nil
+	default:
+		return "", fmt.Errorf("unsupported schema registry type: %s", string(*schemaType))
+	}
+}
+
+func normalizeVersion(version string) string {
+	if version == "" {
+		return "latest"
+	}
+	if strings.EqualFold(version, "latest") {
+		return "latest"
+	}
+	return version
+}
+
+func cacheKey(subject, version string) string {
+	return subject + ":" + version
+}

--- a/pkg/messaging/kafka/schema_serde.go
+++ b/pkg/messaging/kafka/schema_serde.go
@@ -1,0 +1,277 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package kafka
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+const (
+	schemaHeaderID      = "schema.registry.id"
+	schemaHeaderSubject = "schema.registry.subject"
+	schemaHeaderVersion = "schema.registry.version"
+	schemaHeaderFormat  = "schema.registry.format"
+)
+
+type schemaSerDe struct {
+	format   messaging.SerializationFormat
+	registry *schemaRegistryClient
+	config   *messaging.SerializationOptions
+}
+
+func newSchemaSerDe(cfg *messaging.SerializationOptions, manager *schemaRegistryManager) (*schemaSerDe, error) {
+	if cfg == nil || cfg.SchemaRegistry == nil {
+		return nil, fmt.Errorf("schema registry serialization requires configuration")
+	}
+	switch cfg.Format {
+	case messaging.FormatAvro, messaging.FormatJSON:
+	default:
+		return nil, fmt.Errorf("schema registry integration supports avro or json formats, got %s", cfg.Format)
+	}
+
+	client, err := manager.getClient(cfg.SchemaRegistry)
+	if err != nil {
+		return nil, err
+	}
+
+	return &schemaSerDe{
+		format:   cfg.Format,
+		registry: client,
+		config:   cfg,
+	}, nil
+}
+
+func (s *schemaSerDe) Encode(ctx context.Context, message *messaging.Message) (*messaging.Message, error) {
+	if s == nil {
+		return message, nil
+	}
+	if message == nil {
+		return nil, fmt.Errorf("message cannot be nil")
+	}
+
+	payload := message.Payload
+	if len(payload) == 0 {
+		return nil, messaging.NewSerializationErrorWithFormat(s.format, "payload cannot be empty for schema registry encoding", nil)
+	}
+
+	if isConfluentWireFormat(payload) {
+		return s.decorateFromEncoded(ctx, message, payload)
+	}
+
+	descriptor, err := s.registry.getSchemaForSubject(ctx, s.config.SchemaRegistry.Subject, s.config.SchemaRegistry.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	if descriptor.format != s.format {
+		return nil, fmt.Errorf("schema format mismatch: registry format %s, configured %s", descriptor.format, s.format)
+	}
+
+	var encoded []byte
+	switch s.format {
+	case messaging.FormatAvro:
+		encoded, err = encodeAvroPayload(descriptor, payload)
+	case messaging.FormatJSON:
+		encoded, err = encodeJSONPayload(descriptor, payload)
+	default:
+		return nil, fmt.Errorf("serialization format %s not supported for schema registry integration", s.format)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return cloneWithSchemaHeaders(message, encoded, descriptor, s.config.SchemaRegistry.Subject), nil
+}
+
+func (s *schemaSerDe) Decode(ctx context.Context, message *messaging.Message) (*messaging.Message, error) {
+	if s == nil {
+		return message, nil
+	}
+	if message == nil {
+		return nil, fmt.Errorf("message cannot be nil")
+	}
+
+	payload := message.Payload
+	if !isConfluentWireFormat(payload) {
+		return message, nil
+	}
+
+	schemaID := int(binary.BigEndian.Uint32(payload[1:5]))
+	descriptor, err := s.registry.getSchemaByID(ctx, schemaID)
+	if err != nil {
+		return nil, err
+	}
+
+	var decoded []byte
+	switch descriptor.format {
+	case messaging.FormatAvro:
+		decoded, err = decodeAvroPayload(descriptor, payload[5:])
+	case messaging.FormatJSON:
+		decoded, err = decodeJSONPayload(descriptor, payload[5:])
+	default:
+		return nil, fmt.Errorf("unsupported schema type %s for decoding", descriptor.format)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return cloneWithSchemaHeaders(message, decoded, descriptor, s.config.SchemaRegistry.Subject), nil
+}
+
+func (s *schemaSerDe) decorateFromEncoded(ctx context.Context, message *messaging.Message, payload []byte) (*messaging.Message, error) {
+	schemaID := int(binary.BigEndian.Uint32(payload[1:5]))
+	descriptor, err := s.registry.getSchemaByID(ctx, schemaID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only validate format matches expectation when the payload was pre-encoded
+	if descriptor.format != s.format {
+		return nil, fmt.Errorf("encoded payload uses format %s but publisher expects %s", descriptor.format, s.format)
+	}
+
+	return cloneWithSchemaHeaders(message, payload, descriptor, s.config.SchemaRegistry.Subject), nil
+}
+
+func cloneWithSchemaHeaders(message *messaging.Message, payload []byte, descriptor *schemaDescriptor, fallbackSubject string) *messaging.Message {
+	clone := *message
+	headers := make(map[string]string, len(message.Headers)+4)
+	for k, v := range message.Headers {
+		headers[k] = v
+	}
+
+	if descriptor != nil {
+		headers[schemaHeaderID] = strconv.Itoa(descriptor.id)
+		subject := descriptor.subject
+		if subject == "" {
+			if headers[schemaHeaderSubject] != "" {
+				subject = headers[schemaHeaderSubject]
+			} else {
+				subject = fallbackSubject
+			}
+		}
+		headers[schemaHeaderSubject] = subject
+		headers[schemaHeaderVersion] = strconv.Itoa(descriptor.version)
+		headers[schemaHeaderFormat] = descriptor.format.String()
+	}
+
+	clone.Headers = headers
+	clone.Payload = append([]byte(nil), payload...)
+	return &clone
+}
+
+func isConfluentWireFormat(payload []byte) bool {
+	return len(payload) > 5 && payload[0] == 0
+}
+
+func encodeAvroPayload(descriptor *schemaDescriptor, payload []byte) ([]byte, error) {
+	codec := descriptor.schema.Codec()
+	if codec == nil {
+		return nil, fmt.Errorf("schema id %d does not provide an Avro codec", descriptor.id)
+	}
+
+	native, _, err := codec.NativeFromTextual(payload)
+	if err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatAvro, "failed to convert JSON payload to Avro", err)
+	}
+
+	binaryValue, err := codec.BinaryFromNative(nil, native)
+	if err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatAvro, "failed to encode Avro payload", err)
+	}
+
+	return wrapWithSchemaID(descriptor.id, binaryValue), nil
+}
+
+func encodeJSONPayload(descriptor *schemaDescriptor, payload []byte) ([]byte, error) {
+	validator := descriptor.schema.JsonSchema()
+	if validator == nil {
+		return nil, fmt.Errorf("schema id %d does not have a compiled JSON Schema", descriptor.id)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatJSON, "invalid JSON payload for schema registry", err)
+	}
+
+	if err := validator.Validate(value); err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatJSON, "JSON payload failed schema validation", err)
+	}
+
+	return wrapWithSchemaID(descriptor.id, payload), nil
+}
+
+func decodeAvroPayload(descriptor *schemaDescriptor, payload []byte) ([]byte, error) {
+	codec := descriptor.schema.Codec()
+	if codec == nil {
+		return nil, fmt.Errorf("schema id %d does not provide an Avro codec", descriptor.id)
+	}
+
+	native, _, err := codec.NativeFromBinary(payload)
+	if err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatAvro, "failed to decode Avro payload", err)
+	}
+
+	textual, err := codec.TextualFromNative(nil, native)
+	if err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatAvro, "failed to convert Avro payload to JSON", err)
+	}
+
+	return textual, nil
+}
+
+func decodeJSONPayload(descriptor *schemaDescriptor, payload []byte) ([]byte, error) {
+	validator := descriptor.schema.JsonSchema()
+	if validator == nil {
+		return append([]byte(nil), payload...), nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatJSON, "invalid JSON payload while decoding", err)
+	}
+
+	if err := validator.Validate(value); err != nil {
+		return nil, messaging.NewSerializationErrorWithFormat(messaging.FormatJSON, "JSON payload failed schema validation during decode", err)
+	}
+
+	return append([]byte(nil), payload...), nil
+}
+
+func wrapWithSchemaID(id int, payload []byte) []byte {
+	out := make([]byte, 5+len(payload))
+	out[0] = 0
+	binary.BigEndian.PutUint32(out[1:5], uint32(id))
+	copy(out[5:], payload)
+	return out
+}

--- a/pkg/messaging/kafka/schema_serde_test.go
+++ b/pkg/messaging/kafka/schema_serde_test.go
@@ -1,0 +1,134 @@
+package kafka
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/linkedin/goavro/v2"
+	"github.com/riferrei/srclient"
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+func TestSchemaSerDeAvroRoundTrip(t *testing.T) {
+	schemaStr := `{"type":"record","name":"User","fields":[{"name":"id","type":"string"}]}`
+	codec, err := goavro.NewCodec(schemaStr)
+	if err != nil {
+		t.Fatalf("failed to create codec: %v", err)
+	}
+
+	srSchema, err := srclient.NewSchema(10, schemaStr, srclient.Avro, 1, nil, codec, nil)
+	if err != nil {
+		t.Fatalf("NewSchema: %v", err)
+	}
+
+	descriptor := &schemaDescriptor{
+		subject: "users-value",
+		version: 1,
+		id:      10,
+		format:  messaging.FormatAvro,
+		schema:  srSchema,
+	}
+
+	registry := &schemaRegistryClient{
+		subjectCache: map[string]*schemaDescriptor{cacheKey("users-value", "latest"): descriptor},
+		idCache:      map[int]*schemaDescriptor{10: descriptor},
+	}
+
+	serde := &schemaSerDe{
+		format:   messaging.FormatAvro,
+		registry: registry,
+		config: &messaging.SerializationOptions{
+			Format:         messaging.FormatAvro,
+			SchemaRegistry: &messaging.SchemaRegistryConfig{Subject: "users-value"},
+		},
+	}
+
+	msg := &messaging.Message{ID: "1", Payload: []byte(`{"id":"abc"}`)}
+	encoded, err := serde.Encode(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	if !isConfluentWireFormat(encoded.Payload) {
+		t.Fatalf("expected confluent wire format")
+	}
+
+	schemaID := binary.BigEndian.Uint32(encoded.Payload[1:5])
+	if schemaID != 10 {
+		t.Fatalf("unexpected schema id %d", schemaID)
+	}
+
+	decoded, err := serde.Decode(context.Background(), encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if string(decoded.Payload) != `{"id":"abc"}` {
+		t.Fatalf("unexpected decoded payload: %s", decoded.Payload)
+	}
+
+	if decoded.Headers[schemaHeaderID] != "10" {
+		t.Fatalf("missing schema header, got %v", decoded.Headers)
+	}
+}
+
+func TestSchemaSerDeJSONRoundTrip(t *testing.T) {
+	schemaStr := `{"type":"object","required":["id"],"properties":{"id":{"type":"string"}}}`
+	validator, err := jsonschema.CompileString("schema.json", schemaStr)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+
+	srSchema, err := srclient.NewSchema(5, schemaStr, srclient.Json, 2, nil, nil, validator)
+	if err != nil {
+		t.Fatalf("NewSchema: %v", err)
+	}
+
+	descriptor := &schemaDescriptor{
+		subject: "users-json",
+		version: 2,
+		id:      5,
+		format:  messaging.FormatJSON,
+		schema:  srSchema,
+	}
+
+	registry := &schemaRegistryClient{
+		subjectCache: map[string]*schemaDescriptor{cacheKey("users-json", "latest"): descriptor},
+		idCache:      map[int]*schemaDescriptor{5: descriptor},
+	}
+
+	serde := &schemaSerDe{
+		format:   messaging.FormatJSON,
+		registry: registry,
+		config: &messaging.SerializationOptions{
+			Format:         messaging.FormatJSON,
+			SchemaRegistry: &messaging.SchemaRegistryConfig{Subject: "users-json"},
+		},
+	}
+
+	msg := &messaging.Message{ID: "1", Payload: []byte(`{"id":"42"}`)}
+	encoded, err := serde.Encode(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	if !isConfluentWireFormat(encoded.Payload) {
+		t.Fatalf("expected wire format prefix")
+	}
+
+	decoded, err := serde.Decode(context.Background(), encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if string(decoded.Payload) != `{"id":"42"}` {
+		t.Fatalf("unexpected decoded payload: %s", decoded.Payload)
+	}
+
+	if decoded.Headers[schemaHeaderVersion] != "2" {
+		t.Fatalf("expected version header, got %v", decoded.Headers)
+	}
+}

--- a/pkg/messaging/kafka/schema_serde_test.go
+++ b/pkg/messaging/kafka/schema_serde_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package kafka
 
 import (


### PR DESCRIPTION
## Summary
- add schema registry client, serde, and config validation for kafka broker
- hook schema registry encode/decode into kafka publisher and subscriber
- cover avro/json registry paths with targeted tests

## Testing
- go test ./pkg/messaging/...

Closes #299