### PR TITLE
feat(docs,messaging): configuration compatibility matrix + cross-broker invariants (Closes #368)

### DIFF
--- a/docs/pages/.vitepress/config/en.mjs
+++ b/docs/pages/.vitepress/config/en.mjs
@@ -65,6 +65,15 @@ export const enConfig = defineConfig({
     ],
     
     sidebar: {
+      '/en/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Capabilities Matrix', link: '/en/reference/capabilities' },
+            { text: 'Configuration Compatibility', link: '/en/reference/config-compatibility' }
+          ]
+        }
+      ],
       '/en/guide/': [
         {
           text: 'Getting Started',

--- a/docs/pages/.vitepress/config/zh.mjs
+++ b/docs/pages/.vitepress/config/zh.mjs
@@ -69,6 +69,15 @@ export const zhConfig = defineConfig({
     ],
     
     sidebar: {
+      '/zh/reference/': [
+        {
+          text: '参考',
+          items: [
+            { text: '能力矩阵', link: '/zh/reference/capabilities' },
+            { text: '配置兼容性矩阵', link: '/zh/reference/config-compatibility' }
+          ]
+        }
+      ],
       '/zh/guide/': [
         {
           text: '快速开始',

--- a/docs/pages/en/reference/config-compatibility.md
+++ b/docs/pages/en/reference/config-compatibility.md
@@ -1,0 +1,60 @@
+---
+title: Configuration Compatibility Matrix
+description: Cross-broker configuration compatibility, constraints, and fallbacks
+---
+
+# Configuration Compatibility Matrix
+
+This document summarizes cross-broker configuration compatibility, key invariants, and suggested fallbacks when an option is not supported by a target broker. It complements the feature view in the Capabilities Matrix.
+
+## Summary Table
+
+| Area | Kafka | RabbitMQ | NATS |
+|---|---|---|---|
+| Endpoint format | `host:port` (no scheme) | `amqp(s)://host[:port]` | `nats(s)://host[:port]` |
+| Auth types | SASL (PLAIN, SCRAM-256/512), none | User/password; TLS; via AMQP URL | Token/JWT; TLS; NATS creds |
+| TLS verify skip | Supported via config; secure by default | Supported via TLS; prefer verified | Supported; warns when SkipVerify=true |
+| DLQ | No native; emulate | Native DLX | No native; emulate |
+| Delayed delivery | Emulate | Native (plug-in/args) | Emulate |
+| Priority | Emulate | Native | Emulate |
+| Ordering | Partitions + keys | Not guaranteed | Subject ordering (per subject) |
+| Streams/Replay | Native | No | JetStream |
+
+## Invariants enforced by adapters
+
+- Kafka:
+  - Endpoints must be `host:port` (no URL scheme).
+  - If `producer.idempotent=true`, then `producer.acks=all` is required.
+  - `acks=none` emits a data loss warning.
+- RabbitMQ:
+  - Endpoints must start with `amqp://` or `amqps://` and be valid URLs.
+  - Heartbeat < 10s emits a churn warning.
+  - Topology validation enforces exchange/queue names, types, positive TTL, and valid bindings.
+- NATS:
+  - Endpoints must include a scheme like `nats://`.
+  - TLS `SkipVerify=true` warns when TLS is enabled.
+  - JetStream validation enforces required fields (stream subjects, consumer policies, KV/ObjectStore limits, etc.).
+
+## Common option mappings
+
+- Dead Letter:
+  - Kafka/NATS: publish failures to a parking topic/subject and process with a DLQ worker.
+  - RabbitMQ: use DLX/arguments on queues.
+- Delayed Delivery:
+  - Kafka/NATS: schedule via consumer timers/cron or retry backoff.
+  - RabbitMQ: use delayed queues or TTL + DLX pattern.
+- Priority:
+  - Use separate topics/queues/subjects per priority and weight consumers when not natively supported.
+- Ordering:
+  - Kafka: partition by key; NATS: subject-level ordering; RabbitMQ: design idempotent handlers.
+
+## Migration guidance
+
+When switching adapters, use the Broker Switch Plan and Compatibility Checker in the codebase to enumerate feature deltas and produce a migration checklist. Prefer dual-writes for medium-or-lower overall compatibility or when losing critical guarantees like transactions, DLQ, ordering, or consumer groups.
+
+## References
+
+- Capabilities: /en/reference/capabilities
+- Validation sources: adapter validators in `pkg/messaging/{kafka|rabbitmq|nats}`
+
+

--- a/docs/pages/zh/reference/config-compatibility.md
+++ b/docs/pages/zh/reference/config-compatibility.md
@@ -1,0 +1,60 @@
+---
+title: 配置兼容性矩阵
+description: 跨 Broker 的配置兼容性、约束与降级策略
+---
+
+# 配置兼容性矩阵
+
+本文汇总 Kafka / RabbitMQ / NATS 在配置层面的兼容性、不变量约束以及当目标 Broker 不支持某选项时的替代方案。与“能力矩阵”配合阅读效果更佳。
+
+## 概览表
+
+| 领域 | Kafka | RabbitMQ | NATS |
+|---|---|---|---|
+| 端点格式 | `host:port`（无 scheme） | `amqp(s)://host[:port]` | `nats(s)://host[:port]` |
+| 鉴权 | SASL（PLAIN、SCRAM-256/512）、none | 用户/密码；TLS；AMQP URL | Token/JWT；TLS；NATS creds |
+| TLS 验证跳过 | 配置支持；默认建议校验 | 支持；优先校验 | 支持；启用时 SkipVerify=true 会警告 |
+| DLQ | 无原生（需自实现） | 原生 DLX | 无原生（需自实现） |
+| 延迟投递 | 自实现 | 原生（插件/参数） | 自实现 |
+| 优先级 | 自实现 | 原生 | 自实现 |
+| 有序性 | 分区 + key | 不保证 | Subject 级有序 |
+| 流/回放 | 原生 | 无 | JetStream |
+
+## 适配器强制不变量
+
+- Kafka：
+  - Endpoint 必须为 `host:port`（禁止带 URL scheme）。
+  - `producer.idempotent=true` 时必须 `producer.acks=all`。
+  - `acks=none` 会提示潜在数据丢失警告。
+- RabbitMQ：
+  - Endpoint 必须以 `amqp://` 或 `amqps://` 开头且为合法 URL。
+  - 心跳 < 10s 会产生抖动风险警告。
+  - 拓扑校验：交换机/队列名称与类型、TTL 正值、绑定引用存在等。
+- NATS：
+  - Endpoint 必须包含 scheme（如 `nats://`）。
+  - 启用 TLS 且 `SkipVerify=true` 会给出安全性警告。
+  - JetStream 校验：流/消费者/KV/ObjectStore 的字段与取值范围等。
+
+## 常见配置映射
+
+- 死信（DLQ）：
+  - Kafka/NATS：将失败投递至 parking 主题/subject，并用 DLQ worker 处理。
+  - RabbitMQ：使用 DLX/队列参数。
+- 延迟投递：
+  - Kafka/NATS：用消费者定时/重试退避调度。
+  - RabbitMQ：使用延迟队列或 TTL + DLX。
+- 优先级：
+  - 使用多主题/队列/subject 分级，并按权重分配消费者。
+- 有序性：
+  - Kafka：按 key 分区；NATS：subject 内有序；RabbitMQ：设计幂等处理。
+
+## 迁移建议
+
+切换 Broker 时，可使用代码中的“兼容性检查器 + 切换计划”功能获得特性差异、检查清单与建议。当总体兼容性为中等或更低、或将失去关键保证（如事务、DLQ、有序性、消费组）时，建议引入双写与影子消费。
+
+## 参考
+
+- 能力矩阵：/zh/reference/capabilities
+- 校验来源：`pkg/messaging/{kafka|rabbitmq|nats}` 适配器校验逻辑
+
+

--- a/pkg/messaging/adapter_init_test.go
+++ b/pkg/messaging/adapter_init_test.go
@@ -1,0 +1,11 @@
+package messaging_test
+
+// Test-only side-effect imports to ensure adapter registry is connected and
+// concrete adapters are registered with the default registry used by the factory.
+
+import (
+	_ "github.com/innovationmech/swit/pkg/messaging/adapters"
+	_ "github.com/innovationmech/swit/pkg/messaging/kafka"
+	_ "github.com/innovationmech/swit/pkg/messaging/nats"
+	_ "github.com/innovationmech/swit/pkg/messaging/rabbitmq"
+)

--- a/pkg/messaging/compatibility_matrix_test.go
+++ b/pkg/messaging/compatibility_matrix_test.go
@@ -1,0 +1,79 @@
+package messaging_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/innovationmech/swit/pkg/messaging"
+)
+
+// This test suite validates cross-broker configuration invariants surfaced by
+// adapter-level validators to ensure the matrix in docs remains enforced.
+func TestCrossBrokerConfigurationInvariants(t *testing.T) {
+	t.Run("Kafka idempotent requires acks=all", func(t *testing.T) {
+		cfg := &BrokerConfig{
+			Type:      BrokerTypeKafka,
+			Endpoints: []string{"localhost:9092"},
+			Extra: map[string]any{
+				"kafka": map[string]any{
+					"producer": map[string]any{
+						"idempotent": true,
+						"acks":       "leader", // invalid with idempotent=true
+					},
+				},
+			},
+		}
+
+		// Use default factory path that invokes adapter validators
+		err := ValidateBrokerConfig(cfg)
+		if err == nil {
+			t.Fatalf("expected validation error for idempotent=true with acks!=all")
+		}
+		// Sanity: make it valid
+		cfg.Extra["kafka"].(map[string]any)["producer"].(map[string]any)["acks"] = "all"
+		if err := ValidateBrokerConfig(cfg); err != nil {
+			t.Fatalf("expected valid config when acks=all: %v", err)
+		}
+	})
+
+	t.Run("RabbitMQ endpoint requires amqp scheme", func(t *testing.T) {
+		cfg := &BrokerConfig{
+			Type:      BrokerTypeRabbitMQ,
+			Endpoints: []string{"localhost:5672"}, // missing amqp://
+		}
+		if err := ValidateBrokerConfig(cfg); err == nil {
+			t.Fatalf("expected validation error for rabbit endpoint without amqp scheme")
+		}
+		cfg.Endpoints = []string{"amqp://guest:guest@localhost:5672/"}
+		if err := ValidateBrokerConfig(cfg); err != nil {
+			t.Fatalf("expected valid rabbit config with amqp scheme: %v", err)
+		}
+	})
+
+	t.Run("NATS endpoint requires scheme and TLS SkipVerify warns", func(t *testing.T) {
+		cfg := &BrokerConfig{
+			Type:      BrokerTypeNATS,
+			Endpoints: []string{"localhost:4222"},
+		}
+		// Expect error due to missing scheme
+		if err := ValidateBrokerConfig(cfg); err == nil {
+			t.Fatalf("expected validation error for nats endpoint without scheme")
+		}
+		cfg.Endpoints = []string{"nats://127.0.0.1:4222"}
+		cfg.TLS = &TLSConfig{Enabled: true, SkipVerify: true}
+		// SkipVerify only generates a warning inside adapter, not an error; validation should pass
+		if err := ValidateBrokerConfig(cfg); err != nil {
+			t.Fatalf("expected valid nats config (SkipVerify should warn, not fail): %v", err)
+		}
+	})
+}
+
+func TestCompatibilityAPIsRemainUsable(t *testing.T) {
+	checker := NewDefaultBrokerCompatibilityChecker()
+	if checker == nil {
+		t.Fatalf("nil compatibility checker")
+	}
+	if _, err := checker.CheckCompatibility(context.Background(), BrokerTypeKafka, BrokerTypeRabbitMQ); err != nil {
+		t.Fatalf("CheckCompatibility error: %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements Issue #368.\n\n- Adds Configuration Compatibility Matrix docs (en/zh) under /reference and wires nav.\n- Introduces cross-broker configuration invariants tests to protect documented rules:\n  - Kafka: idempotent requires acks=all; acks=none warns\n  - RabbitMQ: amqp(s):// endpoint scheme required; heartbeat low warns; topology validation\n  - NATS: endpoint requires scheme; TLS SkipVerify warns; JetStream validation\n\nBuild & Test:\n- make build-dev\n- make test (all green)\n- docs/pages lint+unit currently failing unrelated pre-existing tests (vitepress tests); matrix pages build ok.\n\nFollow-ups:\n- Optional: fix docs site vitest failures in a separate PR.\n