### PR TITLE
feat(rabbitmq): DLQ with TTL-based retry (#304)

### DIFF
--- a/pkg/messaging/rabbitmq/consumer_test.go
+++ b/pkg/messaging/rabbitmq/consumer_test.go
@@ -1,0 +1,92 @@
+package rabbitmq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+type retryAlwaysHandler struct{}
+
+func (retryAlwaysHandler) Handle(ctx context.Context, msg *messaging.Message) error {
+	return messaging.NewProcessingError("fail", nil)
+}
+
+func (retryAlwaysHandler) OnError(ctx context.Context, msg *messaging.Message, err error) messaging.ErrorAction {
+	return messaging.ErrorActionRetry
+}
+
+// Test retry path: handler returns retry, message is republished to <queue>.retry and original acked
+func TestRabbitConsumerRetryRepublish(t *testing.T) {
+	base := &messaging.BrokerConfig{Type: messaging.BrokerTypeRabbitMQ, Endpoints: []string{"amqp://localhost:5672"}}
+	base.Connection.PoolSize = 1
+	rabbitCfg := DefaultConfig()
+	broker := newRabbitBroker(base, rabbitCfg)
+
+	mconn := newMockConnection(func() amqpChannel { return newMockChannel() })
+	broker.pool.dial = func(endpoint string, cfg amqp.Config) (amqpConnection, error) { return mconn, nil }
+	require.NoError(t, broker.Connect(context.Background()))
+
+	sub, err := broker.CreateSubscriber(messaging.SubscriberConfig{Topics: []string{"orders"}, ConsumerGroup: "cg", Processing: messaging.ProcessingConfig{AckMode: messaging.AckModeManual}})
+	require.NoError(t, err)
+	rsub := sub.(*rabbitSubscriber)
+
+	go func() { _ = rsub.Subscribe(context.Background(), retryAlwaysHandler{}) }()
+
+	// Wait a moment for consumer to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Enqueue a delivery
+	mc := mconn.channels[0].(*mockChannel)
+	mc.enqueueDelivery(amqp.Delivery{Body: []byte("x"), DeliveryTag: 1, MessageId: "id-1"})
+
+	// Give time to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Inspect publish calls: should have published to orders.retry
+	mc2 := mconn.channels[0].(*mockChannel)
+	require.NotEmpty(t, mc2.publishCalls)
+	last := mc2.lastPublish()
+	require.NotNil(t, last)
+	require.Equal(t, "orders.retry", last.routingKey)
+}
+
+// Test DLQ path: when max retries exceeded, message goes to <queue>.dlq
+func TestRabbitConsumerDeadLetterRepublish(t *testing.T) {
+	base := &messaging.BrokerConfig{Type: messaging.BrokerTypeRabbitMQ, Endpoints: []string{"amqp://localhost:5672"}}
+	base.Connection.PoolSize = 1
+	rabbitCfg := DefaultConfig()
+	broker := newRabbitBroker(base, rabbitCfg)
+
+	mconn := newMockConnection(func() amqpChannel { return newMockChannel() })
+	broker.pool.dial = func(endpoint string, cfg amqp.Config) (amqpConnection, error) { return mconn, nil }
+	require.NoError(t, broker.Connect(context.Background()))
+
+	cfg := messaging.SubscriberConfig{Topics: []string{"orders"}, ConsumerGroup: "cg", Processing: messaging.ProcessingConfig{AckMode: messaging.AckModeManual}}
+	cfg.DeadLetter.MaxRetries = 1
+	sub, err := broker.CreateSubscriber(cfg)
+	require.NoError(t, err)
+	rsub := sub.(*rabbitSubscriber)
+
+	h := messaging.MessageHandlerFunc(func(ctx context.Context, msg *messaging.Message) error {
+		return messaging.NewProcessingError("fail", nil)
+	})
+	go func() { _ = rsub.Subscribe(context.Background(), h) }()
+	time.Sleep(50 * time.Millisecond)
+
+	mc := mconn.channels[0].(*mockChannel)
+	// First failure -> retry
+	mc.enqueueDelivery(amqp.Delivery{Body: []byte("x"), DeliveryTag: 1, MessageId: "id-1"})
+	time.Sleep(30 * time.Millisecond)
+	// Simulate consumption of retry message (with x-retry-attempt=1) -> now exceed and DLQ
+	mc.enqueueDelivery(amqp.Delivery{Body: []byte("x"), DeliveryTag: 2, MessageId: "id-1", Headers: amqp.Table{"x-retry-attempt": 1}})
+	time.Sleep(50 * time.Millisecond)
+
+	last := mc.lastPublish()
+	require.NotNil(t, last)
+	require.Equal(t, "orders.dlq", last.routingKey)
+}


### PR DESCRIPTION
Implements DLX/DLQ with TTL-based delayed retry for RabbitMQ.\n\n- Auto-provision per-queue `<queue>.retry` and `<queue>.dlq`\n- TTL-based retry via `x-message-ttl` and dead-letter routing back to source\n- Dead-letter after max retries to DLQ\n- Added metrics for retried/dead-lettered\n- Unit tests for retry and DLQ flows\n\nCloses #304