### PR TITLE
feat(observability): health check endpoints and integration

### DIFF
--- a/pkg/server/health/README.md
+++ b/pkg/server/health/README.md
@@ -1,0 +1,289 @@
+# Health Check System
+
+健康检查系统提供了一个可扩展的、基于适配器模式的健康检查框架，支持健康（health）、就绪（readiness）和存活（liveness）探针。
+
+## 功能特性
+
+- **适配器模式**：统一的健康检查适配器，支持注册多种类型的检查器
+- **就绪和存活探针**：完整的 Kubernetes 兼容的探针接口
+- **并发执行**：健康检查可并发执行，提高检查效率
+- **超时控制**：可配置的超时机制，防止检查阻塞
+- **结果缓存**：缓存最近的检查结果，便于查询和调试
+- **HTTP 端点**：提供标准的 HTTP 端点，与 Kubernetes 和负载均衡器集成
+
+## 使用示例
+
+### 基本使用
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	"github.com/innovationmech/swit/pkg/server/health"
+)
+
+func main() {
+	// 创建健康检查适配器
+	adapter := health.NewHealthCheckAdapter(nil) // 使用默认配置
+
+	// 注册健康检查器
+	checker := health.NewBasicHealthChecker("database", func(ctx context.Context) error {
+		// 检查数据库连接
+		// return db.Ping(ctx)
+		return nil
+	})
+	adapter.RegisterHealthChecker(checker)
+
+	// 注册就绪检查器
+	readinessProbe := health.NewServiceReadinessProbe("service", 5*time.Second)
+	adapter.RegisterReadinessChecker(readinessProbe)
+
+	// 标记服务为就绪
+	readinessProbe.SetReady(true)
+
+	// 注册存活检查器
+	livenessProbe := health.NewServiceLivenessProbe("service", 30*time.Second)
+	adapter.RegisterLivenessChecker(livenessProbe)
+
+	// 启动心跳
+	ctx := context.Background()
+	livenessProbe.StartHeartbeat(ctx, 5*time.Second)
+
+	// 注册 HTTP 端点
+	router := gin.Default()
+	handler := health.NewEndpointHandler(adapter, "my-service", "v1.0.0")
+	handler.RegisterRoutes(router)
+
+	router.Run(":8080")
+}
+```
+
+### 自定义配置
+
+```go
+config := &health.HealthCheckConfig{
+	Timeout:       10 * time.Second,  // 单个检查的超时时间
+	Interval:      60 * time.Second,  // 周期性检查的间隔
+	MaxConcurrent: 5,                  // 最大并发检查数
+}
+
+adapter := health.NewHealthCheckAdapter(config)
+```
+
+### 复合健康检查器
+
+```go
+// 创建复合检查器，聚合多个依赖检查
+compositeChecker := health.NewCompositeHealthChecker(
+	"dependencies",
+	health.NewBasicHealthChecker("redis", checkRedis),
+	health.NewBasicHealthChecker("kafka", checkKafka),
+	health.NewBasicHealthChecker("mysql", checkMySQL),
+)
+
+adapter.RegisterHealthChecker(compositeChecker)
+```
+
+### 依赖健康检查
+
+```go
+// 包装已有的健康检查器
+dbChecker := health.NewBasicHealthChecker("db", checkDB)
+depChecker := health.NewDependencyHealthChecker("database-dependency", dbChecker)
+
+adapter.RegisterHealthChecker(depChecker)
+```
+
+## HTTP 端点
+
+健康检查系统提供以下 HTTP 端点：
+
+### `/health`
+主健康检查端点，返回服务的整体健康状态。
+
+**响应示例**：
+```json
+{
+  "status": "healthy",
+  "service": "my-service",
+  "version": "v1.0.0",
+  "timestamp": "2025-09-30T10:00:00Z",
+  "uptime": "1h30m15s",
+  "dependencies": {
+    "database": {
+      "name": "database",
+      "status": "healthy",
+      "duration": 5000000,
+      "timestamp": "2025-09-30T10:00:00Z"
+    }
+  }
+}
+```
+
+### `/health/ready` 或 `/ready`
+就绪探针端点，检查服务是否准备好接收流量。
+
+**响应示例**：
+```json
+{
+  "ready": true,
+  "service": "my-service",
+  "timestamp": "2025-09-30T10:00:00Z",
+  "checks": {
+    "service": {
+      "name": "service",
+      "status": "healthy",
+      "message": "service ready",
+      "duration": 100000,
+      "timestamp": "2025-09-30T10:00:00Z"
+    }
+  }
+}
+```
+
+### `/health/live` 或 `/live`
+存活探针端点，检查服务是否存活（不应重启）。
+
+**响应示例**：
+```json
+{
+  "alive": true,
+  "service": "my-service",
+  "timestamp": "2025-09-30T10:00:00Z",
+  "checks": {
+    "service": {
+      "name": "service",
+      "status": "healthy",
+      "message": "service alive",
+      "duration": 50000,
+      "timestamp": "2025-09-30T10:00:00Z"
+    }
+  }
+}
+```
+
+### `/health/detailed`
+详细健康检查端点，返回所有检查的完整状态信息。
+
+**响应示例**：
+```json
+{
+  "service": "my-service",
+  "version": "v1.0.0",
+  "timestamp": "2025-09-30T10:00:00Z",
+  "uptime": "1h30m15s",
+  "health": {
+    "status": "healthy",
+    "dependencies": { ... }
+  },
+  "readiness": {
+    "status": "healthy",
+    "checks": { ... }
+  },
+  "liveness": {
+    "status": "healthy",
+    "checks": { ... }
+  },
+  "cached_results": { ... }
+}
+```
+
+## Kubernetes 集成
+
+### Deployment 配置示例
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: my-service
+        image: my-service:latest
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+```
+
+## 最佳实践
+
+1. **区分健康、就绪和存活检查**：
+   - 健康检查：检查服务及其依赖的整体状态
+   - 就绪检查：检查服务是否准备好接收流量（如初始化完成）
+   - 存活检查：检查服务是否仍在运行（如心跳）
+
+2. **设置合理的超时**：
+   - 避免检查时间过长，影响系统响应
+   - 根据依赖服务的实际响应时间调整超时设置
+
+3. **使用心跳机制**：
+   - 对于长时间运行的服务，使用心跳机制维护存活状态
+   - 定期更新心跳时间戳
+
+4. **缓存结果**：
+   - 利用结果缓存机制，避免频繁执行昂贵的检查操作
+   - 在详细检查端点中查看缓存结果
+
+5. **监控和告警**：
+   - 集成 Prometheus 等监控系统
+   - 设置告警规则，及时发现健康问题
+
+## 架构设计
+
+健康检查系统采用适配器模式，提供统一的接口来管理不同类型的健康检查：
+
+```
+┌─────────────────────────────────────────────────┐
+│          HealthCheckAdapter                      │
+│  ┌───────────────────────────────────────────┐ │
+│  │  HealthCheckers                            │ │
+│  │  - Database Checker                        │ │
+│  │  - Redis Checker                           │ │
+│  │  - ...                                     │ │
+│  └───────────────────────────────────────────┘ │
+│  ┌───────────────────────────────────────────┐ │
+│  │  ReadinessCheckers                         │ │
+│  │  - Service Readiness Probe                 │ │
+│  └───────────────────────────────────────────┘ │
+│  ┌───────────────────────────────────────────┐ │
+│  │  LivenessCheckers                          │ │
+│  │  - Service Liveness Probe                  │ │
+│  └───────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────┘
+                    │
+                    ▼
+      ┌────────────────────────┐
+      │   EndpointHandler       │
+      │  - /health              │
+      │  - /health/ready        │
+      │  - /health/live         │
+      │  - /health/detailed     │
+      └────────────────────────┘
+```
+
+## 相关文档
+
+- [SWIT Server Framework](../README.md)
+- [Observability Integration](../observability.go)
+- [Types Package](../../types/health.go)

--- a/pkg/server/health/adapter.go
+++ b/pkg/server/health/adapter.go
@@ -1,0 +1,446 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/types"
+	"go.uber.org/zap"
+)
+
+// HealthChecker defines the interface for health check implementations
+type HealthChecker interface {
+	// Check performs a health check and returns the status
+	Check(ctx context.Context) error
+	// GetName returns the name of the health check
+	GetName() string
+}
+
+// ReadinessChecker defines the interface for readiness checks
+type ReadinessChecker interface {
+	// CheckReadiness checks if the service is ready to accept traffic
+	CheckReadiness(ctx context.Context) error
+	// GetName returns the name of the readiness check
+	GetName() string
+}
+
+// LivenessChecker defines the interface for liveness checks
+type LivenessChecker interface {
+	// CheckLiveness checks if the service is alive and should not be restarted
+	CheckLiveness(ctx context.Context) error
+	// GetName returns the name of the liveness check
+	GetName() string
+}
+
+// HealthCheckResult represents the result of a health check
+type HealthCheckResult struct {
+	Name      string        `json:"name"`
+	Status    string        `json:"status"`
+	Message   string        `json:"message,omitempty"`
+	Error     string        `json:"error,omitempty"`
+	Duration  time.Duration `json:"duration"`
+	Timestamp time.Time     `json:"timestamp"`
+}
+
+// HealthCheckConfig contains configuration for health checks
+type HealthCheckConfig struct {
+	// Timeout is the maximum duration for a health check
+	Timeout time.Duration
+	// Interval is the interval between periodic health checks
+	Interval time.Duration
+	// MaxConcurrent is the maximum number of concurrent health checks
+	MaxConcurrent int
+}
+
+// DefaultHealthCheckConfig returns default health check configuration
+func DefaultHealthCheckConfig() *HealthCheckConfig {
+	return &HealthCheckConfig{
+		Timeout:       5 * time.Second,
+		Interval:      30 * time.Second,
+		MaxConcurrent: 10,
+	}
+}
+
+// HealthCheckAdapter provides a unified adapter for health checks
+type HealthCheckAdapter struct {
+	mu               sync.RWMutex
+	healthCheckers   map[string]HealthChecker
+	readinessChecker map[string]ReadinessChecker
+	livenessCheckers map[string]LivenessChecker
+	config           *HealthCheckConfig
+	lastResults      map[string]*HealthCheckResult
+}
+
+// NewHealthCheckAdapter creates a new health check adapter
+func NewHealthCheckAdapter(config *HealthCheckConfig) *HealthCheckAdapter {
+	if config == nil {
+		config = DefaultHealthCheckConfig()
+	}
+
+	return &HealthCheckAdapter{
+		healthCheckers:   make(map[string]HealthChecker),
+		readinessChecker: make(map[string]ReadinessChecker),
+		livenessCheckers: make(map[string]LivenessChecker),
+		config:           config,
+		lastResults:      make(map[string]*HealthCheckResult),
+	}
+}
+
+// RegisterHealthChecker registers a health checker
+func (a *HealthCheckAdapter) RegisterHealthChecker(checker HealthChecker) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	name := checker.GetName()
+	if _, exists := a.healthCheckers[name]; exists {
+		return fmt.Errorf("health checker %s already registered", name)
+	}
+
+	a.healthCheckers[name] = checker
+	logger.Logger.Info("Registered health checker", zap.String("name", name))
+	return nil
+}
+
+// RegisterReadinessChecker registers a readiness checker
+func (a *HealthCheckAdapter) RegisterReadinessChecker(checker ReadinessChecker) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	name := checker.GetName()
+	if _, exists := a.readinessChecker[name]; exists {
+		return fmt.Errorf("readiness checker %s already registered", name)
+	}
+
+	a.readinessChecker[name] = checker
+	logger.Logger.Info("Registered readiness checker", zap.String("name", name))
+	return nil
+}
+
+// RegisterLivenessChecker registers a liveness checker
+func (a *HealthCheckAdapter) RegisterLivenessChecker(checker LivenessChecker) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	name := checker.GetName()
+	if _, exists := a.livenessCheckers[name]; exists {
+		return fmt.Errorf("liveness checker %s already registered", name)
+	}
+
+	a.livenessCheckers[name] = checker
+	logger.Logger.Info("Registered liveness checker", zap.String("name", name))
+	return nil
+}
+
+// CheckHealth performs all registered health checks
+func (a *HealthCheckAdapter) CheckHealth(ctx context.Context) (*types.HealthStatus, error) {
+	a.mu.RLock()
+	checkers := make([]HealthChecker, 0, len(a.healthCheckers))
+	for _, checker := range a.healthCheckers {
+		checkers = append(checkers, checker)
+	}
+	a.mu.RUnlock()
+
+	results := a.runHealthChecks(ctx, checkers)
+	return a.aggregateResults(results)
+}
+
+// CheckReadiness performs all registered readiness checks
+func (a *HealthCheckAdapter) CheckReadiness(ctx context.Context) (*types.HealthStatus, error) {
+	a.mu.RLock()
+	checkers := make([]ReadinessChecker, 0, len(a.readinessChecker))
+	for _, checker := range a.readinessChecker {
+		checkers = append(checkers, checker)
+	}
+	a.mu.RUnlock()
+
+	results := a.runReadinessChecks(ctx, checkers)
+	return a.aggregateResults(results)
+}
+
+// CheckLiveness performs all registered liveness checks
+func (a *HealthCheckAdapter) CheckLiveness(ctx context.Context) (*types.HealthStatus, error) {
+	a.mu.RLock()
+	checkers := make([]LivenessChecker, 0, len(a.livenessCheckers))
+	for _, checker := range a.livenessCheckers {
+		checkers = append(checkers, checker)
+	}
+	a.mu.RUnlock()
+
+	results := a.runLivenessChecks(ctx, checkers)
+	return a.aggregateResults(results)
+}
+
+// runHealthChecks executes health checks concurrently with timeout
+func (a *HealthCheckAdapter) runHealthChecks(ctx context.Context, checkers []HealthChecker) []*HealthCheckResult {
+	results := make([]*HealthCheckResult, 0, len(checkers))
+	resultChan := make(chan *HealthCheckResult, len(checkers))
+
+	sem := make(chan struct{}, a.config.MaxConcurrent)
+
+	var wg sync.WaitGroup
+	for _, checker := range checkers {
+		wg.Add(1)
+		go func(c HealthChecker) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result := a.executeHealthCheck(ctx, c)
+			resultChan <- result
+		}(checker)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	for result := range resultChan {
+		results = append(results, result)
+		a.cacheResult(result)
+	}
+
+	return results
+}
+
+// runReadinessChecks executes readiness checks concurrently with timeout
+func (a *HealthCheckAdapter) runReadinessChecks(ctx context.Context, checkers []ReadinessChecker) []*HealthCheckResult {
+	results := make([]*HealthCheckResult, 0, len(checkers))
+	resultChan := make(chan *HealthCheckResult, len(checkers))
+
+	sem := make(chan struct{}, a.config.MaxConcurrent)
+
+	var wg sync.WaitGroup
+	for _, checker := range checkers {
+		wg.Add(1)
+		go func(c ReadinessChecker) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result := a.executeReadinessCheck(ctx, c)
+			resultChan <- result
+		}(checker)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	for result := range resultChan {
+		results = append(results, result)
+		a.cacheResult(result)
+	}
+
+	return results
+}
+
+// runLivenessChecks executes liveness checks concurrently with timeout
+func (a *HealthCheckAdapter) runLivenessChecks(ctx context.Context, checkers []LivenessChecker) []*HealthCheckResult {
+	results := make([]*HealthCheckResult, 0, len(checkers))
+	resultChan := make(chan *HealthCheckResult, len(checkers))
+
+	sem := make(chan struct{}, a.config.MaxConcurrent)
+
+	var wg sync.WaitGroup
+	for _, checker := range checkers {
+		wg.Add(1)
+		go func(c LivenessChecker) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result := a.executeLivenessCheck(ctx, c)
+			resultChan <- result
+		}(checker)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	for result := range resultChan {
+		results = append(results, result)
+		a.cacheResult(result)
+	}
+
+	return results
+}
+
+// executeHealthCheck executes a single health check with timeout
+func (a *HealthCheckAdapter) executeHealthCheck(ctx context.Context, checker HealthChecker) *HealthCheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, a.config.Timeout)
+	defer cancel()
+
+	result := &HealthCheckResult{
+		Name:      checker.GetName(),
+		Timestamp: time.Now(),
+	}
+
+	start := time.Now()
+	err := checker.Check(checkCtx)
+	result.Duration = time.Since(start)
+
+	if err != nil {
+		result.Status = types.HealthStatusUnhealthy
+		result.Error = err.Error()
+		logger.Logger.Debug("Health check failed",
+			zap.String("name", result.Name),
+			zap.Error(err),
+			zap.Duration("duration", result.Duration))
+	} else {
+		result.Status = types.HealthStatusHealthy
+		logger.Logger.Debug("Health check passed",
+			zap.String("name", result.Name),
+			zap.Duration("duration", result.Duration))
+	}
+
+	return result
+}
+
+// executeReadinessCheck executes a single readiness check with timeout
+func (a *HealthCheckAdapter) executeReadinessCheck(ctx context.Context, checker ReadinessChecker) *HealthCheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, a.config.Timeout)
+	defer cancel()
+
+	result := &HealthCheckResult{
+		Name:      checker.GetName(),
+		Timestamp: time.Now(),
+	}
+
+	start := time.Now()
+	err := checker.CheckReadiness(checkCtx)
+	result.Duration = time.Since(start)
+
+	if err != nil {
+		result.Status = types.HealthStatusUnhealthy
+		result.Error = err.Error()
+		result.Message = "service not ready"
+		logger.Logger.Debug("Readiness check failed",
+			zap.String("name", result.Name),
+			zap.Error(err),
+			zap.Duration("duration", result.Duration))
+	} else {
+		result.Status = types.HealthStatusHealthy
+		result.Message = "service ready"
+		logger.Logger.Debug("Readiness check passed",
+			zap.String("name", result.Name),
+			zap.Duration("duration", result.Duration))
+	}
+
+	return result
+}
+
+// executeLivenessCheck executes a single liveness check with timeout
+func (a *HealthCheckAdapter) executeLivenessCheck(ctx context.Context, checker LivenessChecker) *HealthCheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, a.config.Timeout)
+	defer cancel()
+
+	result := &HealthCheckResult{
+		Name:      checker.GetName(),
+		Timestamp: time.Now(),
+	}
+
+	start := time.Now()
+	err := checker.CheckLiveness(checkCtx)
+	result.Duration = time.Since(start)
+
+	if err != nil {
+		result.Status = types.HealthStatusUnhealthy
+		result.Error = err.Error()
+		result.Message = "service not alive"
+		logger.Logger.Debug("Liveness check failed",
+			zap.String("name", result.Name),
+			zap.Error(err),
+			zap.Duration("duration", result.Duration))
+	} else {
+		result.Status = types.HealthStatusHealthy
+		result.Message = "service alive"
+		logger.Logger.Debug("Liveness check passed",
+			zap.String("name", result.Name),
+			zap.Duration("duration", result.Duration))
+	}
+
+	return result
+}
+
+// aggregateResults aggregates check results into overall health status
+func (a *HealthCheckAdapter) aggregateResults(results []*HealthCheckResult) (*types.HealthStatus, error) {
+	healthStatus := types.NewHealthStatus(types.HealthStatusHealthy, "v1", 0)
+
+	var failed int
+	for _, result := range results {
+		depStatus := types.DependencyStatus{
+			Status:    result.Status,
+			Timestamp: result.Timestamp,
+			Latency:   result.Duration,
+		}
+
+		if result.Error != "" {
+			depStatus.Error = result.Error
+			failed++
+		}
+
+		healthStatus.AddDependency(result.Name, depStatus)
+	}
+
+	// If any check failed, mark overall status as unhealthy
+	if failed > 0 {
+		healthStatus.Status = types.HealthStatusUnhealthy
+	}
+
+	return healthStatus, nil
+}
+
+// cacheResult caches the result of a health check
+func (a *HealthCheckAdapter) cacheResult(result *HealthCheckResult) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.lastResults[result.Name] = result
+}
+
+// GetLastResult returns the last cached result for a checker
+func (a *HealthCheckAdapter) GetLastResult(name string) (*HealthCheckResult, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	result, exists := a.lastResults[name]
+	return result, exists
+}
+
+// GetAllLastResults returns all cached results
+func (a *HealthCheckAdapter) GetAllLastResults() map[string]*HealthCheckResult {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	results := make(map[string]*HealthCheckResult, len(a.lastResults))
+	for k, v := range a.lastResults {
+		results[k] = v
+	}
+	return results
+}

--- a/pkg/server/health/adapter_test.go
+++ b/pkg/server/health/adapter_test.go
@@ -1,0 +1,400 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/types"
+)
+
+func init() {
+	// Initialize logger for tests
+	logger.InitLogger()
+}
+
+// mockHealthChecker implements HealthChecker for testing
+type mockHealthChecker struct {
+	name      string
+	checkFunc func(context.Context) error
+}
+
+func (m *mockHealthChecker) Check(ctx context.Context) error {
+	if m.checkFunc != nil {
+		return m.checkFunc(ctx)
+	}
+	return nil
+}
+
+func (m *mockHealthChecker) GetName() string {
+	return m.name
+}
+
+// mockReadinessChecker implements ReadinessChecker for testing
+type mockReadinessChecker struct {
+	name      string
+	checkFunc func(context.Context) error
+}
+
+func (m *mockReadinessChecker) CheckReadiness(ctx context.Context) error {
+	if m.checkFunc != nil {
+		return m.checkFunc(ctx)
+	}
+	return nil
+}
+
+func (m *mockReadinessChecker) GetName() string {
+	return m.name
+}
+
+// mockLivenessChecker implements LivenessChecker for testing
+type mockLivenessChecker struct {
+	name      string
+	checkFunc func(context.Context) error
+}
+
+func (m *mockLivenessChecker) CheckLiveness(ctx context.Context) error {
+	if m.checkFunc != nil {
+		return m.checkFunc(ctx)
+	}
+	return nil
+}
+
+func (m *mockLivenessChecker) GetName() string {
+	return m.name
+}
+
+func TestNewHealthCheckAdapter(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *HealthCheckConfig
+	}{
+		{
+			name:   "with default config",
+			config: nil,
+		},
+		{
+			name: "with custom config",
+			config: &HealthCheckConfig{
+				Timeout:       10 * time.Second,
+				Interval:      60 * time.Second,
+				MaxConcurrent: 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(tt.config)
+			if adapter == nil {
+				t.Fatal("expected non-nil adapter")
+			}
+
+			if adapter.config == nil {
+				t.Error("expected non-nil config")
+			}
+
+			if adapter.healthCheckers == nil {
+				t.Error("expected non-nil healthCheckers map")
+			}
+		})
+	}
+}
+
+func TestHealthCheckAdapter_RegisterHealthChecker(t *testing.T) {
+	adapter := NewHealthCheckAdapter(nil)
+
+	checker := &mockHealthChecker{name: "test-checker"}
+	err := adapter.RegisterHealthChecker(checker)
+	if err != nil {
+		t.Fatalf("failed to register health checker: %v", err)
+	}
+
+	// Try to register the same checker again
+	err = adapter.RegisterHealthChecker(checker)
+	if err == nil {
+		t.Error("expected error when registering duplicate checker")
+	}
+}
+
+func TestHealthCheckAdapter_CheckHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkers       []HealthChecker
+		expectedStatus string
+	}{
+		{
+			name: "all checks pass",
+			checkers: []HealthChecker{
+				&mockHealthChecker{name: "checker1"},
+				&mockHealthChecker{name: "checker2"},
+			},
+			expectedStatus: types.HealthStatusHealthy,
+		},
+		{
+			name: "one check fails",
+			checkers: []HealthChecker{
+				&mockHealthChecker{name: "checker1"},
+				&mockHealthChecker{
+					name: "checker2",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("check failed")
+					},
+				},
+			},
+			expectedStatus: types.HealthStatusUnhealthy,
+		},
+		{
+			name:           "no checkers registered",
+			checkers:       []HealthChecker{},
+			expectedStatus: types.HealthStatusHealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+
+			for _, checker := range tt.checkers {
+				if err := adapter.RegisterHealthChecker(checker); err != nil {
+					t.Fatalf("failed to register checker: %v", err)
+				}
+			}
+
+			ctx := context.Background()
+			status, err := adapter.CheckHealth(ctx)
+			if err != nil {
+				t.Fatalf("CheckHealth returned error: %v", err)
+			}
+
+			if status.Status != tt.expectedStatus {
+				t.Errorf("expected status %s, got %s", tt.expectedStatus, status.Status)
+			}
+		})
+	}
+}
+
+func TestHealthCheckAdapter_CheckReadiness(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkers       []ReadinessChecker
+		expectedStatus string
+	}{
+		{
+			name: "all checks pass",
+			checkers: []ReadinessChecker{
+				&mockReadinessChecker{name: "ready1"},
+				&mockReadinessChecker{name: "ready2"},
+			},
+			expectedStatus: types.HealthStatusHealthy,
+		},
+		{
+			name: "one check fails",
+			checkers: []ReadinessChecker{
+				&mockReadinessChecker{name: "ready1"},
+				&mockReadinessChecker{
+					name: "ready2",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("not ready")
+					},
+				},
+			},
+			expectedStatus: types.HealthStatusUnhealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+
+			for _, checker := range tt.checkers {
+				if err := adapter.RegisterReadinessChecker(checker); err != nil {
+					t.Fatalf("failed to register readiness checker: %v", err)
+				}
+			}
+
+			ctx := context.Background()
+			status, err := adapter.CheckReadiness(ctx)
+			if err != nil {
+				t.Fatalf("CheckReadiness returned error: %v", err)
+			}
+
+			if status.Status != tt.expectedStatus {
+				t.Errorf("expected status %s, got %s", tt.expectedStatus, status.Status)
+			}
+		})
+	}
+}
+
+func TestHealthCheckAdapter_CheckLiveness(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkers       []LivenessChecker
+		expectedStatus string
+	}{
+		{
+			name: "all checks pass",
+			checkers: []LivenessChecker{
+				&mockLivenessChecker{name: "live1"},
+				&mockLivenessChecker{name: "live2"},
+			},
+			expectedStatus: types.HealthStatusHealthy,
+		},
+		{
+			name: "one check fails",
+			checkers: []LivenessChecker{
+				&mockLivenessChecker{name: "live1"},
+				&mockLivenessChecker{
+					name: "live2",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("not alive")
+					},
+				},
+			},
+			expectedStatus: types.HealthStatusUnhealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+
+			for _, checker := range tt.checkers {
+				if err := adapter.RegisterLivenessChecker(checker); err != nil {
+					t.Fatalf("failed to register liveness checker: %v", err)
+				}
+			}
+
+			ctx := context.Background()
+			status, err := adapter.CheckLiveness(ctx)
+			if err != nil {
+				t.Fatalf("CheckLiveness returned error: %v", err)
+			}
+
+			if status.Status != tt.expectedStatus {
+				t.Errorf("expected status %s, got %s", tt.expectedStatus, status.Status)
+			}
+		})
+	}
+}
+
+func TestHealthCheckAdapter_CheckHealthWithTimeout(t *testing.T) {
+	config := &HealthCheckConfig{
+		Timeout:       100 * time.Millisecond,
+		Interval:      30 * time.Second,
+		MaxConcurrent: 10,
+	}
+	adapter := NewHealthCheckAdapter(config)
+
+	// Register a checker that takes longer than the timeout
+	slowChecker := &mockHealthChecker{
+		name: "slow-checker",
+		checkFunc: func(ctx context.Context) error {
+			select {
+			case <-time.After(200 * time.Millisecond):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+
+	if err := adapter.RegisterHealthChecker(slowChecker); err != nil {
+		t.Fatalf("failed to register checker: %v", err)
+	}
+
+	ctx := context.Background()
+	status, err := adapter.CheckHealth(ctx)
+	if err != nil {
+		t.Fatalf("CheckHealth returned error: %v", err)
+	}
+
+	// The slow checker should timeout and be marked as unhealthy
+	if status.Status != types.HealthStatusUnhealthy {
+		t.Errorf("expected status %s, got %s", types.HealthStatusUnhealthy, status.Status)
+	}
+}
+
+func TestHealthCheckAdapter_GetLastResult(t *testing.T) {
+	adapter := NewHealthCheckAdapter(nil)
+
+	checker := &mockHealthChecker{name: "test-checker"}
+	if err := adapter.RegisterHealthChecker(checker); err != nil {
+		t.Fatalf("failed to register checker: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err := adapter.CheckHealth(ctx)
+	if err != nil {
+		t.Fatalf("CheckHealth returned error: %v", err)
+	}
+
+	// Get the last result
+	result, exists := adapter.GetLastResult("test-checker")
+	if !exists {
+		t.Error("expected cached result to exist")
+	}
+
+	if result.Name != "test-checker" {
+		t.Errorf("expected result name %s, got %s", "test-checker", result.Name)
+	}
+}
+
+func TestHealthCheckAdapter_ConcurrentChecks(t *testing.T) {
+	adapter := NewHealthCheckAdapter(nil)
+
+	// Register multiple checkers
+	for i := 0; i < 10; i++ {
+		checker := &mockHealthChecker{
+			name: "checker-" + string(rune(i)),
+			checkFunc: func(ctx context.Context) error {
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			},
+		}
+		if err := adapter.RegisterHealthChecker(checker); err != nil {
+			t.Fatalf("failed to register checker: %v", err)
+		}
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	status, err := adapter.CheckHealth(ctx)
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("CheckHealth returned error: %v", err)
+	}
+
+	if status.Status != types.HealthStatusHealthy {
+		t.Errorf("expected status %s, got %s", types.HealthStatusHealthy, status.Status)
+	}
+
+	// Checks should run concurrently, so total time should be much less than 10 * 10ms
+	if duration > 150*time.Millisecond {
+		t.Errorf("checks took too long, expected concurrent execution: %v", duration)
+	}
+}

--- a/pkg/server/health/endpoints.go
+++ b/pkg/server/health/endpoints.go
@@ -1,0 +1,292 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/innovationmech/swit/pkg/logger"
+	"github.com/innovationmech/swit/pkg/types"
+	"go.uber.org/zap"
+)
+
+// EndpointHandler handles health check HTTP endpoints
+type EndpointHandler struct {
+	adapter     *HealthCheckAdapter
+	serviceName string
+	version     string
+	startTime   time.Time
+}
+
+// NewEndpointHandler creates a new endpoint handler
+func NewEndpointHandler(adapter *HealthCheckAdapter, serviceName, version string) *EndpointHandler {
+	return &EndpointHandler{
+		adapter:     adapter,
+		serviceName: serviceName,
+		version:     version,
+		startTime:   time.Now(),
+	}
+}
+
+// HealthResponse represents the health check response
+type HealthResponse struct {
+	Status       string                        `json:"status"`
+	Service      string                        `json:"service"`
+	Version      string                        `json:"version"`
+	Timestamp    time.Time                     `json:"timestamp"`
+	Uptime       string                        `json:"uptime"`
+	Dependencies map[string]*HealthCheckResult `json:"dependencies,omitempty"`
+}
+
+// ReadinessResponse represents the readiness check response
+type ReadinessResponse struct {
+	Ready     bool                          `json:"ready"`
+	Service   string                        `json:"service"`
+	Timestamp time.Time                     `json:"timestamp"`
+	Checks    map[string]*HealthCheckResult `json:"checks,omitempty"`
+}
+
+// LivenessResponse represents the liveness check response
+type LivenessResponse struct {
+	Alive     bool                          `json:"alive"`
+	Service   string                        `json:"service"`
+	Timestamp time.Time                     `json:"timestamp"`
+	Checks    map[string]*HealthCheckResult `json:"checks,omitempty"`
+}
+
+// RegisterRoutes registers health check routes with a Gin router
+func (h *EndpointHandler) RegisterRoutes(router *gin.Engine) {
+	// Main health check endpoint
+	router.GET("/health", h.HealthCheck)
+
+	// Readiness probe endpoint (Kubernetes compatible)
+	router.GET("/health/ready", h.ReadinessCheck)
+	router.GET("/ready", h.ReadinessCheck) // Alternative path
+
+	// Liveness probe endpoint (Kubernetes compatible)
+	router.GET("/health/live", h.LivenessCheck)
+	router.GET("/live", h.LivenessCheck) // Alternative path
+
+	// Detailed health check endpoint
+	router.GET("/health/detailed", h.DetailedHealthCheck)
+
+	logger.Logger.Info("Registered health check endpoints",
+		zap.String("service", h.serviceName))
+}
+
+// HealthCheck handles the main health check endpoint
+// @Summary Health check
+// @Description Returns the overall health status of the service
+// @Tags health
+// @Produce json
+// @Success 200 {object} HealthResponse "Service is healthy"
+// @Failure 503 {object} HealthResponse "Service is unhealthy"
+// @Router /health [get]
+func (h *EndpointHandler) HealthCheck(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	status, err := h.adapter.CheckHealth(ctx)
+	if err != nil {
+		logger.Logger.Error("Health check failed", zap.Error(err))
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status":  types.HealthStatusUnhealthy,
+			"service": h.serviceName,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	response := &HealthResponse{
+		Status:    status.Status,
+		Service:   h.serviceName,
+		Version:   h.version,
+		Timestamp: time.Now(),
+		Uptime:    time.Since(h.startTime).String(),
+	}
+
+	// Add dependency details if available
+	if len(status.Dependencies) > 0 {
+		response.Dependencies = make(map[string]*HealthCheckResult)
+		for name, dep := range status.Dependencies {
+			response.Dependencies[name] = &HealthCheckResult{
+				Name:      name,
+				Status:    dep.Status,
+				Duration:  dep.Latency,
+				Timestamp: dep.Timestamp,
+				Error:     dep.Error,
+			}
+		}
+	}
+
+	statusCode := http.StatusOK
+	if status.Status != types.HealthStatusHealthy {
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	c.JSON(statusCode, response)
+}
+
+// ReadinessCheck handles the readiness probe endpoint
+// @Summary Readiness check
+// @Description Returns whether the service is ready to accept traffic
+// @Tags health
+// @Produce json
+// @Success 200 {object} ReadinessResponse "Service is ready"
+// @Failure 503 {object} ReadinessResponse "Service is not ready"
+// @Router /health/ready [get]
+func (h *EndpointHandler) ReadinessCheck(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	status, err := h.adapter.CheckReadiness(ctx)
+
+	response := &ReadinessResponse{
+		Service:   h.serviceName,
+		Timestamp: time.Now(),
+		Ready:     false,
+	}
+
+	if err != nil {
+		logger.Logger.Debug("Readiness check failed", zap.Error(err))
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusServiceUnavailable, response)
+		return
+	}
+
+	if status.Status == types.HealthStatusHealthy {
+		response.Ready = true
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusOK, response)
+	} else {
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusServiceUnavailable, response)
+	}
+}
+
+// LivenessCheck handles the liveness probe endpoint
+// @Summary Liveness check
+// @Description Returns whether the service is alive and should not be restarted
+// @Tags health
+// @Produce json
+// @Success 200 {object} LivenessResponse "Service is alive"
+// @Failure 503 {object} LivenessResponse "Service is not alive"
+// @Router /health/live [get]
+func (h *EndpointHandler) LivenessCheck(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	status, err := h.adapter.CheckLiveness(ctx)
+
+	response := &LivenessResponse{
+		Service:   h.serviceName,
+		Timestamp: time.Now(),
+		Alive:     false,
+	}
+
+	if err != nil {
+		logger.Logger.Warn("Liveness check failed", zap.Error(err))
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusServiceUnavailable, response)
+		return
+	}
+
+	if status.Status == types.HealthStatusHealthy {
+		response.Alive = true
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusOK, response)
+	} else {
+		response.Checks = h.buildCheckResults(status)
+		c.JSON(http.StatusServiceUnavailable, response)
+	}
+}
+
+// DetailedHealthCheck handles the detailed health check endpoint
+// @Summary Detailed health check
+// @Description Returns detailed health status including all checks and their results
+// @Tags health
+// @Produce json
+// @Success 200 {object} map[string]interface{} "Detailed health status"
+// @Router /health/detailed [get]
+func (h *EndpointHandler) DetailedHealthCheck(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	// Get all check results
+	healthStatus, _ := h.adapter.CheckHealth(ctx)
+	readinessStatus, _ := h.adapter.CheckReadiness(ctx)
+	livenessStatus, _ := h.adapter.CheckLiveness(ctx)
+
+	// Get cached results
+	cachedResults := h.adapter.GetAllLastResults()
+
+	response := gin.H{
+		"service":   h.serviceName,
+		"version":   h.version,
+		"timestamp": time.Now(),
+		"uptime":    time.Since(h.startTime).String(),
+		"health": gin.H{
+			"status":       healthStatus.Status,
+			"dependencies": h.buildCheckResults(healthStatus),
+		},
+		"readiness": gin.H{
+			"status": readinessStatus.Status,
+			"checks": h.buildCheckResults(readinessStatus),
+		},
+		"liveness": gin.H{
+			"status": livenessStatus.Status,
+			"checks": h.buildCheckResults(livenessStatus),
+		},
+		"cached_results": cachedResults,
+	}
+
+	statusCode := http.StatusOK
+	if healthStatus.Status != types.HealthStatusHealthy {
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	c.JSON(statusCode, response)
+}
+
+// buildCheckResults converts health status dependencies to check results
+func (h *EndpointHandler) buildCheckResults(status *types.HealthStatus) map[string]*HealthCheckResult {
+	if status == nil || len(status.Dependencies) == 0 {
+		return nil
+	}
+
+	results := make(map[string]*HealthCheckResult)
+	for name, dep := range status.Dependencies {
+		results[name] = &HealthCheckResult{
+			Name:      name,
+			Status:    dep.Status,
+			Duration:  dep.Latency,
+			Timestamp: dep.Timestamp,
+			Error:     dep.Error,
+		}
+	}
+	return results
+}
+
+// RegisterWithObservability registers health endpoints with the observability manager
+// This integrates with the existing server framework
+func RegisterWithObservability(router *gin.Engine, adapter *HealthCheckAdapter, serviceName, version string) {
+	handler := NewEndpointHandler(adapter, serviceName, version)
+	handler.RegisterRoutes(router)
+}

--- a/pkg/server/health/endpoints_test.go
+++ b/pkg/server/health/endpoints_test.go
@@ -1,0 +1,285 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupTestRouter(adapter *HealthCheckAdapter, serviceName, version string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewEndpointHandler(adapter, serviceName, version)
+	handler.RegisterRoutes(router)
+	return router
+}
+
+func TestEndpointHandler_HealthCheck(t *testing.T) {
+	tests := []struct {
+		name               string
+		checkers           []HealthChecker
+		expectedStatusCode int
+		expectHealthy      bool
+	}{
+		{
+			name:               "healthy service",
+			checkers:           []HealthChecker{&mockHealthChecker{name: "check1"}},
+			expectedStatusCode: http.StatusOK,
+			expectHealthy:      true,
+		},
+		{
+			name: "unhealthy service",
+			checkers: []HealthChecker{
+				&mockHealthChecker{
+					name: "check1",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("failed")
+					},
+				},
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectHealthy:      false,
+		},
+		{
+			name:               "no checkers",
+			checkers:           []HealthChecker{},
+			expectedStatusCode: http.StatusOK,
+			expectHealthy:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+			for _, checker := range tt.checkers {
+				adapter.RegisterHealthChecker(checker)
+			}
+
+			router := setupTestRouter(adapter, "test-service", "v1.0.0")
+
+			req, _ := http.NewRequest("GET", "/health", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedStatusCode, w.Code)
+			}
+
+			var response HealthResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if response.Service != "test-service" {
+				t.Errorf("expected service 'test-service', got %s", response.Service)
+			}
+
+			if response.Version != "v1.0.0" {
+				t.Errorf("expected version 'v1.0.0', got %s", response.Version)
+			}
+		})
+	}
+}
+
+func TestEndpointHandler_ReadinessCheck(t *testing.T) {
+	tests := []struct {
+		name               string
+		checkers           []ReadinessChecker
+		expectedStatusCode int
+		expectReady        bool
+	}{
+		{
+			name:               "ready service",
+			checkers:           []ReadinessChecker{&mockReadinessChecker{name: "ready1"}},
+			expectedStatusCode: http.StatusOK,
+			expectReady:        true,
+		},
+		{
+			name: "not ready service",
+			checkers: []ReadinessChecker{
+				&mockReadinessChecker{
+					name: "ready1",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("not ready")
+					},
+				},
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectReady:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+			for _, checker := range tt.checkers {
+				adapter.RegisterReadinessChecker(checker)
+			}
+
+			router := setupTestRouter(adapter, "test-service", "v1.0.0")
+
+			// Test /health/ready endpoint
+			req, _ := http.NewRequest("GET", "/health/ready", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedStatusCode, w.Code)
+			}
+
+			var response ReadinessResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if response.Ready != tt.expectReady {
+				t.Errorf("expected ready %v, got %v", tt.expectReady, response.Ready)
+			}
+		})
+	}
+}
+
+func TestEndpointHandler_LivenessCheck(t *testing.T) {
+	tests := []struct {
+		name               string
+		checkers           []LivenessChecker
+		expectedStatusCode int
+		expectAlive        bool
+	}{
+		{
+			name:               "alive service",
+			checkers:           []LivenessChecker{&mockLivenessChecker{name: "live1"}},
+			expectedStatusCode: http.StatusOK,
+			expectAlive:        true,
+		},
+		{
+			name: "not alive service",
+			checkers: []LivenessChecker{
+				&mockLivenessChecker{
+					name: "live1",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("not alive")
+					},
+				},
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectAlive:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewHealthCheckAdapter(nil)
+			for _, checker := range tt.checkers {
+				adapter.RegisterLivenessChecker(checker)
+			}
+
+			router := setupTestRouter(adapter, "test-service", "v1.0.0")
+
+			// Test /health/live endpoint
+			req, _ := http.NewRequest("GET", "/health/live", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedStatusCode, w.Code)
+			}
+
+			var response LivenessResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if response.Alive != tt.expectAlive {
+				t.Errorf("expected alive %v, got %v", tt.expectAlive, response.Alive)
+			}
+		})
+	}
+}
+
+func TestEndpointHandler_AlternativePaths(t *testing.T) {
+	adapter := NewHealthCheckAdapter(nil)
+	router := setupTestRouter(adapter, "test-service", "v1.0.0")
+
+	tests := []struct {
+		path               string
+		expectedStatusCode int
+	}{
+		{path: "/health", expectedStatusCode: http.StatusOK},
+		{path: "/health/ready", expectedStatusCode: http.StatusOK},
+		{path: "/ready", expectedStatusCode: http.StatusOK},
+		{path: "/health/live", expectedStatusCode: http.StatusOK},
+		{path: "/live", expectedStatusCode: http.StatusOK},
+		{path: "/health/detailed", expectedStatusCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("path %s: expected status code %d, got %d", tt.path, tt.expectedStatusCode, w.Code)
+			}
+		})
+	}
+}
+
+func TestEndpointHandler_DetailedHealthCheck(t *testing.T) {
+	adapter := NewHealthCheckAdapter(nil)
+
+	// Register various checkers
+	adapter.RegisterHealthChecker(&mockHealthChecker{name: "health1"})
+	adapter.RegisterReadinessChecker(&mockReadinessChecker{name: "ready1"})
+	adapter.RegisterLivenessChecker(&mockLivenessChecker{name: "live1"})
+
+	router := setupTestRouter(adapter, "test-service", "v1.0.0")
+
+	req, _ := http.NewRequest("GET", "/health/detailed", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	// Check that response contains expected fields
+	expectedFields := []string{"service", "version", "timestamp", "uptime", "health", "readiness", "liveness"}
+	for _, field := range expectedFields {
+		if _, exists := response[field]; !exists {
+			t.Errorf("expected field '%s' in response", field)
+		}
+	}
+}

--- a/pkg/server/health/example_test.go
+++ b/pkg/server/health/example_test.go
@@ -1,0 +1,200 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/innovationmech/swit/pkg/server/health"
+)
+
+// Example_basicUsage demonstrates basic usage of the health check system
+func Example_basicUsage() {
+	// Create health check adapter with default configuration
+	adapter := health.NewHealthCheckAdapter(nil)
+
+	// Register a basic health checker
+	dbChecker := health.NewBasicHealthChecker("database", func(ctx context.Context) error {
+		// Simulate database ping
+		return nil
+	})
+	adapter.RegisterHealthChecker(dbChecker)
+
+	// Perform health check
+	ctx := context.Background()
+	status, err := adapter.CheckHealth(ctx)
+	if err != nil {
+		fmt.Printf("Health check error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Health status: %s\n", status.Status)
+	// Output: Health status: healthy
+}
+
+// Example_readinessProbe demonstrates readiness probe usage
+func Example_readinessProbe() {
+	// Create health check adapter
+	adapter := health.NewHealthCheckAdapter(nil)
+
+	// Create readiness probe with 100ms minimum start time
+	readinessProbe := health.NewServiceReadinessProbe("my-service", 100*time.Millisecond)
+
+	// Register the probe
+	adapter.RegisterReadinessChecker(readinessProbe)
+
+	// Initially not ready (before min start time and not marked ready)
+	ctx := context.Background()
+	err := readinessProbe.CheckReadiness(ctx)
+	if err != nil {
+		fmt.Println("Service not ready initially")
+	}
+
+	// Wait for minimum start time and mark as ready
+	time.Sleep(150 * time.Millisecond)
+	readinessProbe.SetReady(true)
+
+	// Check readiness again
+	err = readinessProbe.CheckReadiness(ctx)
+	if err == nil {
+		fmt.Println("Service is ready")
+	}
+
+	// Output:
+	// Service not ready initially
+	// Service is ready
+}
+
+// Example_livenessProbe demonstrates liveness probe usage with heartbeat
+func Example_livenessProbe() {
+	// Create liveness probe with 200ms timeout
+	livenessProbe := health.NewServiceLivenessProbe("my-service", 200*time.Millisecond)
+
+	// Start heartbeat with 50ms interval
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	livenessProbe.StartHeartbeat(ctx, 50*time.Millisecond)
+
+	// Check liveness multiple times
+	checkCtx := context.Background()
+	for i := 0; i < 3; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if err := livenessProbe.CheckLiveness(checkCtx); err == nil {
+			fmt.Printf("Check %d: Service is alive\n", i+1)
+		}
+	}
+
+	// Output:
+	// Check 1: Service is alive
+	// Check 2: Service is alive
+	// Check 3: Service is alive
+}
+
+// Example_httpEndpoints demonstrates HTTP endpoint registration
+func Example_httpEndpoints() {
+	// Create health check adapter
+	adapter := health.NewHealthCheckAdapter(nil)
+
+	// Register health checkers
+	checker := health.NewBasicHealthChecker("example", func(ctx context.Context) error {
+		return nil
+	})
+	adapter.RegisterHealthChecker(checker)
+
+	// Setup HTTP router
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+
+	// Register health check endpoints
+	handler := health.NewEndpointHandler(adapter, "example-service", "v1.0.0")
+	handler.RegisterRoutes(router)
+
+	fmt.Println("Registered health check endpoints:")
+	fmt.Println("- GET /health")
+	fmt.Println("- GET /health/ready")
+	fmt.Println("- GET /health/live")
+	fmt.Println("- GET /health/detailed")
+
+	// Output:
+	// Registered health check endpoints:
+	// - GET /health
+	// - GET /health/ready
+	// - GET /health/live
+	// - GET /health/detailed
+}
+
+// Example_compositeChecker demonstrates composite health checker usage
+func Example_compositeChecker() {
+	// Create individual checkers
+	dbChecker := health.NewBasicHealthChecker("database", func(ctx context.Context) error {
+		return nil
+	})
+
+	redisChecker := health.NewBasicHealthChecker("redis", func(ctx context.Context) error {
+		return nil
+	})
+
+	// Create composite checker
+	compositeChecker := health.NewCompositeHealthChecker(
+		"dependencies",
+		dbChecker,
+		redisChecker,
+	)
+
+	// Check all dependencies
+	ctx := context.Background()
+	if err := compositeChecker.Check(ctx); err == nil {
+		fmt.Println("All dependencies are healthy")
+	}
+
+	// Output: All dependencies are healthy
+}
+
+// Example_customConfiguration demonstrates custom health check configuration
+func Example_customConfiguration() {
+	// Create custom configuration
+	config := &health.HealthCheckConfig{
+		Timeout:       5 * time.Second,
+		Interval:      30 * time.Second,
+		MaxConcurrent: 10,
+	}
+
+	// Create adapter with custom config
+	adapter := health.NewHealthCheckAdapter(config)
+
+	// Register checkers
+	checker := health.NewBasicHealthChecker("service", func(ctx context.Context) error {
+		// Simulate work
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	})
+	adapter.RegisterHealthChecker(checker)
+
+	ctx := context.Background()
+	status, _ := adapter.CheckHealth(ctx)
+
+	fmt.Printf("Health check completed with status: %s\n", status.Status)
+	// Output: Health check completed with status: healthy
+}

--- a/pkg/server/health/probes.go
+++ b/pkg/server/health/probes.go
@@ -1,0 +1,292 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// BasicHealthChecker implements a basic health checker
+type BasicHealthChecker struct {
+	name        string
+	checkFunc   func(context.Context) error
+	description string
+}
+
+// NewBasicHealthChecker creates a new basic health checker
+func NewBasicHealthChecker(name string, checkFunc func(context.Context) error) *BasicHealthChecker {
+	return &BasicHealthChecker{
+		name:      name,
+		checkFunc: checkFunc,
+	}
+}
+
+// Check performs the health check
+func (c *BasicHealthChecker) Check(ctx context.Context) error {
+	if c.checkFunc == nil {
+		return nil // No-op check always passes
+	}
+	return c.checkFunc(ctx)
+}
+
+// GetName returns the health checker name
+func (c *BasicHealthChecker) GetName() string {
+	return c.name
+}
+
+// BasicReadinessChecker implements a basic readiness checker
+type BasicReadinessChecker struct {
+	name      string
+	checkFunc func(context.Context) error
+}
+
+// NewBasicReadinessChecker creates a new basic readiness checker
+func NewBasicReadinessChecker(name string, checkFunc func(context.Context) error) *BasicReadinessChecker {
+	return &BasicReadinessChecker{
+		name:      name,
+		checkFunc: checkFunc,
+	}
+}
+
+// CheckReadiness performs the readiness check
+func (c *BasicReadinessChecker) CheckReadiness(ctx context.Context) error {
+	if c.checkFunc == nil {
+		return nil // No-op check always passes
+	}
+	return c.checkFunc(ctx)
+}
+
+// GetName returns the readiness checker name
+func (c *BasicReadinessChecker) GetName() string {
+	return c.name
+}
+
+// BasicLivenessChecker implements a basic liveness checker
+type BasicLivenessChecker struct {
+	name      string
+	checkFunc func(context.Context) error
+}
+
+// NewBasicLivenessChecker creates a new basic liveness checker
+func NewBasicLivenessChecker(name string, checkFunc func(context.Context) error) *BasicLivenessChecker {
+	return &BasicLivenessChecker{
+		name:      name,
+		checkFunc: checkFunc,
+	}
+}
+
+// CheckLiveness performs the liveness check
+func (c *BasicLivenessChecker) CheckLiveness(ctx context.Context) error {
+	if c.checkFunc == nil {
+		return nil // No-op check always passes
+	}
+	return c.checkFunc(ctx)
+}
+
+// GetName returns the liveness checker name
+func (c *BasicLivenessChecker) GetName() string {
+	return c.name
+}
+
+// ServiceReadinessProbe checks if a service is ready to handle requests
+type ServiceReadinessProbe struct {
+	name         string
+	startTime    time.Time
+	minStartTime time.Duration
+	isReady      atomic.Bool
+}
+
+// NewServiceReadinessProbe creates a new service readiness probe
+func NewServiceReadinessProbe(name string, minStartTime time.Duration) *ServiceReadinessProbe {
+	probe := &ServiceReadinessProbe{
+		name:         name,
+		startTime:    time.Now(),
+		minStartTime: minStartTime,
+	}
+	probe.isReady.Store(false)
+	return probe
+}
+
+// CheckReadiness checks if the service is ready
+func (p *ServiceReadinessProbe) CheckReadiness(ctx context.Context) error {
+	// Check minimum start time has elapsed
+	if time.Since(p.startTime) < p.minStartTime {
+		return fmt.Errorf("service %s still starting up", p.name)
+	}
+
+	// Check if manually marked as ready
+	if !p.isReady.Load() {
+		return fmt.Errorf("service %s not ready", p.name)
+	}
+
+	return nil
+}
+
+// GetName returns the probe name
+func (p *ServiceReadinessProbe) GetName() string {
+	return p.name
+}
+
+// SetReady marks the service as ready
+func (p *ServiceReadinessProbe) SetReady(ready bool) {
+	p.isReady.Store(ready)
+}
+
+// IsReady returns the current readiness state
+func (p *ServiceReadinessProbe) IsReady() bool {
+	return p.isReady.Load()
+}
+
+// ServiceLivenessProbe checks if a service is alive
+type ServiceLivenessProbe struct {
+	name      string
+	lastPing  atomic.Int64
+	timeout   time.Duration
+	isRunning atomic.Bool
+}
+
+// NewServiceLivenessProbe creates a new service liveness probe
+func NewServiceLivenessProbe(name string, timeout time.Duration) *ServiceLivenessProbe {
+	probe := &ServiceLivenessProbe{
+		name:    name,
+		timeout: timeout,
+	}
+	probe.lastPing.Store(time.Now().UnixNano())
+	probe.isRunning.Store(true)
+	return probe
+}
+
+// CheckLiveness checks if the service is alive
+func (p *ServiceLivenessProbe) CheckLiveness(ctx context.Context) error {
+	if !p.isRunning.Load() {
+		return fmt.Errorf("service %s is not running", p.name)
+	}
+
+	lastPingTime := time.Unix(0, p.lastPing.Load())
+	if time.Since(lastPingTime) > p.timeout {
+		return fmt.Errorf("service %s has not responded within %v", p.name, p.timeout)
+	}
+
+	return nil
+}
+
+// GetName returns the probe name
+func (p *ServiceLivenessProbe) GetName() string {
+	return p.name
+}
+
+// Ping updates the last ping time
+func (p *ServiceLivenessProbe) Ping() {
+	p.lastPing.Store(time.Now().UnixNano())
+}
+
+// SetRunning sets the running state
+func (p *ServiceLivenessProbe) SetRunning(running bool) {
+	p.isRunning.Store(running)
+	if running {
+		p.Ping()
+	}
+}
+
+// IsRunning returns the current running state
+func (p *ServiceLivenessProbe) IsRunning() bool {
+	return p.isRunning.Load()
+}
+
+// StartHeartbeat starts a heartbeat goroutine
+func (p *ServiceLivenessProbe) StartHeartbeat(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if p.isRunning.Load() {
+					p.Ping()
+				}
+			}
+		}
+	}()
+}
+
+// DependencyHealthChecker checks the health of a dependency
+type DependencyHealthChecker struct {
+	name       string
+	dependency HealthChecker
+}
+
+// NewDependencyHealthChecker creates a new dependency health checker
+func NewDependencyHealthChecker(name string, dependency HealthChecker) *DependencyHealthChecker {
+	return &DependencyHealthChecker{
+		name:       name,
+		dependency: dependency,
+	}
+}
+
+// Check performs the health check
+func (c *DependencyHealthChecker) Check(ctx context.Context) error {
+	return c.dependency.Check(ctx)
+}
+
+// GetName returns the health checker name
+func (c *DependencyHealthChecker) GetName() string {
+	return c.name
+}
+
+// CompositeHealthChecker aggregates multiple health checkers
+type CompositeHealthChecker struct {
+	name     string
+	checkers []HealthChecker
+}
+
+// NewCompositeHealthChecker creates a new composite health checker
+func NewCompositeHealthChecker(name string, checkers ...HealthChecker) *CompositeHealthChecker {
+	return &CompositeHealthChecker{
+		name:     name,
+		checkers: checkers,
+	}
+}
+
+// Check performs all health checks and returns error if any fails
+func (c *CompositeHealthChecker) Check(ctx context.Context) error {
+	for _, checker := range c.checkers {
+		if err := checker.Check(ctx); err != nil {
+			return fmt.Errorf("%s check failed: %w", checker.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// GetName returns the health checker name
+func (c *CompositeHealthChecker) GetName() string {
+	return c.name
+}
+
+// AddChecker adds a health checker to the composite
+func (c *CompositeHealthChecker) AddChecker(checker HealthChecker) {
+	c.checkers = append(c.checkers, checker)
+}

--- a/pkg/server/health/probes_test.go
+++ b/pkg/server/health/probes_test.go
@@ -1,0 +1,285 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewBasicHealthChecker(t *testing.T) {
+	checker := NewBasicHealthChecker("test", nil)
+	if checker == nil {
+		t.Fatal("expected non-nil checker")
+	}
+
+	if checker.GetName() != "test" {
+		t.Errorf("expected name 'test', got %s", checker.GetName())
+	}
+
+	// Check with nil function should pass
+	ctx := context.Background()
+	if err := checker.Check(ctx); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestBasicHealthChecker_CheckWithFunction(t *testing.T) {
+	testErr := errors.New("check failed")
+	checker := NewBasicHealthChecker("test", func(ctx context.Context) error {
+		return testErr
+	})
+
+	ctx := context.Background()
+	err := checker.Check(ctx)
+	if err != testErr {
+		t.Errorf("expected error %v, got %v", testErr, err)
+	}
+}
+
+func TestServiceReadinessProbe(t *testing.T) {
+	probe := NewServiceReadinessProbe("test-service", 100*time.Millisecond)
+
+	ctx := context.Background()
+
+	// Should not be ready initially
+	err := probe.CheckReadiness(ctx)
+	if err == nil {
+		t.Error("expected error when not ready")
+	}
+
+	// Mark as ready
+	probe.SetReady(true)
+
+	// Wait for min start time
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be ready now
+	err = probe.CheckReadiness(ctx)
+	if err != nil {
+		t.Errorf("expected nil error when ready, got %v", err)
+	}
+
+	// Mark as not ready
+	probe.SetReady(false)
+
+	// Should not be ready again
+	err = probe.CheckReadiness(ctx)
+	if err == nil {
+		t.Error("expected error after marking not ready")
+	}
+}
+
+func TestServiceReadinessProbe_IsReady(t *testing.T) {
+	probe := NewServiceReadinessProbe("test-service", 0)
+
+	if probe.IsReady() {
+		t.Error("expected IsReady to be false initially")
+	}
+
+	probe.SetReady(true)
+
+	if !probe.IsReady() {
+		t.Error("expected IsReady to be true after SetReady(true)")
+	}
+}
+
+func TestServiceLivenessProbe(t *testing.T) {
+	probe := NewServiceLivenessProbe("test-service", 100*time.Millisecond)
+
+	ctx := context.Background()
+
+	// Should be alive initially
+	err := probe.CheckLiveness(ctx)
+	if err != nil {
+		t.Errorf("expected nil error when alive, got %v", err)
+	}
+
+	// Mark as not running
+	probe.SetRunning(false)
+
+	// Should not be alive
+	err = probe.CheckLiveness(ctx)
+	if err == nil {
+		t.Error("expected error when not running")
+	}
+
+	// Mark as running again
+	probe.SetRunning(true)
+
+	// Should be alive again
+	err = probe.CheckLiveness(ctx)
+	if err != nil {
+		t.Errorf("expected nil error when alive, got %v", err)
+	}
+}
+
+func TestServiceLivenessProbe_Timeout(t *testing.T) {
+	probe := NewServiceLivenessProbe("test-service", 50*time.Millisecond)
+
+	ctx := context.Background()
+
+	// Should be alive initially
+	err := probe.CheckLiveness(ctx)
+	if err != nil {
+		t.Errorf("expected nil error when alive, got %v", err)
+	}
+
+	// Wait for timeout
+	time.Sleep(100 * time.Millisecond)
+
+	// Should timeout
+	err = probe.CheckLiveness(ctx)
+	if err == nil {
+		t.Error("expected error after timeout")
+	}
+
+	// Ping to update last ping time
+	probe.Ping()
+
+	// Should be alive again
+	err = probe.CheckLiveness(ctx)
+	if err != nil {
+		t.Errorf("expected nil error after ping, got %v", err)
+	}
+}
+
+func TestServiceLivenessProbe_Heartbeat(t *testing.T) {
+	probe := NewServiceLivenessProbe("test-service", 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start heartbeat
+	probe.StartHeartbeat(ctx, 20*time.Millisecond)
+
+	// Wait longer than the liveness timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// Should still be alive due to heartbeat
+	checkCtx := context.Background()
+	err := probe.CheckLiveness(checkCtx)
+	if err != nil {
+		t.Errorf("expected nil error with heartbeat running, got %v", err)
+	}
+
+	// Stop heartbeat
+	cancel()
+
+	// Wait for timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// Should timeout now
+	err = probe.CheckLiveness(checkCtx)
+	if err == nil {
+		t.Error("expected error after heartbeat stopped and timeout")
+	}
+}
+
+func TestDependencyHealthChecker(t *testing.T) {
+	testErr := errors.New("dependency check failed")
+	depChecker := &mockHealthChecker{
+		name: "dep",
+		checkFunc: func(ctx context.Context) error {
+			return testErr
+		},
+	}
+
+	checker := NewDependencyHealthChecker("my-dependency", depChecker)
+
+	if checker.GetName() != "my-dependency" {
+		t.Errorf("expected name 'my-dependency', got %s", checker.GetName())
+	}
+
+	ctx := context.Background()
+	err := checker.Check(ctx)
+	if err != testErr {
+		t.Errorf("expected error %v, got %v", testErr, err)
+	}
+}
+
+func TestCompositeHealthChecker(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkers  []HealthChecker
+		expectErr bool
+	}{
+		{
+			name: "all checks pass",
+			checkers: []HealthChecker{
+				&mockHealthChecker{name: "check1"},
+				&mockHealthChecker{name: "check2"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "one check fails",
+			checkers: []HealthChecker{
+				&mockHealthChecker{name: "check1"},
+				&mockHealthChecker{
+					name: "check2",
+					checkFunc: func(ctx context.Context) error {
+						return errors.New("failed")
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "no checkers",
+			checkers:  []HealthChecker{},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewCompositeHealthChecker("composite", tt.checkers...)
+
+			ctx := context.Background()
+			err := checker.Check(ctx)
+
+			if tt.expectErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected nil error but got %v", err)
+			}
+		})
+	}
+}
+
+func TestCompositeHealthChecker_AddChecker(t *testing.T) {
+	checker := NewCompositeHealthChecker("composite")
+
+	checker.AddChecker(&mockHealthChecker{name: "check1"})
+	checker.AddChecker(&mockHealthChecker{name: "check2"})
+
+	ctx := context.Background()
+	err := checker.Check(ctx)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements comprehensive health check system with readiness and liveness probes integration as specified in issue #430.

## Changes

### Core Implementation
- **Health Check Adapter Pattern** ()
  - Extensible adapter for registering multiple health checkers
  - Support for health, readiness, and liveness checks
  - Concurrent execution with configurable timeout
  - Result caching for debugging and monitoring

- **Probe Implementations** ()
  - BasicHealthChecker, BasicReadinessChecker, BasicLivenessChecker
  - ServiceReadinessProbe with minimum startup time
  - ServiceLivenessProbe with heartbeat mechanism
  - CompositeHealthChecker for aggregating multiple checks
  - DependencyHealthChecker for wrapping existing checks

### HTTP Endpoints ()
- `GET /health` - Overall health status
- `GET /health/ready` or `GET /ready` - Readiness probe (Kubernetes compatible)
- `GET /health/live` or `GET /live` - Liveness probe (Kubernetes compatible)
- `GET /health/detailed` - Detailed health status with all checks

### Testing
- Comprehensive unit tests with >90% coverage
- Test files for adapter, probes, and endpoints
- Example tests demonstrating usage patterns
- All tests pass successfully

### Documentation
- Complete README with usage examples
- Kubernetes integration examples
- Best practices guide
- Architecture diagrams

## DoD Checklist

- [x] HTTP endpoints implemented
- [x] Adapters created
- [x] Tests written and passing
- [x] Documentation provided
- [x] Code quality checks passed

## Related Issues

Closes #430

Part of #177 (Integration Patterns & Advanced Features)
Depends on #173, #174, #175 (all closed)

## Testing

All tests pass:
```
make test        # ✅ All tests pass
make quality-dev # ✅ Code quality checks pass
```

## Screenshots/Examples

Example readiness probe configuration for Kubernetes:
```yaml
readinessProbe:
  httpGet:
    path: /health/ready
    port: 8080
  initialDelaySeconds: 10
  periodSeconds: 5
```