### PR TITLE
docs: deployment-specific configuration examples (Docker/K8s) [#384]

### DIFF
--- a/docs/pages/.vitepress/config/en.mjs
+++ b/docs/pages/.vitepress/config/en.mjs
@@ -97,7 +97,8 @@ export const enConfig = defineConfig({
             { text: 'Error Monitoring', link: '/en/guide/monitoring' },
             { text: 'Performance Monitoring', link: '/en/guide/performance' },
             { text: 'Service Discovery', link: '/en/guide/service-discovery' },
-            { text: 'Testing', link: '/en/guide/testing' }
+            { text: 'Testing', link: '/en/guide/testing' },
+            { text: 'Deployment Examples', link: '/en/guide/deployment-examples' }
           ]
         },
         {

--- a/docs/pages/.vitepress/config/zh.mjs
+++ b/docs/pages/.vitepress/config/zh.mjs
@@ -101,7 +101,8 @@ export const zhConfig = defineConfig({
             { text: '错误监控', link: '/zh/guide/monitoring' },
             { text: '性能监控', link: '/zh/guide/performance' },
             { text: '服务发现', link: '/zh/guide/service-discovery' },
-            { text: '测试', link: '/zh/guide/testing' }
+            { text: '测试', link: '/zh/guide/testing' },
+            { text: '部署示例', link: '/zh/guide/deployment-examples' }
           ]
         },
         {

--- a/docs/pages/en/guide/deployment-examples.md
+++ b/docs/pages/en/guide/deployment-examples.md
@@ -1,0 +1,182 @@
+---
+title: Deployment-Specific Configuration Examples
+outline: deep
+---
+
+# Deployment-Specific Configuration Examples
+
+This guide provides production-oriented configuration examples for running Swit services across different environments, with a focus on Docker and Kubernetes. It also shows environment-specific overrides and security/performance best practices.
+
+Useful reference files:
+
+- Example configs: `examples/deployment-config-examples.yaml`
+- Service configs: `swit.yaml`, `switauth.yaml`
+- K8s templates: `deployments/k8s/*.yaml`
+- Docker compose: `deployments/docker/docker-compose.yml`
+
+## Environment Strategy
+
+We recommend a layered configuration approach:
+
+1. Base defaults checked into VCS (`swit.yaml` / `switauth.yaml`)
+2. Per-environment overlays (`swit.dev.yaml`, `swit.prod.yaml`)
+3. Secrets via environment variables or secret managers
+
+See consolidated examples in `examples/deployment-config-examples.yaml`.
+
+## Docker Examples
+
+### 1) Container-Friendly Settings
+
+```yaml
+# swit.docker.yaml (excerpt)
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+messaging:
+  enabled: true
+  default_broker: "local"
+  connection:
+    timeout: "20s"
+    retry_interval: "3s"
+  security:
+    enable_encryption: false
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger:14268/api/traces" # container name on the same network
+```
+
+### 2) Docker Compose Service
+
+```yaml
+# docker-compose.override.yml (service layer)
+services:
+  swit-serve:
+    image: swit-serve:latest
+    ports:
+      - "9000:9000"
+    environment:
+      SWIT_TRACING_EXPORTER_ENDPOINT: http://jaeger:14268/api/traces
+      SWIT_MESSAGING_ENABLED: "true"
+    volumes:
+      - ./swit.docker.yaml:/app/config/swit.yaml:ro
+    depends_on:
+      - jaeger
+```
+
+### 3) Security & Performance Tips
+
+- TLS termination at ingress/reverse-proxy (Caddy/NGINX/Traefik)
+- Restrict CORS origins; avoid wildcards in production
+- Set CPU/memory limits in orchestrator (Compose profiles or K8s)
+- Use `GODEBUG=madvdontneed=1` for memory reuse under pressure
+
+## Kubernetes Examples
+
+### 1) ConfigMap and Secret
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: swit-config
+data:
+  swit.yaml: |
+    server:
+      http:
+        enabled: true
+        port: "9000"
+    messaging:
+      enabled: true
+      default_broker: "local"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: swit-secrets
+type: Opaque
+stringData:
+  SWIT_DB_PASSWORD: "change-me"
+```
+
+### 2) Deployment with Probes and Resources
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swit-serve
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: swit-serve
+  template:
+    metadata:
+      labels:
+        app: swit-serve
+    spec:
+      containers:
+        - name: swit-serve
+          image: swit-serve:latest
+          ports:
+            - containerPort: 9000
+          envFrom:
+            - secretRef: { name: swit-secrets }
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+          readinessProbe:
+            httpGet: { path: /health, port: 9000 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 9000 }
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: config
+          configMap:
+            name: swit-config
+```
+
+### 3) Production Checklist
+
+- Configure PodDisruptionBudget and HPA
+- Enable TLS (mTLS if applicable) and service mesh policies if used
+- Lock down network policies per namespace
+- Define SLOs and alerts (readiness latency, error ratio)
+
+## Environment Overrides
+
+Example overlay pairs included in `examples/deployment-config-examples.yaml`:
+
+- `swit.dev.yaml` vs `swit.prod.yaml`
+- `switauth.dev.yaml` vs `switauth.prod.yaml`
+
+Key differences typically include:
+
+- Log verbosity, sampling rates, and tracing exporters
+- Broker endpoints (localhost/docker network vs managed services)
+- TLS and authentication settings
+- Connection pools and timeouts
+
+## Where to Go Next
+
+- Detailed config reference: `/en/guide/configuration-reference`
+- Capabilities matrix: `/en/reference/capabilities`
+- Adapter switching guide: `/en/guide/messaging-adapter-switching`
+
+

--- a/docs/pages/package.json
+++ b/docs/pages/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
-    "preview": "vitepress preview",
+    "preview": "vitepress preview --port 3000",
     "generate-api-docs": "node scripts/api-docs-generator.js",
     "sync-docs": "node scripts/sync-docs.js",
     "build-all": "./scripts/build-all.sh",

--- a/docs/pages/playwright.config.ts
+++ b/docs/pages/playwright.config.ts
@@ -127,7 +127,9 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
-      NODE_ENV: 'test'
+      NODE_ENV: 'test',
+      // Force root base during E2E to avoid GitHub Pages base path
+      VITEPRESS_BASE: '/'
     }
   },
 

--- a/docs/pages/tests/e2e-results/.last-run.json
+++ b/docs/pages/tests/e2e-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/docs/pages/tests/e2e/deployment-examples.test.ts
+++ b/docs/pages/tests/e2e/deployment-examples.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Deployment Examples Pages', () => {
+  test('English page is accessible and has key sections', async ({ page }) => {
+    await page.goto('/en/guide/deployment-examples')
+    await expect(page.getByRole('heading', { level: 1, name: /Deployment/i })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 2, name: /Docker Examples/ })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 2, name: /Kubernetes Examples/ })).toBeVisible()
+  })
+
+  test('Chinese page is accessible and has key sections', async ({ page }) => {
+    await page.goto('/zh/guide/deployment-examples')
+    await expect(page.getByRole('heading', { level: 1, name: /部署场景配置示例/ })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 2, name: /Docker 示例/ })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 2, name: /Kubernetes 示例/ })).toBeVisible()
+  })
+})
+
+

--- a/docs/pages/tests/e2e/global-setup.ts
+++ b/docs/pages/tests/e2e/global-setup.ts
@@ -18,17 +18,11 @@ async function globalSetup(config: FullConfig) {
     mkdirSync(e2eResultsDir, { recursive: true })
   }
 
-  // 确保静态资源准备就绪
+  // 由 Playwright webServer 负责构建与预览，此处不再执行构建以避免与预览进程的产物竞争
   try {
-    console.log('📦 Building project for E2E tests...')
-    execSync('npm run build', { 
-      stdio: 'inherit',
-      timeout: 300000 // 5分钟超时
-    })
-    console.log('✅ Build completed successfully')
+    console.log('🧭 Skipping build in global setup (handled by webServer)')
   } catch (error) {
-    console.error('❌ Build failed:', error)
-    process.exit(1)
+    console.warn('⚠️  Setup note:', (error as Error).message)
   }
 
   // 预热服务器 - 确保第一个测试运行时服务器已就绪
@@ -67,7 +61,9 @@ async function globalSetup(config: FullConfig) {
       '/zh/',
       '/en/guide/getting-started',
       '/en/api/',
-      '/en/examples/'
+      '/en/examples/',
+      '/en/guide/deployment-examples',
+      '/zh/guide/deployment-examples'
     ]
 
     console.log('🔄 Preloading critical pages...')

--- a/docs/pages/tests/reports/playwright-results.json
+++ b/docs/pages/tests/reports/playwright-results.json
@@ -1,0 +1,364 @@
+{
+  "config": {
+    "configFile": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/playwright.config.ts",
+    "rootDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+    "forbidOnly": false,
+    "fullyParallel": true,
+    "globalSetup": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e/global-setup.ts",
+    "globalTeardown": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e/global-teardown.ts",
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "Test Environment": "development",
+      "Base URL": "http://localhost:3000",
+      "Test Framework": "Playwright",
+      "CI": "false",
+      "actualWorkers": 2
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "html",
+        {
+          "outputFolder": "tests/reports/playwright-report"
+        }
+      ],
+      [
+        "json",
+        {
+          "outputFile": "tests/reports/playwright-results.json"
+        }
+      ],
+      [
+        "junit",
+        {
+          "outputFile": "tests/reports/playwright-results.xml"
+        }
+      ],
+      [
+        "list",
+        null
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "chromium",
+        "name": "chromium",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "firefox",
+        "name": "firefox",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "webkit",
+        "name": "webkit",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "Mobile Chrome",
+        "name": "Mobile Chrome",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "Mobile Safari",
+        "name": "Mobile Safari",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "iPad",
+        "name": "iPad",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "High DPI",
+        "name": "High DPI",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "Dark Mode",
+        "name": "Dark Mode",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "No JavaScript",
+        "name": "No JavaScript",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      },
+      {
+        "outputDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "Test Environment": "development",
+          "Base URL": "http://localhost:3000",
+          "Test Framework": "Playwright",
+          "CI": "false",
+          "actualWorkers": 2
+        },
+        "id": "Slow Network",
+        "name": "Slow Network",
+        "testDir": "/Users/liyanjie/VSCodeProjects/swit/docs/pages/tests/e2e",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 60000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.54.2",
+    "workers": 7,
+    "webServer": {
+      "command": "npm run build && npm run preview",
+      "port": 3000,
+      "reuseExistingServer": true,
+      "timeout": 120000,
+      "env": {
+        "NODE_ENV": "test",
+        "VITEPRESS_BASE": "/"
+      }
+    }
+  },
+  "suites": [
+    {
+      "title": "deployment-examples.test.ts",
+      "file": "deployment-examples.test.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Deployment Examples Pages",
+          "file": "deployment-examples.test.ts",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "English page is accessible and has key sections",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 425,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-27T15:08:55.950Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d463aefae151d34cd3b1-9a12976fc04e4f793c8f",
+              "file": "deployment-examples.test.ts",
+              "line": 4,
+              "column": 7
+            },
+            {
+              "title": "Chinese page is accessible and has key sections",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 60000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 424,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2025-09-27T15:08:55.948Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d463aefae151d34cd3b1-d9b3486f660e62802f78",
+              "file": "deployment-examples.test.ts",
+              "line": 11,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2025-09-27T15:08:39.013Z",
+    "duration": 17502.583,
+    "expected": 2,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  }
+}

--- a/docs/pages/tests/reports/playwright-results.xml
+++ b/docs/pages/tests/reports/playwright-results.xml
@@ -1,0 +1,8 @@
+<testsuites id="" name="" tests="2" failures="0" skipped="0" errors="0" time="17.502582999999998">
+<testsuite name="deployment-examples.test.ts" timestamp="2025-09-27T15:08:55.679Z" hostname="chromium" tests="2" failures="0" skipped="0" time="0.849" errors="0">
+<testcase name="Deployment Examples Pages › English page is accessible and has key sections" classname="deployment-examples.test.ts" time="0.425">
+</testcase>
+<testcase name="Deployment Examples Pages › Chinese page is accessible and has key sections" classname="deployment-examples.test.ts" time="0.424">
+</testcase>
+</testsuite>
+</testsuites>

--- a/docs/pages/tests/reports/setup-info.json
+++ b/docs/pages/tests/reports/setup-info.json
@@ -1,0 +1,5 @@
+{
+  "timestamp": "2025-09-27T15:08:55.625Z",
+  "baseUrl": "http://localhost:3000",
+  "ci": false
+}

--- a/docs/pages/tests/reports/test-summary.json
+++ b/docs/pages/tests/reports/test-summary.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2025-09-27T15:08:56.509Z",
+  "environment": {
+    "ci": false,
+    "baseUrl": "http://localhost:3000"
+  },
+  "teardownCompleted": true,
+  "testResults": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "duration": 16999.333
+  }
+}

--- a/docs/pages/zh/guide/deployment-examples.md
+++ b/docs/pages/zh/guide/deployment-examples.md
@@ -1,0 +1,182 @@
+---
+title: 部署场景配置示例
+outline: deep
+---
+
+# 部署场景配置示例
+
+本文档提供面向生产的 Swit 服务部署配置示例，覆盖 Docker 与 Kubernetes，并展示按环境覆盖、以及安全与性能的最佳实践。
+
+相关参考：
+
+- 示例配置：`examples/deployment-config-examples.yaml`
+- 服务配置：`swit.yaml`、`switauth.yaml`
+- K8s 模板：`deployments/k8s/*.yaml`
+- Docker 组合：`deployments/docker/docker-compose.yml`
+
+## 环境分层策略
+
+推荐采用分层配置：
+
+1. 基础默认（纳入版本库）：`swit.yaml` / `switauth.yaml`
+2. 按环境覆盖：`swit.dev.yaml`、`swit.prod.yaml`
+3. 机密通过环境变量或密钥管理器注入
+
+综合示例见 `examples/deployment-config-examples.yaml`。
+
+## Docker 示例
+
+### 1) 容器友好配置
+
+```yaml
+# swit.docker.yaml（片段）
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+messaging:
+  enabled: true
+  default_broker: "local"
+  connection:
+    timeout: "20s"
+    retry_interval: "3s"
+  security:
+    enable_encryption: false
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger:14268/api/traces" # 同网段容器名
+```
+
+### 2) Docker Compose 服务
+
+```yaml
+# docker-compose.override.yml（服务层）
+services:
+  swit-serve:
+    image: swit-serve:latest
+    ports:
+      - "9000:9000"
+    environment:
+      SWIT_TRACING_EXPORTER_ENDPOINT: http://jaeger:14268/api/traces
+      SWIT_MESSAGING_ENABLED: "true"
+    volumes:
+      - ./swit.docker.yaml:/app/config/swit.yaml:ro
+    depends_on:
+      - jaeger
+```
+
+### 3) 安全与性能要点
+
+- 在入口或反向代理（Caddy/NGINX/Traefik）终止 TLS
+- 生产环境限制 CORS 源；避免通配符
+- 在编排层设定 CPU/内存限制（Compose profiles 或 K8s）
+- 在压力场景使用 `GODEBUG=madvdontneed=1` 改善内存重用
+
+## Kubernetes 示例
+
+### 1) ConfigMap 与 Secret
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: swit-config
+data:
+  swit.yaml: |
+    server:
+      http:
+        enabled: true
+        port: "9000"
+    messaging:
+      enabled: true
+      default_broker: "local"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: swit-secrets
+type: Opaque
+stringData:
+  SWIT_DB_PASSWORD: "change-me"
+```
+
+### 2) 带探针与资源配额的 Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swit-serve
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: swit-serve
+  template:
+    metadata:
+      labels:
+        app: swit-serve
+    spec:
+      containers:
+        - name: swit-serve
+          image: swit-serve:latest
+          ports:
+            - containerPort: 9000
+          envFrom:
+            - secretRef: { name: swit-secrets }
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+          readinessProbe:
+            httpGet: { path: /health, port: 9000 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 9000 }
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: config
+          configMap:
+            name: swit-config
+```
+
+### 3) 生产清单
+
+- 配置 PodDisruptionBudget 与 HPA
+- 若使用网格，开启 TLS/mTLS 与策略
+- 使用每命名空间的网络策略限制流量
+- 定义 SLO 与告警（就绪延迟、错误比率）
+
+## 环境覆盖
+
+`examples/deployment-config-examples.yaml` 中包含以下覆盖示例：
+
+- `swit.dev.yaml` vs `swit.prod.yaml`
+- `switauth.dev.yaml` vs `switauth.prod.yaml`
+
+典型差异：
+
+- 日志级别、采样率、追踪导出器
+- Broker 端点（本地/容器网络 vs 托管服务）
+- TLS 与认证配置
+- 连接池与超时
+
+## 下一步
+
+- 配置参考：`/zh/guide/configuration-reference`
+- 能力矩阵：`/zh/reference/capabilities`
+- 适配器切换：`/zh/guide/messaging-adapter-switching`
+
+

--- a/examples/deployment-config-examples.yaml
+++ b/examples/deployment-config-examples.yaml
@@ -1,0 +1,84 @@
+# Consolidated deployment configuration examples
+
+---
+# swit.dev.yaml - development defaults
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+tracing:
+  enabled: true
+  sampling:
+    type: "traceidratio"
+    rate: 1.0
+  exporter:
+    type: "jaeger"
+    endpoint: "http://localhost:14268/api/traces"
+
+messaging:
+  enabled: false
+  default_broker: "local"
+  connection:
+    timeout: "30s"
+    retry_interval: "5s"
+    max_attempts: 3
+
+---
+# swit.prod.yaml - production overlay
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+tracing:
+  enabled: true
+  sampling:
+    type: "traceidratio"
+    rate: 0.2
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger-collector:14268/api/traces"
+
+messaging:
+  enabled: true
+  default_broker: "local"
+  connection:
+    timeout: "20s"
+    retry_interval: "3s"
+    max_attempts: 5
+  security:
+    enable_encryption: true
+    enable_authentication: true
+
+---
+# switauth.dev.yaml
+server:
+  http:
+    enabled: true
+    port: "9001"
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://localhost:14268/api/traces"
+
+---
+# switauth.prod.yaml
+server:
+  http:
+    enabled: true
+    port: "9001"
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger-collector:14268/api/traces"
+
+security:
+  cookie_secure: true
+  csrf_enabled: true
+
+


### PR DESCRIPTION
Adds deployment-specific configuration examples with Docker and Kubernetes sections, environment overlays, and best practices. Includes:

- New pages: en/zh 
- Consolidated examples: 
- E2E coverage for new pages (Playwright)
- Navigation updates (EN/ZH)

Closes #384

---
Checklist:
- [x] Lint & unit tests pass
- [x] E2E for new pages (Chromium)
- [x] Make quality & make test pass
