### PR TITLE
feat(config): add AccessControlConfig with validation and docs

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -133,6 +133,8 @@ type ServerConfig struct {
     ShutdownTimeout time.Duration     `yaml:"shutdown_timeout"`
     Discovery       DiscoveryConfig   `yaml:"discovery"`
     Middleware      MiddlewareConfig  `yaml:"middleware"`
+    Messaging       MessagingConfig   `yaml:"messaging"`
+    AccessControl   AccessControlConfig `yaml:"access_control"`
 }
 ```
 
@@ -491,6 +493,74 @@ type GRPCTLSConfig struct {
     CAFile     string `yaml:"ca_file"`
     ServerName string `yaml:"server_name"`
 }
+```
+
+## AccessControlConfig
+
+Role-Based Access Control (RBAC) configuration for services.
+
+```go
+type AccessControlConfig struct {
+    Enabled           bool                          `yaml:"enabled"`
+    StrictMode        bool                          `yaml:"strict_mode"`
+    SuperAdminRole    string                        `yaml:"super_admin_role"`
+    DefaultRoles      []string                      `yaml:"default_roles"`
+    ResourceSeparator string                        `yaml:"resource_separator"`
+    Permissions       map[string]PermissionDefinition `yaml:"permissions"`
+    Roles             map[string]RoleDefinition       `yaml:"roles"`
+}
+
+type PermissionDefinition struct {
+    Description string `yaml:"description"`
+    Resource    string `yaml:"resource"`
+    Action      string `yaml:"action"`
+    IsSystem    bool   `yaml:"is_system"`
+}
+
+type RoleDefinition struct {
+    Description string   `yaml:"description"`
+    Permissions []string `yaml:"permissions"`
+    Inherits    []string `yaml:"inherits"`
+    IsSystem    bool     `yaml:"is_system"`
+}
+```
+
+### AccessControl Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Enabled` | `bool` | `false` | Enable RBAC configuration validation |
+| `StrictMode` | `bool` | `false` | Enforce strict validation at startup |
+| `SuperAdminRole` | `string` | `""` | Role that has all permissions |
+| `DefaultRoles` | `[]string` | `[]` | Roles assigned to new identities |
+| `ResourceSeparator` | `string` | `":"` | Separator for inline permissions (e.g., `orders:read`) |
+| `Permissions` | `map[string]PermissionDefinition` | `{}` | Registry of named permissions |
+| `Roles` | `map[string]RoleDefinition` | `{}` | Registry of roles with permissions and inheritance |
+
+### AccessControl Example
+
+```yaml
+access_control:
+  enabled: true
+  strict_mode: true
+  super_admin_role: "admin"
+  default_roles: ["reader"]
+  resource_separator: ":"
+  permissions:
+    orders_read:
+      description: "Read orders"
+      resource: "orders"
+      action: "read"
+  roles:
+    reader:
+      description: "Read-only"
+      permissions: ["orders_read", "inventory:read"]
+      inherits: []
+    admin:
+      description: "Administrator"
+      permissions: ["*"]
+      inherits: ["reader"]
+      is_system: true
 ```
 
 #### GRPCTLSConfig Fields

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -92,6 +92,12 @@ func TestNewServerConfig(t *testing.T) {
 	assert.Equal(t, []float64{0.001, 0.01, 0.1, 0.5, 1, 2.5, 5, 10}, config.Prometheus.Buckets.Duration)
 	assert.Equal(t, []float64{100, 1000, 10000, 100000, 1000000}, config.Prometheus.Buckets.Size)
 	assert.NotNil(t, config.Prometheus.Labels)
+
+	// AccessControl defaults
+	assert.False(t, config.AccessControl.Enabled)
+	assert.Equal(t, ":", config.AccessControl.ResourceSeparator)
+	assert.NotNil(t, config.AccessControl.Permissions)
+	assert.NotNil(t, config.AccessControl.Roles)
 }
 
 func TestServerConfig_SetDefaults(t *testing.T) {
@@ -271,6 +277,15 @@ func TestServerConfig_SetDefaults(t *testing.T) {
 					},
 					Labels:           make(map[string]string),
 					CardinalityLimit: 10000,
+				},
+				AccessControl: AccessControlConfig{
+					Enabled:           false,
+					StrictMode:        false,
+					SuperAdminRole:    "",
+					DefaultRoles:      nil,
+					ResourceSeparator: ":",
+					Permissions:       map[string]PermissionDefinition{},
+					Roles:             map[string]RoleDefinition{},
 				},
 				Tracing: tracing.TracingConfig{
 					Enabled:     false,
@@ -480,6 +495,15 @@ func TestServerConfig_SetDefaults(t *testing.T) {
 					},
 					Labels:           make(map[string]string),
 					CardinalityLimit: 10000,
+				},
+				AccessControl: AccessControlConfig{
+					Enabled:           false,
+					StrictMode:        false,
+					SuperAdminRole:    "",
+					DefaultRoles:      nil,
+					ResourceSeparator: ":",
+					Permissions:       map[string]PermissionDefinition{},
+					Roles:             map[string]RoleDefinition{},
 				},
 				Tracing: tracing.TracingConfig{
 					Enabled:     false,

--- a/swit.yaml
+++ b/swit.yaml
@@ -115,5 +115,34 @@ messaging:
     health_check_enabled: true
     health_check_interval: "30s"
 
+# Access Control (RBAC) Configuration
+access_control:
+  enabled: false
+  strict_mode: false
+  super_admin_role: ""
+  default_roles: []
+  resource_separator: ":"
+
+  # Define permissions registry (optional). You can also reference inline patterns like "orders:read"
+  permissions:
+    # example_view:
+    #   description: "View example resource"
+    #   resource: "example"
+    #   action: "view"
+    #   is_system: true
+
+  # Define roles and their permissions (names or inline patterns) and inheritance
+  roles:
+    # reader:
+    #   description: "Read-only access"
+    #   permissions: ["example:view", "orders:read"]
+    #   inherits: []
+    #   is_system: false
+    # admin:
+    #   description: "Administrator"
+    #   permissions: ["*"]  # Grant via inline wildcard patterns if your enforcement supports it
+    #   inherits: ["reader"]
+    #   is_system: true
+
 serviceDiscovery:
   address: "localhost:8500"


### PR DESCRIPTION
Implements RBAC access control configuration per #372.\n\n- Adds `AccessControlConfig` with roles/permissions, validation, and defaults\n- Updates `swit.yaml` example and docs\n- Adds unit tests for defaults\n\nCloses #372