### PR TITLE
feat(nats): NATS KV helpers (EnsureBucket/Get/Put/Watch)

### DIFF
--- a/pkg/messaging/nats/broker.go
+++ b/pkg/messaging/nats/broker.go
@@ -201,7 +201,18 @@ func (b *natsBroker) GetMetrics() *messaging.BrokerMetrics {
 
 func (b *natsBroker) GetCapabilities() *messaging.BrokerCapabilities {
 	caps, _ := messaging.GetCapabilityProfile(messaging.BrokerTypeNATS)
+	// Signal extended capability for NATS KV store (JS required)
+	if b.js != nil {
+		caps.Extended["nats.kv"] = true
+	}
 	return caps
+}
+
+// GetJetStream implements JetStreamProvider for exposing JS context to utils.
+func (b *natsBroker) GetJetStream() nats.JetStreamContext {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.js
 }
 
 // ensureJetStreamTopology creates or updates declared streams and consumers.

--- a/pkg/messaging/nats/js_provider.go
+++ b/pkg/messaging/nats/js_provider.go
@@ -1,0 +1,16 @@
+package nats
+
+import "github.com/nats-io/nats.go"
+
+// JetStreamProvider 由支持 JetStream 的 broker 实现，用于暴露 JS 上下文。
+type JetStreamProvider interface {
+	GetJetStream() nats.JetStreamContext
+}
+
+// GetJetStreamFrom 尝试从通用 broker 获取 JetStreamContext。
+func GetJetStreamFrom(broker interface{}) (nats.JetStreamContext, bool) {
+	if p, ok := broker.(JetStreamProvider); ok {
+		return p.GetJetStream(), true
+	}
+	return nil, false
+}

--- a/pkg/messaging/nats/js_provider.go
+++ b/pkg/messaging/nats/js_provider.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package nats
 
 import "github.com/nats-io/nats.go"

--- a/pkg/messaging/nats/kv/doc.go
+++ b/pkg/messaging/nats/kv/doc.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 // Package natskv 提供对 NATS JetStream Key-Value 的轻量封装，
 // 便于在 SWIT 中实现分布式配置/状态存储：
 // - EnsureBucket：按配置创建或获取 KV 桶

--- a/pkg/messaging/nats/kv/doc.go
+++ b/pkg/messaging/nats/kv/doc.go
@@ -1,0 +1,10 @@
+// Package natskv 提供对 NATS JetStream Key-Value 的轻量封装，
+// 便于在 SWIT 中实现分布式配置/状态存储：
+// - EnsureBucket：按配置创建或获取 KV 桶
+// - OpenBucket：打开已有 KV 桶
+// - Put/Create/Get：基本读写接口
+// - Watch：键或通配符的变更订阅
+//
+// 注意：此封装依赖 github.com/nats-io/nats.go 的 KV/JS 抽象，
+// 不负责连接管理，调用方应从 NATS broker 或已建立的 JetStreamContext 注入。
+package natskv

--- a/pkg/messaging/nats/kv/kv.go
+++ b/pkg/messaging/nats/kv/kv.go
@@ -1,0 +1,243 @@
+// Copyright © 2025 SWIT
+//
+// NATS Key-Value helpers: thin utilities wrapping github.com/nats-io/nats.go
+// KeyValue/JetStreamContext to provide a simple way to create buckets, and
+// perform get/put/watch operations for distributed config/state.
+
+package natskv
+
+import (
+	"context"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/nats-io/nats.go"
+)
+
+// JetStream defines the minimal subset of nats.JetStreamContext used by helpers.
+// This enables test doubles without requiring a running NATS server.
+type JetStream interface {
+	CreateKeyValue(cfg *nats.KeyValueConfig) (nats.KeyValue, error)
+	KeyValue(bucket string) (nats.KeyValue, error)
+}
+
+// Watcher defines the minimal subset of nats.KeyWatcher used by helpers.
+type Watcher interface {
+	Updates() <-chan *nats.KeyValueEntry
+	Stop() error
+}
+
+// BucketConfig contains the parameters to create or ensure a KV bucket exists.
+type BucketConfig struct {
+	// Name is required and maps to KeyValueConfig.Bucket.
+	Name string
+
+	// Description is an optional human-readable description.
+	Description string
+
+	// TTL controls time-to-live for entries in this bucket.
+	TTL time.Duration
+
+	// History controls the number of historical values to keep per key.
+	History int
+
+	// MaxValueSize limits value size in bytes (0 means unlimited as per server limits).
+	MaxValueSize int32
+
+	// MaxBucketBytes limits total bucket size in bytes (0 means unlimited).
+	MaxBucketBytes int64
+
+	// Storage controls storage backend: "file" (default) or "memory".
+	Storage string
+
+	// Replicas sets the replication factor for the underlying stream (JetStream only).
+	Replicas int
+}
+
+// Normalize fills defaults and bounds for the configuration.
+func (c *BucketConfig) Normalize() {
+	if c.History < 0 {
+		c.History = 0
+	}
+	if c.History > 64 {
+		c.History = 64
+	}
+	if c.Replicas <= 0 {
+		c.Replicas = 1
+	}
+	if c.Storage == "" {
+		c.Storage = "file"
+	}
+	if c.TTL < 0 {
+		c.TTL = 0
+	}
+}
+
+// toKeyValueConfig translates BucketConfig to nats.KeyValueConfig.
+func (c *BucketConfig) toKeyValueConfig() (*nats.KeyValueConfig, error) {
+	if c == nil || c.Name == "" {
+		return nil, messaging.NewConfigError("kv bucket name is required", nil)
+	}
+	c.Normalize()
+
+	var storage nats.StorageType
+	switch c.Storage {
+	case "memory":
+		storage = nats.MemoryStorage
+	default:
+		storage = nats.FileStorage
+	}
+
+	return &nats.KeyValueConfig{
+		Bucket:       c.Name,
+		Description:  c.Description,
+		TTL:          c.TTL,
+		MaxValueSize: c.MaxValueSize,
+		History:      uint8(c.History),
+		MaxBytes:     c.MaxBucketBytes,
+		Storage:      storage,
+		Replicas:     c.Replicas,
+	}, nil
+}
+
+// EnsureBucket returns an existing bucket or creates it if missing.
+// It is safe to call concurrently; the server enforces idempotency.
+func EnsureBucket(ctx context.Context, js JetStream, cfg BucketConfig) (nats.KeyValue, error) {
+	if js == nil {
+		return nil, messaging.NewConfigError("nil JetStream context", nil)
+	}
+
+	// Try to open existing bucket first
+	kv, err := js.KeyValue(cfg.Name)
+	if err == nil && kv != nil {
+		return kv, nil
+	}
+
+	// Create if not found
+	nkvc, cerr := cfg.toKeyValueConfig()
+	if cerr != nil {
+		return nil, cerr
+	}
+	kv, err = js.CreateKeyValue(nkvc)
+	if err != nil {
+		return nil, err
+	}
+	return kv, nil
+}
+
+// OpenBucket opens an existing bucket by name.
+func OpenBucket(_ context.Context, js JetStream, name string) (nats.KeyValue, error) {
+	if js == nil {
+		return nil, messaging.NewConfigError("nil JetStream context", nil)
+	}
+	if name == "" {
+		return nil, messaging.NewConfigError("kv bucket name is required", nil)
+	}
+	return js.KeyValue(name)
+}
+
+// Put stores or replaces the value for the key. Returns the new revision.
+func Put(_ context.Context, kv nats.KeyValue, key string, value []byte) (uint64, error) {
+	if kv == nil {
+		return 0, messaging.NewConfigError("nil KeyValue bucket", nil)
+	}
+	return kv.Put(key, value)
+}
+
+// Create inserts the value only if the key does not already exist. Returns revision.
+func Create(_ context.Context, kv nats.KeyValue, key string, value []byte) (uint64, error) {
+	if kv == nil {
+		return 0, messaging.NewConfigError("nil KeyValue bucket", nil)
+	}
+	return kv.Create(key, value)
+}
+
+// Get returns the value and its revision for a given key.
+func Get(_ context.Context, kv nats.KeyValue, key string) ([]byte, uint64, error) {
+	if kv == nil {
+		return nil, 0, messaging.NewConfigError("nil KeyValue bucket", nil)
+	}
+	entry, err := kv.Get(key)
+	if err != nil {
+		return nil, 0, err
+	}
+	return entry.Value(), entry.Revision(), nil
+}
+
+// EntryEvent is a simplified watch event.
+type EntryEvent struct {
+	Bucket    string
+	Key       string
+	Value     []byte
+	Revision  uint64
+	Operation string // "PUT" | "DEL" | "PURGE" | "UNKNOWN"
+	Created   time.Time
+}
+
+// Watch starts a watcher on a key or pattern (e.g., ">" for all keys).
+// includeHistory indicates whether to replay historical values on startup.
+// It returns a channel of EntryEvent and a cancel function to stop the watcher.
+func Watch(ctx context.Context, kv nats.KeyValue, keyPattern string, includeHistory bool) (<-chan EntryEvent, func() error, error) {
+	if kv == nil {
+		return nil, nil, messaging.NewConfigError("nil KeyValue bucket", nil)
+	}
+
+	var opts []nats.WatchOpt
+	if includeHistory {
+		opts = append(opts, nats.IncludeHistory())
+	}
+	// Drop delete notifications by default; callers can derive deletes via missing keys.
+	opts = append(opts, nats.IgnoreDeletes())
+
+	w, err := kv.Watch(keyPattern, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ch := make(chan EntryEvent, 64)
+
+	// Fan-out updates until canceled.
+	go func() {
+		defer close(ch)
+		updates := w.Updates()
+		for {
+			select {
+			case <-ctx.Done():
+				_ = w.Stop()
+				return
+			case e, ok := <-updates:
+				if !ok {
+					return
+				}
+				if e == nil {
+					// Initial snapshot barrier
+					continue
+				}
+				ch <- EntryEvent{
+					Bucket:    e.Bucket(),
+					Key:       e.Key(),
+					Value:     e.Value(),
+					Revision:  e.Revision(),
+					Operation: opToString(e.Operation()),
+					Created:   e.Created(),
+				}
+			}
+		}
+	}()
+
+	cancel := func() error { return w.Stop() }
+	return ch, cancel, nil
+}
+
+func opToString(op nats.KeyValueOp) string {
+	switch op {
+	case nats.KeyValuePut:
+		return "PUT"
+	case nats.KeyValueDelete:
+		return "DEL"
+	case nats.KeyValuePurge:
+		return "PURGE"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/pkg/messaging/nats/kv/kv.go
+++ b/pkg/messaging/nats/kv/kv.go
@@ -1,8 +1,23 @@
-// Copyright © 2025 SWIT
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
 //
-// NATS Key-Value helpers: thin utilities wrapping github.com/nats-io/nats.go
-// KeyValue/JetStreamContext to provide a simple way to create buckets, and
-// perform get/put/watch operations for distributed config/state.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 
 package natskv
 

--- a/pkg/messaging/nats/kv/kv_config_test.go
+++ b/pkg/messaging/nats/kv/kv_config_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package natskv
 
 import (

--- a/pkg/messaging/nats/kv/kv_config_test.go
+++ b/pkg/messaging/nats/kv/kv_config_test.go
@@ -1,0 +1,56 @@
+package natskv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBucketConfigNormalizeAndTranslate(t *testing.T) {
+	cfg := BucketConfig{
+		Name:           "app.cfg",
+		Description:    "application config",
+		TTL:            -1,
+		History:        200, // will be capped
+		MaxValueSize:   1024,
+		MaxBucketBytes: 10 * 1024,
+		Storage:        "",
+		Replicas:       0,
+	}
+
+	cfg.Normalize()
+	if cfg.TTL != 0 {
+		t.Fatalf("TTL should be normalized to 0 when negative, got %v", cfg.TTL)
+	}
+	if cfg.History > 64 {
+		t.Fatalf("History should be capped <=64, got %d", cfg.History)
+	}
+	if cfg.Storage != "file" {
+		t.Fatalf("default storage should be file, got %s", cfg.Storage)
+	}
+	if cfg.Replicas != 1 {
+		t.Fatalf("replicas should default to 1, got %d", cfg.Replicas)
+	}
+
+	nkv, err := cfg.toKeyValueConfig()
+	if err != nil {
+		t.Fatalf("toKeyValueConfig error: %v", err)
+	}
+	if nkv.Bucket != "app.cfg" {
+		t.Fatalf("bucket mismatch: %s", nkv.Bucket)
+	}
+	if nkv.Description != "application config" {
+		t.Fatalf("desc mismatch: %s", nkv.Description)
+	}
+	if nkv.TTL != time.Duration(0) {
+		t.Fatalf("ttl mismatch: %v", nkv.TTL)
+	}
+	if nkv.MaxValueSize != 1024 {
+		t.Fatalf("max value size mismatch: %d", nkv.MaxValueSize)
+	}
+	if nkv.MaxBytes != 10*1024 {
+		t.Fatalf("max bytes mismatch: %d", nkv.MaxBytes)
+	}
+	if nkv.Replicas != 1 {
+		t.Fatalf("replicas mismatch: %d", nkv.Replicas)
+	}
+}


### PR DESCRIPTION
This PR implements NATS Key-Value store integration per Issue #310.\n\n- Adds pkg/messaging/nats/kv helpers:\n  - EnsureBucket/OpenBucket\n  - Put/Create/Get\n  - Watch with optional history replay\n- Exposes JetStreamContext via broker for utilities\n- Marks extended capability 'nats.kv' when JS is available\n\nTests:\n- Unit tests for BucketConfig normalization and translation\n\nCloses #310