### PR TITLE
feat: add cross-broker benchmark harness

### DIFF
--- a/internal/switctl/cmd/bench/bench.go
+++ b/internal/switctl/cmd/bench/bench.go
@@ -1,0 +1,311 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/spf13/cobra"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/innovationmech/swit/pkg/messaging/benchmark"
+)
+
+const (
+	defaultOutputDir = "docs/_output/benchmarks"
+)
+
+// NewBenchCommand creates the `switctl bench` command that executes cross-broker benchmarks.
+func NewBenchCommand() *cobra.Command {
+	var (
+		configPath   string
+		csvPath      string
+		markdownPath string
+		outputDir    string
+		profile      string
+		timeoutFlag  string
+		printReport  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "bench",
+		Short: "Run cross-broker messaging benchmarks",
+		Long: `Execute standardized throughput and latency benchmarks across configured message broker adapters.
+
+Examples:
+  # Run benchmarks using a YAML config and write CSV/Markdown outputs
+  switctl bench --config configs/benchmarks/messaging.yaml --csv results.csv --markdown results.md
+
+  # Inspect results in the terminal without writing files
+  switctl bench --config configs/benchmarks/messaging.yaml --print`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(configPath) == "" {
+				return errors.New("--config is required to run benchmarks")
+			}
+
+			if outputDir == "" {
+				outputDir = defaultOutputDir
+			}
+
+			opts := runOptions{
+				ConfigPath:   configPath,
+				OutputDir:    outputDir,
+				CSVPath:      csvPath,
+				MarkdownPath: markdownPath,
+				Profile:      profile,
+				TimeoutFlag:  timeoutFlag,
+				PrintReport:  printReport,
+			}
+
+			return runBench(cmd.Context(), cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to benchmark configuration file (YAML)")
+	cmd.Flags().StringVar(&csvPath, "csv", "", "Relative or absolute path for CSV output (defaults to output-dir/benchmarks.csv)")
+	cmd.Flags().StringVar(&markdownPath, "markdown", "", "Relative or absolute path for Markdown output (defaults to output-dir/benchmarks.md)")
+	cmd.Flags().StringVar(&outputDir, "output-dir", defaultOutputDir, "Directory where benchmark artifacts are written")
+	cmd.Flags().StringVar(&profile, "profile", "default", "Workload profile to use when config omits workloads (default|light|balanced|burst)")
+	cmd.Flags().StringVar(&timeoutFlag, "timeout", "", "Per-target timeout override (e.g. 2m, 30s)")
+	cmd.Flags().BoolVar(&printReport, "print", false, "Print reports to stdout in addition to writing files")
+
+	return cmd
+}
+
+type runOptions struct {
+	ConfigPath   string
+	OutputDir    string
+	CSVPath      string
+	MarkdownPath string
+	Profile      string
+	TimeoutFlag  string
+	PrintReport  bool
+}
+
+type fileConfig struct {
+	Timeout   string          `yaml:"timeout"`
+	Brokers   []brokerEntry   `yaml:"brokers"`
+	Workloads []workloadEntry `yaml:"workloads"`
+}
+
+type brokerEntry struct {
+	Name        string                  `yaml:"name"`
+	Description string                  `yaml:"description"`
+	TopicPrefix string                  `yaml:"topic_prefix"`
+	Config      *messaging.BrokerConfig `yaml:"config"`
+}
+
+type workloadEntry struct {
+	Name        string `yaml:"name"`
+	Topic       string `yaml:"topic"`
+	Messages    int    `yaml:"messages"`
+	MessageSize int    `yaml:"message_size"`
+	Publishers  int    `yaml:"publishers"`
+	BatchSize   int    `yaml:"batch_size"`
+}
+
+func runBench(ctx context.Context, cmd *cobra.Command, opts runOptions) error {
+	cfg, err := loadConfig(opts.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	targets, workloads, timeout, err := cfg.toSuiteInputs(opts.Profile)
+	if err != nil {
+		return err
+	}
+
+	if opts.TimeoutFlag != "" {
+		parsed, perr := time.ParseDuration(opts.TimeoutFlag)
+		if perr != nil {
+			return fmt.Errorf("invalid --timeout value: %w", perr)
+		}
+		timeout = parsed
+	}
+
+	if len(targets) == 0 {
+		return errors.New("configuration must specify at least one broker target")
+	}
+
+	suite := benchmark.Suite{
+		Factory:   messaging.GetDefaultFactory(),
+		Targets:   targets,
+		Workloads: workloads,
+		Timeout:   timeout,
+	}
+
+	report, err := suite.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	if opts.PrintReport {
+		fmt.Fprintln(cmd.OutOrStdout(), report.ToMarkdown())
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintln(cmd.OutOrStdout(), report.ToCSV())
+	}
+
+	if err := ensureDir(opts.OutputDir); err != nil {
+		return err
+	}
+
+	if err := writeArtifacts(report, opts); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "benchmarks completed for %d targets and %d workloads\n", len(targets), len(workloads))
+	return nil
+}
+
+func loadConfig(path string) (*fileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading config %s: %w", path, err)
+	}
+
+	var cfg fileConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed parsing config %s: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+func (cfg *fileConfig) toSuiteInputs(profile string) ([]benchmark.Target, []benchmark.Workload, time.Duration, error) {
+	targets := make([]benchmark.Target, 0, len(cfg.Brokers))
+	for _, broker := range cfg.Brokers {
+		if broker.Config == nil {
+			return nil, nil, 0, fmt.Errorf("broker %q missing config", broker.Name)
+		}
+		broker.Config.SetDefaults()
+		if err := broker.Config.Validate(); err != nil {
+			return nil, nil, 0, fmt.Errorf("broker %q has invalid configuration: %w", broker.Name, err)
+		}
+		targets = append(targets, benchmark.Target{
+			Name:        broker.Name,
+			Description: broker.Description,
+			Config:      broker.Config,
+			TopicPrefix: broker.TopicPrefix,
+		})
+	}
+
+	var workloads []benchmark.Workload
+	if len(cfg.Workloads) > 0 {
+		workloads = make([]benchmark.Workload, 0, len(cfg.Workloads))
+		for _, wl := range cfg.Workloads {
+			workloads = append(workloads, benchmark.Workload{
+				Name:        wl.Name,
+				Topic:       wl.Topic,
+				Messages:    wl.Messages,
+				MessageSize: wl.MessageSize,
+				Publishers:  wl.Publishers,
+				BatchSize:   wl.BatchSize,
+			})
+		}
+	} else {
+		workloads = defaultProfile(profile)
+	}
+
+	var timeout time.Duration
+	if cfg.Timeout != "" {
+		parsed, err := time.ParseDuration(cfg.Timeout)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("invalid timeout in config: %w", err)
+		}
+		timeout = parsed
+	}
+
+	return targets, workloads, timeout, nil
+}
+
+func defaultProfile(profile string) []benchmark.Workload {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "light":
+		return []benchmark.Workload{{
+			Name:        "light",
+			Messages:    500,
+			MessageSize: 512,
+			Publishers:  1,
+			BatchSize:   1,
+		}}
+	case "balanced":
+		return []benchmark.Workload{{
+			Name:        "balanced",
+			Messages:    2000,
+			MessageSize: 1024,
+			Publishers:  4,
+			BatchSize:   1,
+		}}
+	case "burst":
+		return []benchmark.Workload{{
+			Name:        "burst",
+			Messages:    5000,
+			MessageSize: 4096,
+			Publishers:  8,
+			BatchSize:   10,
+		}}
+	default:
+		return benchmark.DefaultWorkloads()
+	}
+}
+
+func ensureDir(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed creating output directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+func writeArtifacts(report *benchmark.Report, opts runOptions) error {
+	if report == nil {
+		return errors.New("nil report")
+	}
+
+	csvPath := resolvePath(opts.OutputDir, opts.CSVPath, "benchmarks.csv")
+	markdownPath := resolvePath(opts.OutputDir, opts.MarkdownPath, "benchmarks.md")
+
+	if csvPath != "" {
+		if err := writeFile(csvPath, report.ToCSV()); err != nil {
+			return err
+		}
+	}
+	if markdownPath != "" {
+		if err := writeFile(markdownPath, report.ToMarkdown()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resolvePath(baseDir, override, fallback string) string {
+	if override == "-" {
+		return ""
+	}
+	target := override
+	if target == "" {
+		target = filepath.Join(baseDir, fallback)
+	} else if !filepath.IsAbs(target) {
+		target = filepath.Join(baseDir, target)
+	}
+	return target
+}
+
+func writeFile(path string, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed creating directory for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), fs.FileMode(0o644)); err != nil {
+		return fmt.Errorf("failed writing %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/switctl/cmd/bench/bench.go
+++ b/internal/switctl/cmd/bench/bench.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package bench
 
 import (

--- a/internal/switctl/cmd/bench/bench_test.go
+++ b/internal/switctl/cmd/bench/bench_test.go
@@ -1,0 +1,80 @@
+package bench
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/innovationmech/swit/pkg/messaging/benchmark"
+)
+
+func TestLoadConfigAndConvert(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bench.yaml")
+
+	yaml := `timeout: 90s
+brokers:
+  - name: inmemory
+    description: In-memory broker for tests
+    topic_prefix: demo
+    config:
+      type: inmemory
+      endpoints: ["localhost"]
+workloads:
+  - name: sample
+    topic: demo.sample
+    messages: 42
+    message_size: 256
+    publishers: 2
+    batch_size: 1
+`
+
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
+
+	cfg, err := loadConfig(path)
+	require.NoError(t, err)
+
+	targets, workloads, timeout, err := cfg.toSuiteInputs("default")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Len(t, workloads, 1)
+	require.Equal(t, time.Second*90, timeout)
+
+	require.Equal(t, "inmemory", targets[0].Name)
+	require.Equal(t, "demo.sample", workloads[0].Topic)
+	require.Equal(t, 42, workloads[0].Messages)
+}
+
+func TestDefaultProfileFallback(t *testing.T) {
+	cfg := &fileConfig{}
+
+	// Without brokers we expect no targets but also no error (checked upstream).
+	targets, workloads, _, err := cfg.toSuiteInputs("default")
+	require.NoError(t, err)
+	require.Empty(t, targets)
+	require.Equal(t, benchmark.DefaultWorkloads(), workloads)
+
+	cfg.Brokers = []brokerEntry{{
+		Name:   "fake",
+		Config: dummyBrokerConfig(),
+	}}
+
+	targets, workloads, _, err = cfg.toSuiteInputs("balanced")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Len(t, workloads, 1)
+	require.Equal(t, "balanced", workloads[0].Name)
+}
+
+func dummyBrokerConfig() *messaging.BrokerConfig {
+	cfg := &messaging.BrokerConfig{
+		Type:      messaging.BrokerTypeInMemory,
+		Endpoints: []string{"localhost"},
+	}
+	cfg.SetDefaults()
+	return cfg
+}

--- a/internal/switctl/cmd/bench/bench_test.go
+++ b/internal/switctl/cmd/bench/bench_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package bench
 
 import (

--- a/internal/switctl/cmd/cmd.go
+++ b/internal/switctl/cmd/cmd.go
@@ -22,6 +22,7 @@
 package cmd
 
 import (
+	"github.com/innovationmech/swit/internal/switctl/cmd/bench"
 	"github.com/innovationmech/swit/internal/switctl/cmd/check"
 	"github.com/innovationmech/swit/internal/switctl/cmd/config"
 	"github.com/innovationmech/swit/internal/switctl/cmd/deps"
@@ -66,6 +67,7 @@ Use switctl to:
 
 	// Add subcommands
 	rootCmd.AddCommand(version.NewSwitctlVersionCmd())
+	rootCmd.AddCommand(bench.NewBenchCommand())
 	rootCmd.AddCommand(new.NewNewCommand())
 	rootCmd.AddCommand(check.NewCheckCommand())
 	rootCmd.AddCommand(generate.NewGenerateCommand())

--- a/pkg/messaging/benchmark/harness.go
+++ b/pkg/messaging/benchmark/harness.go
@@ -1,0 +1,634 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Package benchmark provides a reusable harness for measuring cross-broker
+// messaging performance characteristics such as throughput and latency.
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+const (
+	defaultMessageSize   = 1024 // 1 KiB messages as baseline
+	defaultMessageCount  = 1000
+	defaultPublisherPool = 4
+)
+
+// Workload describes a benchmark profile that the harness executes against each broker target.
+type Workload struct {
+	Name        string
+	Topic       string
+	Messages    int
+	MessageSize int
+	Publishers  int
+	BatchSize   int
+}
+
+// Validate ensures the workload configuration is usable.
+func (w Workload) Validate() error {
+	if strings.TrimSpace(w.Name) == "" {
+		return errors.New("workload name cannot be empty")
+	}
+	if w.Messages <= 0 {
+		return fmt.Errorf("workload %q must publish at least one message", w.Name)
+	}
+	if w.MessageSize <= 0 {
+		return fmt.Errorf("workload %q must use a positive message size", w.Name)
+	}
+	if w.Publishers <= 0 {
+		return fmt.Errorf("workload %q must have at least one publisher", w.Name)
+	}
+	if w.BatchSize < 0 {
+		return fmt.Errorf("workload %q has invalid batch size", w.Name)
+	}
+	return nil
+}
+
+// WithDefaults returns a copy of the workload filled with sensible defaults and sanitized fields.
+func (w Workload) WithDefaults() Workload {
+	if w.Messages == 0 {
+		w.Messages = defaultMessageCount
+	}
+	if w.MessageSize == 0 {
+		w.MessageSize = defaultMessageSize
+	}
+	if w.Publishers == 0 {
+		w.Publishers = defaultPublisherPool
+	}
+	if w.BatchSize == 0 {
+		w.BatchSize = 1
+	}
+	if strings.TrimSpace(w.Topic) == "" {
+		w.Topic = fmt.Sprintf("bench-%s", sanitizeName(w.Name))
+	}
+	return w
+}
+
+// Target identifies a broker instance (adapter + configuration) that should be benchmarked.
+type Target struct {
+	Name        string
+	Description string
+	Config      *messaging.BrokerConfig
+	TopicPrefix string
+}
+
+// Validate ensures the target has a usable configuration.
+func (t Target) Validate() error {
+	if strings.TrimSpace(t.Name) == "" {
+		return errors.New("target name cannot be empty")
+	}
+	if t.Config == nil {
+		return fmt.Errorf("target %q requires a broker configuration", t.Name)
+	}
+	if !t.Config.Type.IsValid() {
+		return fmt.Errorf("target %q specifies invalid broker type %q", t.Name, t.Config.Type)
+	}
+	return nil
+}
+
+// Suite coordinates execution of workloads across a set of broker targets.
+type Suite struct {
+	Factory   messaging.MessageBrokerFactory
+	Targets   []Target
+	Workloads []Workload
+	Timeout   time.Duration
+}
+
+// Report captures all benchmark results from a suite execution.
+type Report struct {
+	GeneratedAt time.Time
+	Results     []Result
+}
+
+// Result describes the outcome of executing a single workload against a broker target.
+type Result struct {
+	TargetName   string
+	BrokerType   messaging.BrokerType
+	WorkloadName string
+	Workload     Workload
+	Metrics      Metrics
+	Error        error
+}
+
+// Metrics aggregates throughput and latency information gathered from a workload run.
+type Metrics struct {
+	TotalMessages  int
+	Successful     int
+	Failed         int
+	Duration       time.Duration
+	Throughput     float64
+	AverageLatency time.Duration
+	P50Latency     time.Duration
+	P95Latency     time.Duration
+	P99Latency     time.Duration
+	MaxLatency     time.Duration
+	ErrorSummaries []ErrorSummary
+}
+
+// ErrorSummary groups errors by canonical message for reporting.
+type ErrorSummary struct {
+	Message string
+	Count   int
+}
+
+// DefaultWorkloads returns a representative mix of light, balanced, and peak benchmark profiles.
+func DefaultWorkloads() []Workload {
+	return []Workload{
+		{
+			Name:        "light",
+			Messages:    500,
+			MessageSize: 512,
+			Publishers:  1,
+			BatchSize:   1,
+		},
+		{
+			Name:        "balanced",
+			Messages:    2000,
+			MessageSize: 1024,
+			Publishers:  4,
+			BatchSize:   1,
+		},
+		{
+			Name:        "burst",
+			Messages:    5000,
+			MessageSize: 4096,
+			Publishers:  8,
+			BatchSize:   10,
+		},
+	}
+}
+
+// Run executes all workloads for every target and returns a consolidated report.
+func (s *Suite) Run(ctx context.Context) (*Report, error) {
+	if s.Factory == nil {
+		return nil, errors.New("benchmark suite requires a messaging factory")
+	}
+	if len(s.Targets) == 0 {
+		return nil, errors.New("benchmark suite requires at least one target")
+	}
+	if len(s.Workloads) == 0 {
+		return nil, errors.New("benchmark suite requires at least one workload")
+	}
+
+	var report Report
+	report.GeneratedAt = time.Now()
+
+	for _, target := range s.Targets {
+		if err := target.Validate(); err != nil {
+			return nil, err
+		}
+		if err := s.runTarget(ctx, &report, target); err != nil {
+			return nil, err
+		}
+	}
+
+	return &report, nil
+}
+
+func (s *Suite) runTarget(parentCtx context.Context, report *Report, target Target) error {
+	broker, err := s.Factory.CreateBroker(target.Config)
+	if err != nil {
+		return fmt.Errorf("failed creating broker for target %q: %w", target.Name, err)
+	}
+
+	brokerCtx := parentCtx
+	var cancel context.CancelFunc
+	if s.Timeout > 0 {
+		brokerCtx, cancel = context.WithTimeout(parentCtx, s.Timeout)
+	}
+	if cancel != nil {
+		defer cancel()
+	}
+
+	if err := broker.Connect(brokerCtx); err != nil {
+		report.Results = append(report.Results, failureResult(target, err))
+		_ = broker.Close()
+		return nil
+	}
+
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_ = broker.Disconnect(cleanupCtx)
+		_ = broker.Close()
+	}()
+
+	for _, workload := range s.Workloads {
+		wl := workload.WithDefaults()
+		if err := wl.Validate(); err != nil {
+			report.Results = append(report.Results, Result{
+				TargetName:   target.Name,
+				BrokerType:   target.Config.Type,
+				WorkloadName: workload.Name,
+				Workload:     wl,
+				Error:        err,
+			})
+			continue
+		}
+		if prefix := strings.TrimSpace(target.TopicPrefix); prefix != "" {
+			wl.Topic = fmt.Sprintf("%s.%s", prefix, wl.Topic)
+		}
+
+		res := s.executeWorkload(brokerCtx, broker, target, wl)
+		report.Results = append(report.Results, res)
+	}
+
+	return nil
+}
+
+func failureResult(target Target, err error) Result {
+	return Result{
+		TargetName:   target.Name,
+		BrokerType:   target.Config.Type,
+		WorkloadName: "connect",
+		Workload: Workload{
+			Name:       "connect",
+			Messages:   0,
+			Publishers: 0,
+			BatchSize:  1,
+		},
+		Error: err,
+	}
+}
+
+func (s *Suite) executeWorkload(ctx context.Context, broker messaging.MessageBroker, target Target, workload Workload) Result {
+	metrics := Metrics{TotalMessages: workload.Messages}
+
+	start := time.Now()
+	latencies := make([]time.Duration, 0, workload.Messages)
+	var latenciesMu sync.Mutex
+
+	errorCounts := make(map[string]int)
+	var errorMu sync.Mutex
+
+	var successCount int64
+	var failureCount int64
+
+	jobs := make(chan []*messaging.Message)
+	var wg sync.WaitGroup
+
+	for worker := 0; worker < workload.Publishers; worker++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+
+			publisherConfig := messaging.PublisherConfig{
+				Topic: workload.Topic,
+				Async: false,
+			}
+
+			publisher, err := broker.CreatePublisher(publisherConfig)
+			if err != nil {
+				incrementError(&errorMu, errorCounts, fmt.Sprintf("publisher[%d] create: %v", workerID, err))
+				return
+			}
+			defer publisher.Close()
+
+			for batch := range jobs {
+				select {
+				case <-ctx.Done():
+					incrementError(&errorMu, errorCounts, ctx.Err().Error())
+					atomic.AddInt64(&failureCount, int64(len(batch)))
+					return
+				default:
+				}
+
+				batchStart := time.Now()
+				var publishErr error
+				if len(batch) == 1 && workload.BatchSize <= 1 {
+					publishErr = publisher.Publish(ctx, batch[0])
+				} else if len(batch) == 1 {
+					publishErr = publisher.PublishBatch(ctx, batch)
+				} else {
+					publishErr = publisher.PublishBatch(ctx, batch)
+				}
+
+				elapsed := time.Since(batchStart)
+				if publishErr != nil {
+					incrementError(&errorMu, errorCounts, publishErr.Error())
+					atomic.AddInt64(&failureCount, int64(len(batch)))
+					continue
+				}
+
+				latenciesMu.Lock()
+				for range batch {
+					latencies = append(latencies, elapsed)
+				}
+				latenciesMu.Unlock()
+				atomic.AddInt64(&successCount, int64(len(batch)))
+			}
+		}(worker)
+	}
+
+	go func() {
+		defer close(jobs)
+		payload := makePayload(workload.MessageSize)
+		remaining := workload.Messages
+		produced := 0
+		for remaining > 0 {
+			batchSize := workload.BatchSize
+			if batchSize <= 1 {
+				batchSize = 1
+			}
+			if batchSize > remaining {
+				batchSize = remaining
+			}
+
+			batch := make([]*messaging.Message, batchSize)
+			for i := 0; i < batchSize; i++ {
+				seq := produced + i
+				batch[i] = createMessage(workload, target, seq, payload)
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- batch:
+				produced += batchSize
+				remaining -= batchSize
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	successful := int(atomic.LoadInt64(&successCount))
+	recordedFailures := int(atomic.LoadInt64(&failureCount))
+	pending := metrics.TotalMessages - successful - recordedFailures
+	if pending < 0 {
+		pending = 0
+	}
+	metrics.Successful = successful
+	metrics.Failed = recordedFailures + pending
+	metrics.Duration = time.Since(start)
+	if metrics.Duration <= 0 {
+		metrics.Duration = time.Nanosecond
+	}
+	metrics.Throughput = float64(metrics.Successful) / metrics.Duration.Seconds()
+
+	metrics.ErrorSummaries = collapseErrors(errorCounts)
+	metrics.AverageLatency, metrics.P50Latency, metrics.P95Latency, metrics.P99Latency, metrics.MaxLatency = computeLatencyMetrics(latencies)
+
+	return Result{
+		TargetName:   target.Name,
+		BrokerType:   target.Config.Type,
+		WorkloadName: workload.Name,
+		Workload:     workload,
+		Metrics:      metrics,
+	}
+}
+
+func incrementError(mu *sync.Mutex, counts map[string]int, message string) {
+	mu.Lock()
+	defer mu.Unlock()
+	counts[message]++
+}
+
+func collapseErrors(counts map[string]int) []ErrorSummary {
+	if len(counts) == 0 {
+		return nil
+	}
+	summaries := make([]ErrorSummary, 0, len(counts))
+	for msg, count := range counts {
+		summaries = append(summaries, ErrorSummary{Message: msg, Count: count})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Count == summaries[j].Count {
+			return summaries[i].Message < summaries[j].Message
+		}
+		return summaries[i].Count > summaries[j].Count
+	})
+	return summaries
+}
+
+func computeLatencyMetrics(latencies []time.Duration) (avg, p50, p95, p99, max time.Duration) {
+	if len(latencies) == 0 {
+		return 0, 0, 0, 0, 0
+	}
+
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	var sum time.Duration
+	for _, v := range latencies {
+		sum += v
+	}
+
+	avg = sum / time.Duration(len(latencies))
+	p50 = percentile(latencies, 0.50)
+	p95 = percentile(latencies, 0.95)
+	p99 = percentile(latencies, 0.99)
+	max = latencies[len(latencies)-1]
+	return
+}
+
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(math.Ceil(p*float64(len(sorted))) - 1)
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func makePayload(size int) []byte {
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte('A' + (i % 26))
+	}
+	return buf
+}
+
+func createMessage(workload Workload, target Target, seq int, payloadTemplate []byte) *messaging.Message {
+	payload := make([]byte, len(payloadTemplate))
+	copy(payload, payloadTemplate)
+
+	headers := map[string]string{
+		"benchmark": "true",
+		"workload":  workload.Name,
+		"sequence":  strconv.Itoa(seq),
+	}
+
+	if target.Description != "" {
+		headers["target"] = target.Description
+	}
+
+	return &messaging.Message{
+		ID:        fmt.Sprintf("%s-%d", sanitizeName(workload.Name), seq),
+		Topic:     workload.Topic,
+		Payload:   payload,
+		Timestamp: time.Now(),
+		Headers:   headers,
+		Key:       []byte(fmt.Sprintf("key-%d", seq%16)),
+	}
+}
+
+func sanitizeName(input string) string {
+	input = strings.ToLower(strings.TrimSpace(input))
+	if input == "" {
+		return "workload"
+	}
+
+	var b strings.Builder
+	b.Grow(len(input))
+	for _, r := range input {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune('-')
+		case r == '.' || r == ':' || r == '/':
+			b.WriteRune('-')
+		case r == ' ':
+			b.WriteRune('-')
+		}
+	}
+
+	sanitized := strings.Trim(b.String(), "-")
+	if sanitized == "" {
+		return "workload"
+	}
+	return sanitized
+}
+
+// ErrorRate returns the percentage of failed messages relative to the total messages attempted.
+func (m Metrics) ErrorRate() float64 {
+	if m.TotalMessages == 0 {
+		return 0
+	}
+	return float64(m.Failed) / float64(m.TotalMessages)
+}
+
+// LatencyHistogram returns a human-readable summary of high-percentile latencies.
+func (m Metrics) LatencyHistogram() string {
+	if m.Successful == 0 {
+		return "no successful publishes"
+	}
+	parts := []string{
+		fmt.Sprintf("avg=%s", m.AverageLatency),
+		fmt.Sprintf("p50=%s", m.P50Latency),
+		fmt.Sprintf("p95=%s", m.P95Latency),
+		fmt.Sprintf("p99=%s", m.P99Latency),
+		fmt.Sprintf("max=%s", m.MaxLatency),
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ErrorDetails returns the error summaries formatted as a single string.
+func (m Metrics) ErrorDetails() string {
+	if len(m.ErrorSummaries) == 0 {
+		return ""
+	}
+	parts := make([]string, len(m.ErrorSummaries))
+	for i, summary := range m.ErrorSummaries {
+		parts[i] = fmt.Sprintf("%s (%d)", summary.Message, summary.Count)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ToCSV renders the report in CSV format suitable for spreadsheet import.
+func (r *Report) ToCSV() string {
+	var b strings.Builder
+	b.WriteString("broker,broker_type,workload,messages,publishers,batch_size,duration_seconds,throughput_msgs_per_sec,avg_latency_ms,p95_latency_ms,error_rate,failures,error_details\n")
+	for _, result := range r.Results {
+		durationSeconds := result.Metrics.Duration.Seconds()
+		avgLatencyMs := float64(result.Metrics.AverageLatency) / float64(time.Millisecond)
+		p95LatencyMs := float64(result.Metrics.P95Latency) / float64(time.Millisecond)
+
+		b.WriteString(fmt.Sprintf(
+			"%s,%s,%s,%d,%d,%d,%.4f,%.2f,%.2f,%.2f,%.4f,%d,%q\n",
+			sanitizeForCSV(result.TargetName),
+			result.BrokerType.String(),
+			sanitizeForCSV(result.WorkloadName),
+			result.Workload.Messages,
+			result.Workload.Publishers,
+			result.Workload.BatchSize,
+			durationSeconds,
+			result.Metrics.Throughput,
+			avgLatencyMs,
+			p95LatencyMs,
+			result.Metrics.ErrorRate(),
+			result.Metrics.Failed,
+			result.Metrics.ErrorDetails(),
+		))
+	}
+	return b.String()
+}
+
+// ToMarkdown renders the report as a Markdown table.
+func (r *Report) ToMarkdown() string {
+	var b strings.Builder
+	b.WriteString("| Broker | Type | Workload | Messages | Publishers | Batch | Duration (s) | Throughput (msg/s) | Avg Latency (ms) | P95 Latency (ms) | Failures |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n")
+
+	for _, result := range r.Results {
+		avgLatencyMs := float64(result.Metrics.AverageLatency) / float64(time.Millisecond)
+		p95LatencyMs := float64(result.Metrics.P95Latency) / float64(time.Millisecond)
+		b.WriteString(fmt.Sprintf(
+			"| %s | %s | %s | %d | %d | %d | %.2f | %.2f | %.2f | %.2f | %d |\n",
+			escapeMarkdown(result.TargetName),
+			result.BrokerType.String(),
+			escapeMarkdown(result.WorkloadName),
+			result.Workload.Messages,
+			result.Workload.Publishers,
+			result.Workload.BatchSize,
+			result.Metrics.Duration.Seconds(),
+			result.Metrics.Throughput,
+			avgLatencyMs,
+			p95LatencyMs,
+			result.Metrics.Failed,
+		))
+	}
+
+	return b.String()
+}
+
+func sanitizeForCSV(input string) string {
+	input = strings.ReplaceAll(input, "\n", " ")
+	input = strings.ReplaceAll(input, ",", " ")
+	return input
+}
+
+func escapeMarkdown(input string) string {
+	replacer := strings.NewReplacer("|", "\\|", "\n", " ", "`", "'", "*", "\\*", "_", "\\_")
+	return replacer.Replace(input)
+}

--- a/pkg/messaging/benchmark/harness.go
+++ b/pkg/messaging/benchmark/harness.go
@@ -4,7 +4,8 @@
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to do so, subject to the following conditions:
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
@@ -18,8 +19,6 @@
 // THE SOFTWARE.
 //
 
-// Package benchmark provides a reusable harness for measuring cross-broker
-// messaging performance characteristics such as throughput and latency.
 package benchmark
 
 import (

--- a/pkg/messaging/benchmark/harness_test.go
+++ b/pkg/messaging/benchmark/harness_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package benchmark
 
 import (

--- a/pkg/messaging/benchmark/harness_test.go
+++ b/pkg/messaging/benchmark/harness_test.go
@@ -1,0 +1,225 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	"github.com/stretchr/testify/require"
+)
+
+type stubFactory struct {
+	broker messaging.MessageBroker
+}
+
+func (f *stubFactory) CreateBroker(_ *messaging.BrokerConfig) (messaging.MessageBroker, error) {
+	return f.broker, nil
+}
+
+func (f *stubFactory) GetSupportedBrokerTypes() []messaging.BrokerType {
+	return []messaging.BrokerType{messaging.BrokerTypeInMemory}
+}
+
+func (f *stubFactory) ValidateConfig(_ *messaging.BrokerConfig) error { return nil }
+
+type fakeBroker struct {
+	latency       time.Duration
+	failuresLeft  int32
+	connected     bool
+	failOnConnect bool
+}
+
+func (b *fakeBroker) Connect(_ context.Context) error {
+	if b.failOnConnect {
+		return errors.New("connect failure")
+	}
+	b.connected = true
+	return nil
+}
+
+func (b *fakeBroker) Disconnect(_ context.Context) error {
+	b.connected = false
+	return nil
+}
+
+func (b *fakeBroker) Close() error { b.connected = false; return nil }
+
+func (b *fakeBroker) IsConnected() bool { return b.connected }
+
+func (b *fakeBroker) CreatePublisher(config messaging.PublisherConfig) (messaging.EventPublisher, error) {
+	if config.Topic == "" {
+		return nil, errors.New("topic required")
+	}
+	return &fakePublisher{broker: b}, nil
+}
+
+func (b *fakeBroker) CreateSubscriber(messaging.SubscriberConfig) (messaging.EventSubscriber, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b *fakeBroker) HealthCheck(context.Context) (*messaging.HealthStatus, error) {
+	return &messaging.HealthStatus{Status: messaging.HealthStatusHealthy}, nil
+}
+
+func (b *fakeBroker) GetMetrics() *messaging.BrokerMetrics { return &messaging.BrokerMetrics{} }
+
+func (b *fakeBroker) GetCapabilities() *messaging.BrokerCapabilities {
+	return &messaging.BrokerCapabilities{}
+}
+
+type fakePublisher struct {
+	broker *fakeBroker
+	calls  int32
+}
+
+func (p *fakePublisher) Publish(ctx context.Context, _ *messaging.Message) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	time.Sleep(p.broker.latency)
+	if atomic.LoadInt32(&p.broker.failuresLeft) > 0 {
+		atomic.AddInt32(&p.broker.failuresLeft, -1)
+		return errors.New("injected failure")
+	}
+	atomic.AddInt32(&p.calls, 1)
+	return nil
+}
+
+func (p *fakePublisher) PublishBatch(ctx context.Context, batch []*messaging.Message) error {
+	for range batch {
+		if err := p.Publish(ctx, &messaging.Message{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *fakePublisher) PublishWithConfirm(ctx context.Context, m *messaging.Message) (*messaging.PublishConfirmation, error) {
+	if err := p.Publish(ctx, m); err != nil {
+		return nil, err
+	}
+	return &messaging.PublishConfirmation{}, nil
+}
+
+func (p *fakePublisher) PublishAsync(ctx context.Context, m *messaging.Message, callback messaging.PublishCallback) error {
+	go func() {
+		err := p.Publish(ctx, m)
+		callback(&messaging.PublishConfirmation{}, err)
+	}()
+	return nil
+}
+
+func (p *fakePublisher) BeginTransaction(context.Context) (messaging.Transaction, error) {
+	return nil, errors.New("not supported")
+}
+
+func (p *fakePublisher) Flush(context.Context) error { return nil }
+
+func (p *fakePublisher) Close() error { return nil }
+
+func (p *fakePublisher) GetMetrics() *messaging.PublisherMetrics {
+	return &messaging.PublisherMetrics{}
+}
+
+func TestSuiteRunSuccess(t *testing.T) {
+	broker := &fakeBroker{latency: 2 * time.Millisecond}
+	factory := &stubFactory{broker: broker}
+
+	suite := Suite{
+		Factory: factory,
+		Targets: []Target{
+			{
+				Name: "fake",
+				Config: &messaging.BrokerConfig{
+					Type:      messaging.BrokerTypeInMemory,
+					Endpoints: []string{"localhost"},
+				},
+			},
+		},
+		Workloads: []Workload{{
+			Name:        "single",
+			Messages:    20,
+			MessageSize: 128,
+			Publishers:  2,
+			BatchSize:   1,
+		}},
+	}
+
+	report, err := suite.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+
+	result := report.Results[0]
+	require.Equal(t, "single", result.WorkloadName)
+	require.Equal(t, 20, result.Metrics.TotalMessages)
+	require.Equal(t, 20, result.Metrics.Successful)
+	require.Equal(t, 0, result.Metrics.Failed)
+	require.Greater(t, result.Metrics.Throughput, 0.0)
+	require.True(t, result.Metrics.AverageLatency >= broker.latency)
+	require.Zero(t, result.Metrics.ErrorRate())
+}
+
+func TestSuiteRunRecordsFailures(t *testing.T) {
+	broker := &fakeBroker{latency: time.Millisecond, failuresLeft: 5}
+	factory := &stubFactory{broker: broker}
+
+	suite := Suite{
+		Factory: factory,
+		Targets: []Target{
+			{
+				Name: "faulty",
+				Config: &messaging.BrokerConfig{
+					Type:      messaging.BrokerTypeInMemory,
+					Endpoints: []string{"localhost"},
+				},
+			},
+		},
+		Workloads: []Workload{{
+			Name:        "failure",
+			Messages:    10,
+			MessageSize: 256,
+			Publishers:  1,
+			BatchSize:   1,
+		}},
+	}
+
+	report, err := suite.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+
+	result := report.Results[0]
+	require.Equal(t, 10, result.Metrics.TotalMessages)
+	require.Equal(t, 5, result.Metrics.Successful)
+	require.Equal(t, 5, result.Metrics.Failed)
+	require.NotEmpty(t, result.Metrics.ErrorSummaries)
+	require.Greater(t, result.Metrics.ErrorRate(), 0.0)
+}
+
+func TestFailureOnConnect(t *testing.T) {
+	broker := &fakeBroker{failOnConnect: true}
+	factory := &stubFactory{broker: broker}
+
+	suite := Suite{
+		Factory: factory,
+		Targets: []Target{
+			{
+				Name: "unreachable",
+				Config: &messaging.BrokerConfig{
+					Type:      messaging.BrokerTypeInMemory,
+					Endpoints: []string{"localhost"},
+				},
+			},
+		},
+		Workloads: []Workload{{Name: "noop", Messages: 1, MessageSize: 16, Publishers: 1}},
+	}
+
+	report, err := suite.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	require.Error(t, report.Results[0].Error)
+}


### PR DESCRIPTION
## Summary
- add pkg/messaging/benchmark suite to run standardized workloads and collect throughput/latency metrics across adapters
- wire switctl bench command to execute the harness, read broker configs, and emit CSV/Markdown reports
- cover new harness and CLI config logic with focused unit tests and expose the command at the root CLI level

## Testing
- go test ./pkg/messaging/benchmark ./internal/switctl/cmd/bench
- go test ./... *(fails: demo tracing scenario expects Jaeger tracing stack; panic originates from TestTracingDemonstrationScenarios)*

Closes #317