### PR TITLE
feat(middleware): OpenTelemetry tracing middleware (#425)

### DIFF
--- a/pkg/messaging/kafka/publisher.go
+++ b/pkg/messaging/kafka/publisher.go
@@ -350,13 +350,13 @@ func toKafkaMessage(topic string, m *messaging.Message) KafkaMessage {
 	for k, v := range m.Headers {
 		headers[k] = v
 	}
-    // Inject W3C traceparent if present in headers.Custom (ValidatedMessage path)
-    // or derive from existing TraceContext fields if available.
-    if _, ok := headers["traceparent"]; !ok {
-        // If message.Headers contains W3C parts in Custom, skip. Otherwise try to synthesize minimal info.
-        // Note: Full synthesis requires access to context; here we defer to upstream builder/middleware to inject.
-        // No-op if not available.
-    }
+	// Inject W3C traceparent if present in headers.Custom (ValidatedMessage path)
+	// or derive from existing TraceContext fields if available.
+	if _, ok := headers["traceparent"]; !ok {
+		// If message.Headers contains W3C parts in Custom, skip. Otherwise try to synthesize minimal info.
+		// Note: Full synthesis requires access to context; here we defer to upstream builder/middleware to inject.
+		// No-op if not available.
+	}
 	// Populate minimal tracing/correlation metadata if present
 	if m.CorrelationID != "" {
 		headers["correlation_id"] = m.CorrelationID

--- a/pkg/messaging/middleware.go
+++ b/pkg/messaging/middleware.go
@@ -694,11 +694,11 @@ func (mr *MiddlewareRegistry) RegisterMiddleware(name string, mw Middleware) err
 	mr.mutex.Lock()
 	defer mr.mutex.Unlock()
 
-    if _, exists := mr.middleware[name]; exists {
+	if _, exists := mr.middleware[name]; exists {
 		return fmt.Errorf("middleware already registered: %s", name)
 	}
 
-    mr.middleware[name] = mw
+	mr.middleware[name] = mw
 	return nil
 }
 

--- a/pkg/messaging/middleware/init.go
+++ b/pkg/messaging/middleware/init.go
@@ -1,3 +1,24 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package middleware
 
 import (
@@ -10,5 +31,3 @@ func init() {
 		_ = messaging.GlobalMiddlewareRegistry.RegisterFactory("tracing", CreateTracingMiddleware)
 	}
 }
-
-

--- a/pkg/messaging/middleware/middleware_test.go
+++ b/pkg/messaging/middleware/middleware_test.go
@@ -189,29 +189,29 @@ func TestTracingMiddleware(t *testing.T) {
 
 // TestPublisherTracingMiddleware ensures publish path injects propagation headers and sets span status
 func TestPublisherTracingMiddleware(t *testing.T) {
-    tracer := NewInMemoryTracer()
-    mw := NewPublisherTracingMiddleware(tracer)
+	tracer := NewInMemoryTracer()
+	mw := NewPublisherTracingMiddleware(tracer)
 
-    // next func records headers presence
-    var injected bool
-    next := func(ctx context.Context, msg *messaging.Message) error {
-        if msg != nil && len(msg.Headers) > 0 {
-            // traceparent should exist for in-memory injection style
-            if _, ok := msg.Headers["traceparent"]; ok {
-                injected = true
-            }
-        }
-        return nil
-    }
+	// next func records headers presence
+	var injected bool
+	next := func(ctx context.Context, msg *messaging.Message) error {
+		if msg != nil && len(msg.Headers) > 0 {
+			// traceparent should exist for in-memory injection style
+			if _, ok := msg.Headers["traceparent"]; ok {
+				injected = true
+			}
+		}
+		return nil
+	}
 
-    msg := &messaging.Message{ID: "id", Topic: "t", Headers: map[string]string{}}
-    err := mw.WrapPublish(next)(context.Background(), msg)
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    if !injected {
-        t.Fatalf("expected trace headers to be injected")
-    }
+	msg := &messaging.Message{ID: "id", Topic: "t", Headers: map[string]string{}}
+	err := mw.WrapPublish(next)(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !injected {
+		t.Fatalf("expected trace headers to be injected")
+	}
 }
 
 // TestRateLimitMiddleware tests the rate limiting middleware.

--- a/pkg/messaging/middleware/publisher_tracing.go
+++ b/pkg/messaging/middleware/publisher_tracing.go
@@ -1,69 +1,89 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 package middleware
 
 import (
-    "context"
-    "github.com/innovationmech/swit/pkg/messaging"
+	"context"
+
+	"github.com/innovationmech/swit/pkg/messaging"
 )
 
 // PublisherTracingMiddleware injects propagation headers on publish path and
 // creates PRODUCER spans when a Tracer is provided.
 type PublisherTracingMiddleware struct {
-    tracer Tracer
+	tracer Tracer
 }
 
 func NewPublisherTracingMiddleware(tracer Tracer) *PublisherTracingMiddleware {
-    if tracer == nil {
-        tracer = NewNoOpTracer()
-    }
-    return &PublisherTracingMiddleware{tracer: tracer}
+	if tracer == nil {
+		tracer = NewNoOpTracer()
+	}
+	return &PublisherTracingMiddleware{tracer: tracer}
 }
 
 func (m *PublisherTracingMiddleware) Name() string { return "publisher-tracing" }
 
 func (m *PublisherTracingMiddleware) WrapPublish(next messaging.PublishFunc) messaging.PublishFunc {
-    return func(ctx context.Context, message *messaging.Message) error {
-        // Start PRODUCER span, inject headers then call next
-        spanName := "publish_message"
-        ctx2, span := m.tracer.StartSpan(ctx, spanName, WithSpanKind(SpanKindProducer))
-        if message != nil {
-            if message.Headers == nil {
-                message.Headers = make(map[string]string)
-            }
-            m.tracer.Inject(ctx2, message.Headers)
-        }
-        err := next(ctx2, message)
-        if err != nil {
-            span.SetStatus(SpanStatusError, err.Error())
-        } else {
-            span.SetStatus(SpanStatusOK, "")
-        }
-        span.End()
-        return err
-    }
+	return func(ctx context.Context, message *messaging.Message) error {
+		// Start PRODUCER span, inject headers then call next
+		spanName := "publish_message"
+		ctx2, span := m.tracer.StartSpan(ctx, spanName, WithSpanKind(SpanKindProducer))
+		if message != nil {
+			if message.Headers == nil {
+				message.Headers = make(map[string]string)
+			}
+			m.tracer.Inject(ctx2, message.Headers)
+		}
+		err := next(ctx2, message)
+		if err != nil {
+			span.SetStatus(SpanStatusError, err.Error())
+		} else {
+			span.SetStatus(SpanStatusOK, "")
+		}
+		span.End()
+		return err
+	}
 }
 
 func (m *PublisherTracingMiddleware) WrapPublishBatch(next messaging.PublishBatchFunc) messaging.PublishBatchFunc {
-    return func(ctx context.Context, messages []*messaging.Message) error {
-        spanName := "publish_messages_batch"
-        ctx2, span := m.tracer.StartSpan(ctx, spanName, WithSpanKind(SpanKindProducer))
-        for _, msg := range messages {
-            if msg == nil {
-                continue
-            }
-            if msg.Headers == nil {
-                msg.Headers = make(map[string]string)
-            }
-            m.tracer.Inject(ctx2, msg.Headers)
-        }
-        err := next(ctx2, messages)
-        if err != nil {
-            span.SetStatus(SpanStatusError, err.Error())
-        } else {
-            span.SetStatus(SpanStatusOK, "")
-        }
-        span.End()
-        return err
-    }
+	return func(ctx context.Context, messages []*messaging.Message) error {
+		spanName := "publish_messages_batch"
+		ctx2, span := m.tracer.StartSpan(ctx, spanName, WithSpanKind(SpanKindProducer))
+		for _, msg := range messages {
+			if msg == nil {
+				continue
+			}
+			if msg.Headers == nil {
+				msg.Headers = make(map[string]string)
+			}
+			m.tracer.Inject(ctx2, msg.Headers)
+		}
+		err := next(ctx2, messages)
+		if err != nil {
+			span.SetStatus(SpanStatusError, err.Error())
+		} else {
+			span.SetStatus(SpanStatusOK, "")
+		}
+		span.End()
+		return err
+	}
 }
-
-

--- a/pkg/messaging/middleware/tracing.go
+++ b/pkg/messaging/middleware/tracing.go
@@ -666,13 +666,13 @@ func CreateTracingMiddleware(config map[string]interface{}) (messaging.Middlewar
 				tracingConfig.Tracer = NewNoOpTracer()
 			case "in_memory":
 				tracingConfig.Tracer = NewInMemoryTracer()
-            case "otel":
-                // Use global OpenTelemetry provider/propagator via adapter
-                serviceName := ""
-                if v, ok := config["service_name"].(string); ok {
-                    serviceName = v
-                }
-                tracingConfig.Tracer = NewOTelTracerAdapter(serviceName)
+			case "otel":
+				// Use global OpenTelemetry provider/propagator via adapter
+				serviceName := ""
+				if v, ok := config["service_name"].(string); ok {
+					serviceName = v
+				}
+				tracingConfig.Tracer = NewOTelTracerAdapter(serviceName)
 			default:
 				tracingConfig.Tracer = NewNoOpTracer()
 			}

--- a/pkg/messaging/middleware/tracing_otel_adapter.go
+++ b/pkg/messaging/middleware/tracing_otel_adapter.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
+
 package middleware
 
 import (
@@ -238,5 +239,3 @@ func (w *otelSpanWrapper) GetSpanID() string {
 	}
 	return w.span.SpanContext().SpanID().String()
 }
-
-

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -56,20 +56,20 @@ func (p *publisher) Publish(ctx context.Context, message *messaging.Message) err
 	}
 
 	start := time.Now()
-    var err error
-    // Headers injection for core NATS is not native; prefer prior middleware/builder to inject
-    // into message.Headers. JetStream supports headers via nats.Msg; basic publish uses payload only.
+	var err error
+	// Headers injection for core NATS is not native; prefer prior middleware/builder to inject
+	// into message.Headers. JetStream supports headers via nats.Msg; basic publish uses payload only.
 	if js != nil {
-        // JetStream sync publish with headers if available
-        if len(message.Headers) > 0 {
-            msg := &nats.Msg{Subject: message.Topic, Data: message.Payload, Header: nats.Header{}}
-            for k, v := range message.Headers {
-                msg.Header.Set(k, v)
-            }
-            _, err = js.PublishMsg(msg)
-        } else {
-            _, err = js.Publish(message.Topic, message.Payload)
-        }
+		// JetStream sync publish with headers if available
+		if len(message.Headers) > 0 {
+			msg := &nats.Msg{Subject: message.Topic, Data: message.Payload, Header: nats.Header{}}
+			for k, v := range message.Headers {
+				msg.Header.Set(k, v)
+			}
+			_, err = js.PublishMsg(msg)
+		} else {
+			_, err = js.Publish(message.Topic, message.Payload)
+		}
 	} else {
 		if deadline, ok := ctx.Deadline(); ok {
 			timeout := time.Until(deadline)

--- a/pkg/messaging/publisher.go
+++ b/pkg/messaging/publisher.go
@@ -619,61 +619,61 @@ func (b *publisherBuilderImpl) Build(ctx context.Context) (EventPublisher, error
 
 // wrapWithMiddleware wraps the publisher with middleware chain.
 func (b *publisherBuilderImpl) wrapWithMiddleware(publisher EventPublisher) EventPublisher {
-    // Build wrapped publish function
-    publish := func(ctx context.Context, message *Message) error {
-        return publisher.Publish(ctx, message)
-    }
+	// Build wrapped publish function
+	publish := func(ctx context.Context, message *Message) error {
+		return publisher.Publish(ctx, message)
+	}
 
-    batch := func(ctx context.Context, messages []*Message) error {
-        return publisher.PublishBatch(ctx, messages)
-    }
+	batch := func(ctx context.Context, messages []*Message) error {
+		return publisher.PublishBatch(ctx, messages)
+	}
 
-    // Apply middleware in reverse order so the first added is outermost
-    for i := len(b.middleware) - 1; i >= 0; i-- {
-        mw := b.middleware[i]
-        if mw != nil {
-            publish = mw.WrapPublish(publish)
-            batch = mw.WrapPublishBatch(batch)
-        }
-    }
+	// Apply middleware in reverse order so the first added is outermost
+	for i := len(b.middleware) - 1; i >= 0; i-- {
+		mw := b.middleware[i]
+		if mw != nil {
+			publish = mw.WrapPublish(publish)
+			batch = mw.WrapPublishBatch(batch)
+		}
+	}
 
-    return &middlewareWrappedPublisher{
-        base:        publisher,
-        publish:     publish,
-        publishBatch: batch,
-    }
+	return &middlewareWrappedPublisher{
+		base:         publisher,
+		publish:      publish,
+		publishBatch: batch,
+	}
 }
 
 // middlewareWrappedPublisher decorates an EventPublisher with middleware chains
 // for Publish and PublishBatch while delegating other methods directly.
 type middlewareWrappedPublisher struct {
-    base         EventPublisher
-    publish      PublishFunc
-    publishBatch PublishBatchFunc
+	base         EventPublisher
+	publish      PublishFunc
+	publishBatch PublishBatchFunc
 }
 
 func (m *middlewareWrappedPublisher) Publish(ctx context.Context, message *Message) error {
-    return m.publish(ctx, message)
+	return m.publish(ctx, message)
 }
 
 func (m *middlewareWrappedPublisher) PublishBatch(ctx context.Context, messages []*Message) error {
-    return m.publishBatch(ctx, messages)
+	return m.publishBatch(ctx, messages)
 }
 
 func (m *middlewareWrappedPublisher) PublishWithConfirm(ctx context.Context, message *Message) (*PublishConfirmation, error) {
-    // Delegate directly (middleware currently targets Publish/PublishBatch)
-    return m.base.PublishWithConfirm(ctx, message)
+	// Delegate directly (middleware currently targets Publish/PublishBatch)
+	return m.base.PublishWithConfirm(ctx, message)
 }
 
 func (m *middlewareWrappedPublisher) PublishAsync(ctx context.Context, message *Message, callback PublishCallback) error {
-    // Delegate directly
-    return m.base.PublishAsync(ctx, message, callback)
+	// Delegate directly
+	return m.base.PublishAsync(ctx, message, callback)
 }
 
 func (m *middlewareWrappedPublisher) BeginTransaction(ctx context.Context) (Transaction, error) {
-    return m.base.BeginTransaction(ctx)
+	return m.base.BeginTransaction(ctx)
 }
 
 func (m *middlewareWrappedPublisher) Flush(ctx context.Context) error { return m.base.Flush(ctx) }
-func (m *middlewareWrappedPublisher) Close() error { return m.base.Close() }
-func (m *middlewareWrappedPublisher) GetMetrics() *PublisherMetrics { return m.base.GetMetrics() }
+func (m *middlewareWrappedPublisher) Close() error                    { return m.base.Close() }
+func (m *middlewareWrappedPublisher) GetMetrics() *PublisherMetrics   { return m.base.GetMetrics() }


### PR DESCRIPTION
Implements OTEL tracing middleware for messaging.\n\n- Consumer-side tracing with span extraction and attributes\n- Publisher-side propagation injection and PRODUCER spans\n- OTel tracer adapter and factory registration via subpackage init\n- PublisherBuilder middleware chain wrapping\n- NATS JetStream header propagation support\n\nCloses #425