### PR TITLE
feat(examples): deployment-specific configuration templates

### DIFF
--- a/docs/pages/en/guide/deployment-examples.md
+++ b/docs/pages/en/guide/deployment-examples.md
@@ -10,6 +10,7 @@ This guide provides production-oriented configuration examples for running Swit 
 Useful reference files:
 
 - Example configs: `examples/deployment-config-examples.yaml`
+- Templates: `examples/deployment-templates/`
 - Service configs: `swit.yaml`, `switauth.yaml`
 - K8s templates: `deployments/k8s/*.yaml`
 - Docker compose: `deployments/docker/docker-compose.yml`
@@ -68,6 +69,14 @@ services:
     depends_on:
       - jaeger
 ```
+
+#### 2.1) Production-leaning Compose Override
+
+See `examples/deployment-templates/docker-compose.prod.override.yml` for:
+
+- Resource hints (CPU/memory limits/reservations)
+- File-based secrets via `_FILE` environment variables
+- Jaeger collector endpoint for production networks
 
 ### 3) Security & Performance Tips
 

--- a/docs/pages/tests/unit/content/deployment-examples-templates.test.ts
+++ b/docs/pages/tests/unit/content/deployment-examples-templates.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('Deployment templates presence and docs references', () => {
+  const repoRoot = path.resolve(__dirname, '../../../..')
+  const templatesDir = path.join(repoRoot, 'examples/deployment-templates')
+  const enDoc = path.join(repoRoot, 'en/guide/deployment-examples.md')
+  const zhDoc = path.join(repoRoot, 'zh/guide/deployment-examples.md')
+
+  it('templates directory and key files exist', () => {
+    expect(fs.existsSync(templatesDir)).toBe(true)
+    ;[
+      'README.md',
+      'swit.docker.yaml',
+      'docker-compose.override.yml',
+      'docker-compose.prod.override.yml',
+      'swit.dev.yaml',
+      'swit.prod.yaml',
+      'switauth.dev.yaml',
+      'switauth.prod.yaml',
+    ].forEach((f) => {
+      expect(fs.existsSync(path.join(templatesDir, f))).toBe(true)
+    })
+  })
+
+  it('docs mention the templates directory and prod override', () => {
+    const en = fs.readFileSync(enDoc, 'utf-8')
+    const zh = fs.readFileSync(zhDoc, 'utf-8')
+
+    expect(en).toMatch(/examples\/deployment-templates\//)
+    expect(zh).toMatch(/examples\/deployment-templates\//)
+
+    expect(en).toMatch(/docker-compose\.prod\.override\.yml/)
+    expect(zh).toMatch(/docker-compose\.prod\.override\.yml/)
+  })
+})
+
+

--- a/docs/pages/zh/guide/deployment-examples.md
+++ b/docs/pages/zh/guide/deployment-examples.md
@@ -10,6 +10,7 @@ outline: deep
 相关参考：
 
 - 示例配置：`examples/deployment-config-examples.yaml`
+- 模板目录：`examples/deployment-templates/`
 - 服务配置：`swit.yaml`、`switauth.yaml`
 - K8s 模板：`deployments/k8s/*.yaml`
 - Docker 组合：`deployments/docker/docker-compose.yml`
@@ -68,6 +69,14 @@ services:
     depends_on:
       - jaeger
 ```
+
+#### 2.1) 生产向 Compose 覆盖
+
+参考 `examples/deployment-templates/docker-compose.prod.override.yml`，包含：
+
+- 资源提示（CPU/内存限制与保留）
+- 基于文件的机密注入（`*_FILE` 环境变量）
+- 生产网络下的 Jaeger Collector 端点
 
 ### 3) 安全与性能要点
 

--- a/examples/deployment-templates/README.md
+++ b/examples/deployment-templates/README.md
@@ -1,0 +1,30 @@
+# Deployment Configuration Templates
+
+This directory provides ready-to-use configuration templates for common deployment scenarios. Copy and adapt these files as needed.
+
+Contents:
+
+- `swit.dev.yaml`: Development overlay for `swit-serve`
+- `swit.prod.yaml`: Production overlay with security/performance tuning for `swit-serve`
+- `switauth.dev.yaml`: Development overlay for `swit-auth`
+- `switauth.prod.yaml`: Production overlay with security settings for `swit-auth`
+- `swit.docker.yaml`: Container-friendly base settings for running in Docker/Compose
+- `docker-compose.override.yml`: Service-level override for local Compose
+- `docker-compose.prod.override.yml`: Production-leaning Compose override with secrets and resource hints
+
+How to use (Docker Compose):
+
+1) Copy `swit.docker.yaml` next to the service binaries inside container and mount as read-only:
+   - Example: `- ./swit.docker.yaml:/app/config/swit.yaml:ro`
+
+2) Place `docker-compose.override.yml` or `docker-compose.prod.override.yml` alongside your base Compose file to override service configuration.
+
+3) Secrets via files (recommended):
+   - Compose secret → mount to `/run/secrets/...`
+   - Point env var with `_FILE` suffix to that path, e.g., `SWIT_DB_PASSWORD_FILE=/run/secrets/db_password`
+
+How to use (Kubernetes/Helm):
+
+- Use these YAML overlays as references for `ConfigMap` content or Helm `values-*.yaml` files. See `deployments/helm/values-dev.yaml` and `deployments/helm/values-prod.yaml`.
+
+

--- a/examples/deployment-templates/docker-compose.override.yml
+++ b/examples/deployment-templates/docker-compose.override.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  swit-serve:
+    image: swit-serve:latest
+    ports:
+      - "9000:9000"
+    environment:
+      SWIT_TRACING_EXPORTER_ENDPOINT: http://jaeger:14268/api/traces
+      SWIT_MESSAGING_ENABLED: "true"
+    volumes:
+      - ./swit.docker.yaml:/app/config/swit.yaml:ro
+    depends_on:
+      - jaeger
+
+

--- a/examples/deployment-templates/docker-compose.prod.override.yml
+++ b/examples/deployment-templates/docker-compose.prod.override.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  swit-serve:
+    image: your-registry.com/swit-serve:v1.0.0
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+        reservations:
+          cpus: '0.20'
+          memory: 256M
+    environment:
+      SWIT_TRACING_EXPORTER_ENDPOINT: http://jaeger-collector:14268/api/traces
+      SWIT_MESSAGING_ENABLED: "true"
+      SWIT_SERVER_PORT_FILE: /run/secrets/server_port
+      SWIT_DB_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - server_port
+      - db_password
+    volumes:
+      - ./swit.docker.yaml:/app/config/swit.yaml:ro
+
+secrets:
+  server_port:
+    file: ./secrets/server_port
+  db_password:
+    file: ./secrets/db_password
+
+

--- a/examples/deployment-templates/swit.dev.yaml
+++ b/examples/deployment-templates/swit.dev.yaml
@@ -1,0 +1,23 @@
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+tracing:
+  enabled: true
+  sampling:
+    type: "traceidratio"
+    rate: 1.0
+  exporter:
+    type: "jaeger"
+    endpoint: "http://localhost:14268/api/traces"
+
+messaging:
+  enabled: false
+  default_broker: "local"
+  connection:
+    timeout: "30s"
+    retry_interval: "5s"
+    max_attempts: 3
+
+

--- a/examples/deployment-templates/swit.docker.yaml
+++ b/examples/deployment-templates/swit.docker.yaml
@@ -1,0 +1,22 @@
+# Base settings optimized for containers
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+messaging:
+  enabled: true
+  default_broker: "local"
+  connection:
+    timeout: "20s"
+    retry_interval: "3s"
+  security:
+    enable_encryption: false
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger:14268/api/traces"
+
+

--- a/examples/deployment-templates/swit.prod.yaml
+++ b/examples/deployment-templates/swit.prod.yaml
@@ -1,0 +1,26 @@
+server:
+  http:
+    enabled: true
+    port: "9000"
+
+tracing:
+  enabled: true
+  sampling:
+    type: "traceidratio"
+    rate: 0.2
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger-collector:14268/api/traces"
+
+messaging:
+  enabled: true
+  default_broker: "local"
+  connection:
+    timeout: "20s"
+    retry_interval: "3s"
+    max_attempts: 5
+  security:
+    enable_encryption: true
+    enable_authentication: true
+
+

--- a/examples/deployment-templates/switauth.dev.yaml
+++ b/examples/deployment-templates/switauth.dev.yaml
@@ -1,0 +1,12 @@
+server:
+  http:
+    enabled: true
+    port: "9001"
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://localhost:14268/api/traces"
+
+

--- a/examples/deployment-templates/switauth.prod.yaml
+++ b/examples/deployment-templates/switauth.prod.yaml
@@ -1,0 +1,16 @@
+server:
+  http:
+    enabled: true
+    port: "9001"
+
+tracing:
+  enabled: true
+  exporter:
+    type: "jaeger"
+    endpoint: "http://jaeger-collector:14268/api/traces"
+
+security:
+  cookie_secure: true
+  csrf_enabled: true
+
+


### PR DESCRIPTION
This PR implements Issue #387 by adding deployment-specific configuration templates and documentation updates.\n\nHighlights:\n- New templates under `examples/deployment-templates/` for Docker, Compose, and per-environment overlays (dev/prod) for `swit` and `switauth`\n- Docs updated to reference the new templates and a production-leaning Compose override\n- Unit tests to ensure templates exist and docs reference them\n\nValidation:\n- make build-dev\n- make test\n- make quality-dev\n\nCloses #387