### PR TITLE
feat(middleware): chain interfaces and base executor

### DIFF
--- a/pkg/messaging/chain.go
+++ b/pkg/messaging/chain.go
@@ -1,0 +1,89 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package messaging
+
+import "sync"
+
+// HandlerChain defines an ordered collection of MessageHandler steps.
+//
+// The chain guarantees iteration order consistency (insertion order) and is
+// intended to be executed by a ChainExecutor with deterministic semantics.
+// It is separate from MiddlewareChain to represent business handler steps
+// rather than cross-cutting middleware concerns.
+type HandlerChain interface {
+	// Add appends one or more handlers to the end of the chain.
+	Add(steps ...MessageHandler)
+
+	// Prepend inserts one or more handlers at the beginning of the chain,
+	// preserving the relative order of the inserted steps.
+	Prepend(steps ...MessageHandler)
+
+	// Steps returns a snapshot copy of the handlers in order.
+	Steps() []MessageHandler
+
+	// Len returns the number of handlers in the chain.
+	Len() int
+}
+
+// DefaultHandlerChain is a threadsafe implementation of HandlerChain.
+type DefaultHandlerChain struct {
+	mu    sync.RWMutex
+	steps []MessageHandler
+}
+
+// NewHandlerChain creates a new DefaultHandlerChain with optional initial steps.
+func NewHandlerChain(steps ...MessageHandler) *DefaultHandlerChain {
+	copied := make([]MessageHandler, len(steps))
+	copy(copied, steps)
+	return &DefaultHandlerChain{steps: copied}
+}
+
+// Add appends one or more handlers to the end of the chain.
+func (c *DefaultHandlerChain) Add(steps ...MessageHandler) {
+	c.mu.Lock()
+	c.steps = append(c.steps, steps...)
+	c.mu.Unlock()
+}
+
+// Prepend inserts one or more handlers at the beginning of the chain.
+func (c *DefaultHandlerChain) Prepend(steps ...MessageHandler) {
+	c.mu.Lock()
+	c.steps = append(append([]MessageHandler(nil), steps...), c.steps...)
+	c.mu.Unlock()
+}
+
+// Steps returns a snapshot copy of the handlers in order.
+func (c *DefaultHandlerChain) Steps() []MessageHandler {
+	c.mu.RLock()
+	out := make([]MessageHandler, len(c.steps))
+	copy(out, c.steps)
+	c.mu.RUnlock()
+	return out
+}
+
+// Len returns the number of handlers in the chain.
+func (c *DefaultHandlerChain) Len() int {
+	c.mu.RLock()
+	n := len(c.steps)
+	c.mu.RUnlock()
+	return n
+}

--- a/pkg/messaging/chain_executor.go
+++ b/pkg/messaging/chain_executor.go
@@ -1,0 +1,105 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package messaging
+
+import (
+	"context"
+)
+
+// ChainExecutor defines how a HandlerChain is executed.
+//
+// The base semantics are:
+// - Deterministic ordering (chain order)
+// - Short-circuit on first error when ShortCircuit is true
+// - ErrorPolicy decides how errors are surfaced/collected
+// - Context must flow through steps
+type ChainExecutor interface {
+	// Execute runs the chain against the provided message.
+	// The executor should honor ordering and short-circuit when configured.
+	Execute(ctx context.Context, chain HandlerChain, message *Message) error
+
+	// WithOptions returns a shallow-copied executor with provided options.
+	WithOptions(opts ChainExecutorOptions) ChainExecutor
+}
+
+// ChainExecutorOptions controls execution behavior.
+type ChainExecutorOptions struct {
+	// ShortCircuit stops on first error if true.
+	ShortCircuit bool
+
+	// ErrorPolicy controls error surfacing.
+	ErrorPolicy ErrorPolicy
+}
+
+// BaseChainExecutor provides a default implementation of ChainExecutor.
+// It executes handlers sequentially, preserves order, and adheres to options.
+type BaseChainExecutor struct {
+	opts ChainExecutorOptions
+}
+
+// NewBaseChainExecutor creates a new BaseChainExecutor with defaults.
+func NewBaseChainExecutor() *BaseChainExecutor {
+	return &BaseChainExecutor{
+		opts: ChainExecutorOptions{ShortCircuit: true, ErrorPolicy: ErrorPolicyStopOnFirst},
+	}
+}
+
+// WithOptions returns a shallow-copied executor with the given options.
+func (e *BaseChainExecutor) WithOptions(opts ChainExecutorOptions) ChainExecutor {
+	cp := *e
+	cp.opts = opts
+	return &cp
+}
+
+// Execute runs the chain steps in order with ordering and error short-circuit.
+func (e *BaseChainExecutor) Execute(ctx context.Context, chain HandlerChain, message *Message) error {
+	if chain == nil || chain.Len() == 0 {
+		return nil
+	}
+
+	var collected []error
+	for _, step := range chain.Steps() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err := step.Handle(ctx, message); err != nil {
+			switch e.opts.ErrorPolicy {
+			case ErrorPolicyIgnoreErrors:
+				// swallow
+			case ErrorPolicyCollectAll:
+				collected = append(collected, err)
+			default: // ErrorPolicyStopOnFirst
+				if e.opts.ShortCircuit {
+					return err
+				}
+				collected = append(collected, err)
+			}
+		}
+	}
+
+	if len(collected) == 0 {
+		return nil
+	}
+	// For simplicity: return first error when not StopOnFirst collected earlier
+	return collected[0]
+}

--- a/pkg/messaging/chain_executor_test.go
+++ b/pkg/messaging/chain_executor_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package messaging
 
 import (

--- a/pkg/messaging/chain_executor_test.go
+++ b/pkg/messaging/chain_executor_test.go
@@ -1,0 +1,64 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stepHandler struct {
+	name string
+	cb   func(ctx context.Context, msg *Message) error
+}
+
+func (s stepHandler) Handle(ctx context.Context, message *Message) error { return s.cb(ctx, message) }
+func (s stepHandler) OnError(ctx context.Context, message *Message, err error) ErrorAction {
+	return ErrorActionRetry
+}
+
+func TestBaseChainExecutor_OrderAndShortCircuit(t *testing.T) {
+	exec := NewBaseChainExecutor()
+	chain := NewHandlerChain(
+		stepHandler{"s1", func(ctx context.Context, msg *Message) error { return nil }},
+		stepHandler{"s2", func(ctx context.Context, msg *Message) error { return errors.New("boom") }},
+		stepHandler{"s3", func(ctx context.Context, msg *Message) error { t.Fatalf("should short-circuit"); return nil }},
+	)
+
+	err := exec.Execute(context.Background(), chain, &Message{ID: "1"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestBaseChainExecutor_CollectAll(t *testing.T) {
+	exec := NewBaseChainExecutor().WithOptions(ChainExecutorOptions{ShortCircuit: false, ErrorPolicy: ErrorPolicyCollectAll})
+	chain := NewHandlerChain(
+		stepHandler{"s1", func(ctx context.Context, msg *Message) error { return errors.New("e1") }},
+		stepHandler{"s2", func(ctx context.Context, msg *Message) error { return errors.New("e2") }},
+	)
+
+	err := exec.Execute(context.Background(), chain, &Message{ID: "1"})
+	if err == nil {
+		t.Fatalf("expected aggregated error, got nil")
+	}
+}
+
+func TestBaseChainExecutor_ContextCancel(t *testing.T) {
+	exec := NewBaseChainExecutor()
+	chain := NewHandlerChain(
+		stepHandler{"s1", func(ctx context.Context, msg *Message) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}},
+		stepHandler{"s2", func(ctx context.Context, msg *Message) error { t.Fatalf("should not run"); return nil }},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := exec.Execute(ctx, chain, &Message{ID: "1"})
+	if err == nil {
+		t.Fatalf("expected context error, got nil")
+	}
+}

--- a/pkg/messaging/chain_test.go
+++ b/pkg/messaging/chain_test.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package messaging
 
 import (

--- a/pkg/messaging/chain_test.go
+++ b/pkg/messaging/chain_test.go
@@ -1,0 +1,32 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHandlerChain_AddPrependAndLen(t *testing.T) {
+	c := NewHandlerChain()
+	if c.Len() != 0 {
+		t.Fatalf("expected 0")
+	}
+
+	h1 := MessageHandlerFunc(func(ctx context.Context, m *Message) error { return nil })
+	h2 := MessageHandlerFunc(func(ctx context.Context, m *Message) error { return nil })
+	h3 := MessageHandlerFunc(func(ctx context.Context, m *Message) error { return nil })
+
+	c.Add(h1)
+	c.Add(h2)
+	if c.Len() != 2 {
+		t.Fatalf("expected 2, got %d", c.Len())
+	}
+
+	c.Prepend(h3)
+	steps := c.Steps()
+	if len(steps) != 3 {
+		t.Fatalf("expected 3, got %d", len(steps))
+	}
+	if &steps[0] == &steps[1] {
+		t.Fatalf("unexpected aliasing")
+	}
+}


### PR DESCRIPTION
Implements HandlerChain and BaseChainExecutor with ordered execution and error short-circuiting. Includes unit tests and integrates with existing middleware pipeline concepts.\n\nCloses #419