### PR TITLE
feat(rabbitmq): topology management for exchanges/queues/bindings (Closes #303)

### DIFF
--- a/pkg/messaging/rabbitmq/broker.go
+++ b/pkg/messaging/rabbitmq/broker.go
@@ -73,6 +73,15 @@ func (b *rabbitBroker) Connect(ctx context.Context) error {
 		return err
 	}
 
+	// Setup topology (exchanges, queues, bindings) if configured
+	if err := setupTopology(ctx, b.pool, b.rabbitConfig.Topology); err != nil {
+		b.mu.Lock()
+		b.metrics.ConnectionFailures++
+		b.metrics.LastConnectionError = err.Error()
+		b.mu.Unlock()
+		return err
+	}
+
 	b.mu.Lock()
 	b.started = true
 	b.metrics.ConnectionStatus = "connected"

--- a/pkg/messaging/rabbitmq/connection_pool.go
+++ b/pkg/messaging/rabbitmq/connection_pool.go
@@ -46,6 +46,10 @@ type amqpChannel interface {
 	Qos(prefetchCount, prefetchSize int, global bool) error
 	Confirm(noWait bool) error
 	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	// Topology management
+	ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
 	NotifyClose(receiver chan *amqp.Error) chan *amqp.Error
 	NotifyPublish(receiver chan amqp.Confirmation) chan amqp.Confirmation
 	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
@@ -260,6 +264,18 @@ func (r *realChannel) Confirm(noWait bool) error {
 
 func (r *realChannel) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	return r.ch.Publish(exchange, key, mandatory, immediate, msg)
+}
+
+func (r *realChannel) ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
+	return r.ch.ExchangeDeclare(name, kind, durable, autoDelete, internal, noWait, args)
+}
+
+func (r *realChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
+	return r.ch.QueueDeclare(name, durable, autoDelete, exclusive, noWait, args)
+}
+
+func (r *realChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	return r.ch.QueueBind(name, key, exchange, noWait, args)
 }
 
 func (r *realChannel) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {

--- a/pkg/messaging/rabbitmq/topology.go
+++ b/pkg/messaging/rabbitmq/topology.go
@@ -1,0 +1,100 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package rabbitmq
+
+import (
+	"context"
+
+	"github.com/streadway/amqp"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+// setupTopology declares exchanges, queues, and bindings as configured.
+// It is safe to call multiple times; RabbitMQ declarations are idempotent
+// as long as properties are consistent with existing entities.
+func setupTopology(ctx context.Context, pool *connectionPool, topo TopologyConfig) error {
+	if pool == nil {
+		return messaging.NewConfigError("rabbitmq topology requires a connection pool", nil)
+	}
+
+	// Fast path: nothing to declare
+	if len(topo.Exchanges) == 0 && len(topo.Queues) == 0 && len(topo.Bindings) == 0 {
+		return nil
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return messaging.NewConnectionError("rabbitmq acquire connection for topology failed", err)
+	}
+	defer pool.Release(conn)
+
+	session, err := conn.AcquireChannel(ctx)
+	if err != nil {
+		return messaging.NewConnectionError("rabbitmq acquire channel for topology failed", err)
+	}
+	defer conn.ReleaseChannel(session)
+
+	ch := session.channel
+
+	// Declare exchanges
+	for name, ex := range topo.Exchanges {
+		// Allow name from key to override struct field when missing
+		if ex.Name == "" {
+			ex.Name = name
+		}
+		args := amqp.Table(nil)
+		if ex.Arguments != nil {
+			args = amqp.Table(ex.Arguments)
+		}
+		if err := ch.ExchangeDeclare(ex.Name, ex.Type, ex.Durable, ex.AutoDelete, ex.Internal, false, args); err != nil {
+			return messaging.NewConfigError("rabbitmq declare exchange failed", err)
+		}
+	}
+
+	// Declare queues
+	for name, q := range topo.Queues {
+		if q.Name == "" {
+			q.Name = name
+		}
+		args := amqp.Table(nil)
+		if q.Arguments != nil {
+			args = amqp.Table(q.Arguments)
+		}
+		if _, err := ch.QueueDeclare(q.Name, q.Durable, q.AutoDelete, q.Exclusive, false, args); err != nil {
+			return messaging.NewConfigError("rabbitmq declare queue failed", err)
+		}
+	}
+
+	// Bindings
+	for _, b := range topo.Bindings {
+		args := amqp.Table(nil)
+		if b.Arguments != nil {
+			args = amqp.Table(b.Arguments)
+		}
+		if err := ch.QueueBind(b.Queue, b.RoutingKey, b.Exchange, false, args); err != nil {
+			return messaging.NewConfigError("rabbitmq queue bind failed", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR implements RabbitMQ topology management per #303.\n\nHighlights:\n- Declare exchanges/queues with durability/TTL/DLX via config\n- Manage bindings and routing keys\n- Idempotent create on startup\n\nImplementation:\n- Add topology.go and extend channel interface for ExchangeDeclare/QueueDeclare/QueueBind\n- Call setupTopology() during rabbitBroker.Connect()\n- Update mocks and add unit test TestRabbitBrokerSetupTopologyOnConnect\n\nQuality:\n- make build-dev, make test, make test-coverage all pass locally\n\nLinks:\n- Closes #303\n- Part of #175\n