### PR TITLE
feat(security): unified TLS/SSL configuration management

### DIFF
--- a/pkg/messaging/kafka/reader_factory.go
+++ b/pkg/messaging/kafka/reader_factory.go
@@ -49,7 +49,7 @@ func newKafkaGoReader(brokerCfg *messaging.BrokerConfig, topic string, groupID s
 	// Build SASL/TLS dialer if configured
 	var dialer *kafka.Dialer
 	if brokerCfg != nil {
-		tlsConf, _ := buildTLSConfig(brokerCfg.TLS)
+		tlsConf, _ := messaging.BuildTLSConfig(brokerCfg.TLS)
 		mech, _ := buildSASLMechanism(brokerCfg.Authentication)
 		if tlsConf != nil || mech != nil || brokerCfg.Connection.Timeout > 0 {
 			d := &kafka.Dialer{

--- a/pkg/messaging/kafka/security.go
+++ b/pkg/messaging/kafka/security.go
@@ -22,10 +22,7 @@
 package kafka
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/innovationmech/swit/pkg/messaging"
 	kgo "github.com/segmentio/kafka-go"
@@ -33,42 +30,6 @@ import (
 	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/segmentio/kafka-go/sasl/scram"
 )
-
-// buildTLSConfig constructs a *tls.Config from generic messaging TLS settings.
-func buildTLSConfig(tlsCfg *messaging.TLSConfig) (*tls.Config, error) {
-	if tlsCfg == nil || !tlsCfg.Enabled {
-		return nil, nil
-	}
-
-	cfg := &tls.Config{InsecureSkipVerify: tlsCfg.SkipVerify} //nolint:gosec // allow via configuration
-	if tlsCfg.ServerName != "" {
-		cfg.ServerName = tlsCfg.ServerName
-	}
-
-	// Load client cert if provided
-	if tlsCfg.CertFile != "" && tlsCfg.KeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(tlsCfg.CertFile, tlsCfg.KeyFile)
-		if err != nil {
-			return nil, messaging.NewConfigError(fmt.Sprintf("failed to load client TLS cert/key: %v", err), err)
-		}
-		cfg.Certificates = []tls.Certificate{cert}
-	}
-
-	// Load CA if provided
-	if tlsCfg.CAFile != "" {
-		caData, err := os.ReadFile(tlsCfg.CAFile)
-		if err != nil {
-			return nil, messaging.NewConfigError(fmt.Sprintf("failed to read CA file: %v", err), err)
-		}
-		pool := x509.NewCertPool()
-		if ok := pool.AppendCertsFromPEM(caData); !ok {
-			return nil, messaging.NewConfigError("failed to append CA certificates", nil)
-		}
-		cfg.RootCAs = pool
-	}
-
-	return cfg, nil
-}
 
 // buildSASLMechanism constructs a kafka-go SASL mechanism from generic auth config.
 func buildSASLMechanism(auth *messaging.AuthConfig) (sasl.Mechanism, error) {

--- a/pkg/messaging/kafka/security_test.go
+++ b/pkg/messaging/kafka/security_test.go
@@ -79,7 +79,7 @@ func TestBuildSASLMechanism_Unsupported(t *testing.T) {
 }
 
 func TestBuildTLSConfig_Basic(t *testing.T) {
-	cfg, err := buildTLSConfig(&messaging.TLSConfig{Enabled: true, SkipVerify: true, ServerName: "kafka.local"})
+	cfg, err := messaging.BuildTLSConfig(&messaging.TLSConfig{Enabled: true, SkipVerify: true, ServerName: "kafka.local"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/messaging/kafka/writer_factory.go
+++ b/pkg/messaging/kafka/writer_factory.go
@@ -76,7 +76,7 @@ func wireDefaultWriterFactory() {
 		// Build optional transport with TLS/SASL
 		var transport *kafka.Transport
 		if brokerCfg != nil {
-			tlsConf, _ := buildTLSConfig(brokerCfg.TLS)
+			tlsConf, _ := messaging.BuildTLSConfig(brokerCfg.TLS)
 			mech, _ := buildSASLMechanism(brokerCfg.Authentication)
 			if tlsConf != nil || mech != nil {
 				transport = &kafka.Transport{TLS: tlsConf, SASL: mech}

--- a/pkg/messaging/tls_config.go
+++ b/pkg/messaging/tls_config.go
@@ -1,0 +1,67 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package messaging
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// BuildTLSConfig constructs a *tls.Config from TLS settings.
+// Returns nil when settings are nil or disabled.
+func BuildTLSConfig(settings *TLSConfig) (*tls.Config, error) {
+	if settings == nil || !settings.Enabled {
+		return nil, nil
+	}
+
+	cfg := &tls.Config{InsecureSkipVerify: settings.SkipVerify} // nolint:gosec // explicitly controlled via configuration
+
+	if settings.ServerName != "" {
+		cfg.ServerName = settings.ServerName
+	}
+
+	// Load client certificate for mTLS if provided
+	if settings.CertFile != "" && settings.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(settings.CertFile, settings.KeyFile)
+		if err != nil {
+			return nil, NewConfigError(fmt.Sprintf("failed to load client TLS cert/key: %v", err), err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	// Load custom CA bundle if provided
+	if settings.CAFile != "" {
+		caData, err := os.ReadFile(settings.CAFile)
+		if err != nil {
+			return nil, NewConfigError(fmt.Sprintf("failed to read CA file: %v", err), err)
+		}
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM(caData); !ok {
+			return nil, NewConfigError("failed to append CA certificates", nil)
+		}
+		cfg.RootCAs = pool
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
Implements unified TLS/SSL configuration per #369.\n\n- Add generic `messaging.BuildTLSConfig`\n- Integrate with Kafka writer/reader, NATS broker, RabbitMQ connection pool\n- Preserve adapter-specific toggles (e.g., NATS insecure skip)\n- Update tests (Kafka TLS builder)\n\nCloses #369