### PR TITLE
feat(nats): queue groups for load balancing (#308)

### DIFF
--- a/pkg/messaging/nats/subscriber_test.go
+++ b/pkg/messaging/nats/subscriber_test.go
@@ -1,0 +1,48 @@
+package nats
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetDeliverGroupFor_MatchAndNoMatch(t *testing.T) {
+	jsCfg := &JetStreamConfig{
+		Enabled: true,
+		Consumers: []JSConsumerConfig{
+			{Name: "c1", FilterSubject: "orders.created", DeliverGroup: "order-workers"},
+			{Name: "c2", FilterSubject: "payments.>", DeliverGroup: "payment-workers"},
+		},
+	}
+
+	s := &subscriber{jsConfig: jsCfg}
+
+	if got := s.getDeliverGroupFor("orders.created"); got != "order-workers" {
+		t.Fatalf("expected deliver group 'order-workers', got %q", got)
+	}
+	if got := s.getDeliverGroupFor("orders.updated"); got != "" {
+		t.Fatalf("expected empty deliver group for unmatched subject, got %q", got)
+	}
+}
+
+func TestGetDeliverSubjectFor_Match(t *testing.T) {
+	jsCfg := &JetStreamConfig{
+		Enabled: true,
+		Consumers: []JSConsumerConfig{
+			{Name: "c1", FilterSubject: "orders.created", DeliverSubject: "_INBOX.orders.created"},
+		},
+	}
+	s := &subscriber{jsConfig: jsCfg}
+	if got := s.getDeliverSubjectFor("orders.created"); got != "_INBOX.orders.created" {
+		t.Fatalf("expected deliver subject '_INBOX.orders.created', got %q", got)
+	}
+}
+
+func TestUnsubscribeWithoutSubscriptions_ReturnsImmediately(t *testing.T) {
+	s := &subscriber{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Should return nil quickly without panic
+	if err := s.Unsubscribe(ctx); err != nil && err != context.Canceled {
+		t.Fatalf("unexpected error from Unsubscribe: %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements NATS queue groups for distributed processing.\n\n- Core NATS: use QueueSubscribe when ConsumerGroup is set\n- JetStream: prefer push delivery when DeliverSubject is configured, use DeliverGroup for queue semantics; fallback to PullSubscribe with manual ack\n- Graceful shutdown: implement Unsubscribe with drain and worker wait\n- Tests: mapping for deliver subject/group and unsubscribe behavior\n\nCloses #308\n\nMilestone: Message Broker Adapters Implementation\nReferences: specs/event-driven-messaging/implementation-guide.md