### PR TITLE
feat(kafka): full Kafka client configuration (TLS/SASL, acks, compression)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,9 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect

--- a/pkg/messaging/kafka/config.go
+++ b/pkg/messaging/kafka/config.go
@@ -59,6 +59,10 @@ type ProducerConfig struct {
 
 	// Batching controls basic batching strategy
 	Batching ProducerBatchingConfig `json:"batching" yaml:"batching"`
+
+	// Compression overrides global compression for producer (optional)
+	// Supported values follow messaging.CompressionType
+	Compression messaging.CompressionType `json:"compression" yaml:"compression"`
 }
 
 // ProducerBatchingConfig controls producer batching.
@@ -165,6 +169,20 @@ func (c *Config) validate() error {
 	// Validate numeric ranges
 	if c.Producer.Batching.MaxBytes < 0 {
 		return messaging.NewConfigError("producer.batching.max_bytes cannot be negative", nil)
+	}
+
+	// Validate optional producer compression when provided
+	switch c.Producer.Compression {
+	case "":
+		// not set
+	case messaging.CompressionNone, messaging.CompressionGZIP, messaging.CompressionSnappy,
+		messaging.CompressionLZ4, messaging.CompressionZSTD:
+		// ok
+	default:
+		return messaging.NewConfigError(
+			fmt.Sprintf("invalid producer.compression: %s", c.Producer.Compression),
+			nil,
+		)
 	}
 
 	return nil

--- a/pkg/messaging/kafka/security.go
+++ b/pkg/messaging/kafka/security.go
@@ -1,0 +1,137 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package kafka
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+	kgo "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl"
+	"github.com/segmentio/kafka-go/sasl/plain"
+	"github.com/segmentio/kafka-go/sasl/scram"
+)
+
+// buildTLSConfig constructs a *tls.Config from generic messaging TLS settings.
+func buildTLSConfig(tlsCfg *messaging.TLSConfig) (*tls.Config, error) {
+	if tlsCfg == nil || !tlsCfg.Enabled {
+		return nil, nil
+	}
+
+	cfg := &tls.Config{InsecureSkipVerify: tlsCfg.SkipVerify} //nolint:gosec // allow via configuration
+	if tlsCfg.ServerName != "" {
+		cfg.ServerName = tlsCfg.ServerName
+	}
+
+	// Load client cert if provided
+	if tlsCfg.CertFile != "" && tlsCfg.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(tlsCfg.CertFile, tlsCfg.KeyFile)
+		if err != nil {
+			return nil, messaging.NewConfigError(fmt.Sprintf("failed to load client TLS cert/key: %v", err), err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	// Load CA if provided
+	if tlsCfg.CAFile != "" {
+		caData, err := os.ReadFile(tlsCfg.CAFile)
+		if err != nil {
+			return nil, messaging.NewConfigError(fmt.Sprintf("failed to read CA file: %v", err), err)
+		}
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM(caData); !ok {
+			return nil, messaging.NewConfigError("failed to append CA certificates", nil)
+		}
+		cfg.RootCAs = pool
+	}
+
+	return cfg, nil
+}
+
+// buildSASLMechanism constructs a kafka-go SASL mechanism from generic auth config.
+func buildSASLMechanism(auth *messaging.AuthConfig) (sasl.Mechanism, error) {
+	if auth == nil || auth.Type == messaging.AuthTypeNone {
+		return nil, nil
+	}
+	if auth.Type != messaging.AuthTypeSASL {
+		// For now, only SASL is supported for Kafka. Others may be added later.
+		return nil, messaging.NewConfigError(fmt.Sprintf("unsupported auth type for Kafka: %s", auth.Type), nil)
+	}
+
+	mechanism := auth.Mechanism
+	switch mechanism {
+	case "PLAIN", "plain", "Plain":
+		return plain.Mechanism{Username: auth.Username, Password: auth.Password}, nil
+	case "SCRAM-SHA-256", "scram-sha-256":
+		m, err := scram.Mechanism(scram.SHA256, auth.Username, auth.Password)
+		if err != nil {
+			return nil, messaging.NewConfigError("failed to initialize SCRAM-SHA-256 mechanism", err)
+		}
+		return m, nil
+	case "SCRAM-SHA-512", "scram-sha-512":
+		m, err := scram.Mechanism(scram.SHA512, auth.Username, auth.Password)
+		if err != nil {
+			return nil, messaging.NewConfigError("failed to initialize SCRAM-SHA-512 mechanism", err)
+		}
+		return m, nil
+	case "", "AUTO":
+		// Default to PLAIN when mechanism unspecified but SASL chosen
+		return plain.Mechanism{Username: auth.Username, Password: auth.Password}, nil
+	default:
+		return nil, messaging.NewConfigError(fmt.Sprintf("unsupported SASL mechanism: %s", mechanism), nil)
+	}
+}
+
+// mapRequiredAcks converts our Kafka adapter config Acks string into kafka-go RequiredAcks.
+func mapRequiredAcks(acks string) kgo.RequiredAcks {
+	switch acks {
+	case "none":
+		return kgo.RequireNone
+	case "all":
+		return kgo.RequireAll
+	case "leader", "":
+		return kgo.RequireOne
+	default:
+		return kgo.RequireOne
+	}
+}
+
+// mapCompression converts messaging.CompressionType to kafka-go compression codec.
+func mapCompression(c messaging.CompressionType) (kgo.Compression, bool) {
+	switch c {
+	case messaging.CompressionGZIP:
+		return kgo.Gzip, true
+	case messaging.CompressionSnappy:
+		return kgo.Snappy, true
+	case messaging.CompressionLZ4:
+		return kgo.Lz4, true
+	case messaging.CompressionZSTD:
+		return kgo.Zstd, true
+	case messaging.CompressionNone:
+		fallthrough
+	default:
+		return kgo.Compression(0), false // do not set; leave kafka-go default (no compression)
+	}
+}

--- a/pkg/messaging/kafka/security_test.go
+++ b/pkg/messaging/kafka/security_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2025 jackelyj
+package kafka
+
+import (
+	"testing"
+
+	"github.com/innovationmech/swit/pkg/messaging"
+)
+
+func TestBuildSASLMechanism_Plain(t *testing.T) {
+	mech, err := buildSASLMechanism(&messaging.AuthConfig{
+		Type:      messaging.AuthTypeSASL,
+		Mechanism: "PLAIN",
+		Username:  "user",
+		Password:  "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mech == nil {
+		t.Fatalf("expected non-nil mechanism")
+	}
+}
+
+func TestBuildSASLMechanism_Scram256(t *testing.T) {
+	mech, err := buildSASLMechanism(&messaging.AuthConfig{
+		Type:      messaging.AuthTypeSASL,
+		Mechanism: "SCRAM-SHA-256",
+		Username:  "user",
+		Password:  "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mech == nil {
+		t.Fatalf("expected non-nil mechanism")
+	}
+}
+
+func TestBuildSASLMechanism_Scram512(t *testing.T) {
+	mech, err := buildSASLMechanism(&messaging.AuthConfig{
+		Type:      messaging.AuthTypeSASL,
+		Mechanism: "SCRAM-SHA-512",
+		Username:  "user",
+		Password:  "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mech == nil {
+		t.Fatalf("expected non-nil mechanism")
+	}
+}
+
+func TestBuildSASLMechanism_Unsupported(t *testing.T) {
+	if _, err := buildSASLMechanism(&messaging.AuthConfig{Type: messaging.AuthTypeOAuth2}); err == nil {
+		t.Fatalf("expected error for unsupported auth type")
+	}
+}
+
+func TestBuildTLSConfig_Basic(t *testing.T) {
+	cfg, err := buildTLSConfig(&messaging.TLSConfig{Enabled: true, SkipVerify: true, ServerName: "kafka.local"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatalf("expected non-nil tls config")
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=true")
+	}
+	if cfg.ServerName != "kafka.local" {
+		t.Fatalf("unexpected server name: %s", cfg.ServerName)
+	}
+}
+
+func TestMapRequiredAcks(t *testing.T) {
+	if v := mapRequiredAcks("none"); v != 0 { // kafka.RequireNone == 0
+		t.Fatalf("expected RequireNone (0), got %d", v)
+	}
+	if v := mapRequiredAcks("leader"); v != 1 { // kafka.RequireOne == 1
+		t.Fatalf("expected RequireOne (1), got %d", v)
+	}
+	if v := mapRequiredAcks("all"); v != -1 { // kafka.RequireAll == -1 in kafka-go
+		t.Fatalf("expected RequireAll (-1), got %d", v)
+	}
+}
+
+func TestMapCompression(t *testing.T) {
+	if _, ok := mapCompression(messaging.CompressionNone); ok {
+		t.Fatalf("none should not set compression option")
+	}
+	if c, ok := mapCompression(messaging.CompressionGZIP); !ok || int(c) == 0 {
+		t.Fatalf("gzip should set non-zero compression, ok=%v", ok)
+	}
+}


### PR DESCRIPTION
Implements Issue #364.\n\n- TLS/SSL and SASL (PLAIN/SCRAM) wired via kafka-go Dialer/Transport\n- Producer acks mapping (none|leader|all)\n- Compression mapping (gzip|snappy|lz4|zstd) with precedence\n- Reader/Writer factories apply security and tuning\n- Added unit tests for security mapping and options\n\nRun: make quality && make test\nCloses #364