### PR TITLE
feat(integration): service registrar extensions for event handlers (design)

### DIFF
--- a/internal/switauth/adapter.go
+++ b/internal/switauth/adapter.go
@@ -90,6 +90,25 @@ func (s *ServiceRegistrar) RegisterServices(registry server.BusinessServiceRegis
 	return nil
 }
 
+// RegisterEventHandlers implements server.MessagingServiceRegistrar to support event handler registration.
+// switauth currently does not expose messaging handlers; this is a no-op implementation for future use.
+func (s *ServiceRegistrar) RegisterEventHandlers(registry server.EventHandlerRegistry) error {
+    if registry == nil {
+        return fmt.Errorf("event handler registry cannot be nil")
+    }
+    return nil
+}
+
+// GetEventHandlerMetadata returns minimal metadata for messaging capabilities of switauth.
+func (s *ServiceRegistrar) GetEventHandlerMetadata() *server.EventHandlerMetadata {
+    return &server.EventHandlerMetadata{
+        HandlerCount:       0,
+        Topics:             nil,
+        BrokerRequirements: nil,
+        Description:        "switauth has no messaging handlers currently",
+    }
+}
+
 // AuthBusinessHTTPHandler adapts the switauth auth handler to the base server BusinessHTTPHandler interface
 type AuthBusinessHTTPHandler struct {
 	handler *auth.AuthHandler

--- a/internal/switserve/adapter.go
+++ b/internal/switserve/adapter.go
@@ -142,6 +142,26 @@ func (s *ServiceRegistrar) RegisterServices(registry server.BusinessServiceRegis
 	return nil
 }
 
+// RegisterEventHandlers implements server.MessagingServiceRegistrar to support event handler registration.
+// Current service does not expose messaging handlers; provide minimal no-op to satisfy interface and enable future extension.
+func (s *ServiceRegistrar) RegisterEventHandlers(registry server.EventHandlerRegistry) error {
+    if registry == nil {
+        return fmt.Errorf("event handler registry cannot be nil")
+    }
+    // No messaging handlers yet for switserve.
+    return nil
+}
+
+// GetEventHandlerMetadata returns minimal metadata for messaging capabilities.
+func (s *ServiceRegistrar) GetEventHandlerMetadata() *server.EventHandlerMetadata {
+    return &server.EventHandlerMetadata{
+        HandlerCount:       0,
+        Topics:             nil,
+        BrokerRequirements: nil,
+        Description:        "switserve has no messaging handlers currently",
+    }
+}
+
 // GreeterBusinessHTTPHandler adapts the switserve greeter handler to the base server BusinessHTTPHandler interface
 type GreeterBusinessHTTPHandler struct {
 	handler *greeterv1.GreeterHandler


### PR DESCRIPTION
This PR implements the minimal design support for event handler registration in service registrars as requested by #420.\n\nChanges:\n- Implement  methods in  and .\n- Add no-op  and metadata stubs to enable future messaging handler integration.\n\nNotes:\n- Aligns with parent milestone #177 and depends on #173, #174, #175 (already closed).\n- No behavior change to HTTP/gRPC; safe additive API surface.\n\nChecklist:\n- [x] Build passes (🚀 快速开发构建（跳过质量检查）

[0;34m[INFO][0m 🚀 开始 SWIT 多平台构建

[0;34m[INFO][0m 检查构建依赖...
[0;34m[INFO][0m Go 版本: 1.24.4
[0;32m[SUCCESS][0m 依赖检查完成
[0;34m[INFO][0m 准备构建环境...
[0;34m[INFO][0m 运行 go mod tidy...
[0;32m[SUCCESS][0m 构建环境准备完成
[0;34m[INFO][0m 开始构建:
  服务: swit-serve swit-auth switctl
  平台: darwin/arm64

[0;34m[INFO][0m 构建 swit-serve for darwin/arm64...
[0;32m[SUCCESS][0m ✓ swit-serve (darwin/arm64) 构建完成
[0;34m[INFO][0m   文件大小:  23M
[0;34m[INFO][0m   发布文件: _output/build/swit-serve-v1.0.0-428-g5a8fd9d-darwin-arm64
[0;34m[INFO][0m 构建 swit-auth for darwin/arm64...
[0;32m[SUCCESS][0m ✓ swit-auth (darwin/arm64) 构建完成
[0;34m[INFO][0m   文件大小:  23M
[0;34m[INFO][0m   发布文件: _output/build/swit-auth-v1.0.0-428-g5a8fd9d-darwin-arm64
[0;34m[INFO][0m 构建 switctl for darwin/arm64...
[0;32m[SUCCESS][0m ✓ switctl (darwin/arm64) 构建完成
[0;34m[INFO][0m   文件大小:  12M
[0;34m[INFO][0m   发布文件: _output/build/switctl-v1.0.0-428-g5a8fd9d-darwin-arm64

[0;32m[SUCCESS][0m 🎉 所有构建任务完成！用时 2 秒

[0;34m[INFO][0m 构建总结:

[0;34m[INFO][0m 构建配置:
  版本: v1.0.0-428-g5a8fd9d
  Git提交: 5a8fd9d
  构建时间: 2025-09-29T06:37:20Z
  输出目录: _output

[0;34m[INFO][0m 构建的服务:
  swit-serve
  swit-auth
  switctl

[0;34m[INFO][0m 目标平台:
  darwin/arm64

[0;34m[INFO][0m 构建产物:
  _output/build/swit-auth-v1.0.0-277-ga42a8dd-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-397-g470c691-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-381-gb8db415-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-313-g28ee0e5-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-303-ga9cf97b-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-422-ga733d9f-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-338-g362c6e1-dirty-darwin-arm64 ( 11M)
  _output/build/switctl-v1.0.0-405-g0d4c4d4-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-362-g449b46a-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-383-g10067e2-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-364-g8676ec6-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-378-gde0ba58-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-217-g27d8dfb-dirty-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-400-g0860d3d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-373-ga924fd7-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-300-gec33594-dirty-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-291-gf056804-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-427-ge83356d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-287-g51a9870-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-344-gf359cbf-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-264-g94463b4-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-407-gb0ecef1-dirty-darwin-arm64 ( 12M)
  _output/build/swit-serve-v1.0.0-289-g6965de3-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-392-g8eb4f3c-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-118-gfb0481a-dirty-darwin-arm64 (8.3M)
  _output/build/swit-serve-v1.0.0-320-g418e1e6-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-322-gbba4047-dirty-darwin-arm64 ( 23M)
  _output/build/switctl/darwin/arm64/switctl ( 12M)
  _output/build/swit-auth-v1.0.0-356-gfb1a7d2-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth/darwin/arm64/swit-auth ( 23M)
  _output/build/swit-serve-v1.0.0-409-g3827160-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-120-g3086f97-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-252-g7855107-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-354-gecba7ea-dirty-darwin-arm64 ( 11M)
  _output/build/swit-serve-v1.0.0-172-g0970a6e-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-366-ge0a7621-dirty-darwin-arm64 ( 12M)
  _output/build/swit-auth-v1.0.0-230-g3601f4d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-390-g9f2d83a-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-376-g700096c-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-356-gfb1a7d2-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-230-g3601f4d-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-390-g9f2d83a-dirty-darwin-arm64 ( 12M)
  _output/build/swit-auth-v1.0.0-354-gecba7ea-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-344-gf359cbf-darwin-arm64 ( 11M)
  _output/build/swit-auth-v1.0.0-366-ge0a7621-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-118-gfb0481a-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-307-g969d98c-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-252-g7855107-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-255-g69f2358-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-317-g87b72d0-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-217-g27d8dfb-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-400-g0860d3d-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-373-ga924fd7-dirty-darwin-arm64 ( 12M)
  _output/build/swit-auth-v1.0.0-364-g8676ec6-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-378-gde0ba58-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-383-g10067e2-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve/darwin/arm64/swit-serve ( 23M)
  _output/build/switctl-v1.0.0-287-g51a9870-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-252-g7855107-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-407-gb0ecef1-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-300-gec33594-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-291-gf056804-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-397-g470c691-dirty-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-277-ga42a8dd-dirty-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-338-g362c6e1-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-121-gd9c229f-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-405-g0d4c4d4-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-362-g449b46a-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-313-g28ee0e5-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-381-gb8db415-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-303-ga9cf97b-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-422-ga733d9f-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-344-gf359cbf-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-373-ga924fd7-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-400-g0860d3d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-264-g94463b4-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-289-g6965de3-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-428-g5a8fd9d-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-287-g51a9870-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-427-ge83356d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-291-gf056804-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-230-g3601f4d-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-397-g470c691-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-277-ga42a8dd-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-121-gd9c229f-dirty-darwin-arm64 (8.3M)
  _output/build/swit-serve-v1.0.0-408-g8466530-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-120-g3086f97-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-409-g3827160-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-356-gfb1a7d2-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-376-g700096c-dirty-darwin-arm64 ( 12M)
  _output/build/swit-serve-v1.0.0-390-g9f2d83a-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-230-g3601f4d-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-172-g0970a6e-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-424-g9097594-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-307-g969d98c-dirty-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-392-g8eb4f3c-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-255-g69f2358-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-428-g5a8fd9d-darwin-arm64 ( 12M)
  _output/build/swit-auth-v1.0.0-322-gbba4047-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-320-g418e1e6-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-317-g87b72d0-dirty-darwin-arm64 ( 11M)
  _output/build/switctl-v1.0.0-230-g3601f4d-darwin-arm64 (8.3M)
  _output/build/swit-auth-v1.0.0-307-g969d98c-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-392-g8eb4f3c-dirty-darwin-arm64 ( 12M)
  _output/build/swit-serve-v1.0.0-118-gfb0481a-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-320-g418e1e6-dirty-darwin-arm64 ( 11M)
  _output/build/swit-auth-v1.0.0-317-g87b72d0-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-255-g69f2358-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-408-g8466530-darwin-arm64 ( 12M)
  _output/build/switctl-v1.0.0-322-gbba4047-dirty-darwin-arm64 ( 11M)
  _output/build/swit-auth-v1.0.0-376-g700096c-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-120-g3086f97-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-409-g3827160-dirty-darwin-arm64 ( 12M)
  _output/build/swit-auth-v1.0.0-424-g9097594-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-366-ge0a7621-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-172-g0970a6e-dirty-darwin-arm64 (8.3M)
  _output/build/swit-serve-v1.0.0-354-gecba7ea-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-424-g9097594-darwin-arm64 ( 12M)
  _output/build/swit-serve-v1.0.0-422-ga733d9f-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-303-ga9cf97b-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-428-g5a8fd9d-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-313-g28ee0e5-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-381-gb8db415-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-362-g449b46a-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-405-g0d4c4d4-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-338-g362c6e1-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-121-gd9c229f-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-378-gde0ba58-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-230-g3601f4d-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-364-g8676ec6-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-383-g10067e2-dirty-darwin-arm64 ( 23M)
  _output/build/swit-serve-v1.0.0-217-g27d8dfb-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-427-ge83356d-dirty-darwin-arm64 ( 12M)
  _output/build/swit-serve-v1.0.0-300-gec33594-dirty-darwin-arm64 ( 23M)
  _output/build/switctl-v1.0.0-289-g6965de3-dirty-darwin-arm64 (8.3M)
  _output/build/switctl-v1.0.0-264-g94463b4-dirty-darwin-arm64 (8.3M)
  _output/build/swit-serve-v1.0.0-407-gb0ecef1-dirty-darwin-arm64 ( 23M)
  _output/build/swit-auth-v1.0.0-408-g8466530-darwin-arm64 ( 23M)

[0;34m[INFO][0m 发布包:)\n- [x] Tests pass (🧪 标准测试 - 运行所有测试（包含依赖生成）
[0;34m[INFO][0m 🚀 SWIT 测试管理脚本启动

[0;34m[INFO][0m 🧪 标准测试模式
[0;34m[INFO][0m   运行所有测试（包含依赖生成）...
[0;34m[INFO][0m 🔄 生成测试依赖...
[0;34m[INFO][0m   生成proto代码...
[0;34m[INFO][0m   生成swagger文档...
[0;34m[INFO][0m 🧪 运行测试 - 类型: unit, 包: all
[0;32m[SUCCESS][0m ✅ 测试通过
[0;32m[SUCCESS][0m ✅ 标准测试完成！

[0;34m[INFO][0m 📊 测试统计：
  测试文件:      255 个
  覆盖率文件:        8 个

[0;34m[INFO][0m 💡 提示：
[0;34m[INFO][0m   test-dev      # 快速开发测试
[0;34m[INFO][0m   test-coverage # 覆盖率测试
[0;34m[INFO][0m   test-advanced # 高级测试控制

💡 快速提示：
  make test-dev      # 快速开发测试（跳过依赖生成）
  make test-coverage # 覆盖率测试（生成报告）)\n- [x] Lints clean\n\nCloses #420