### PR TITLE
feat(resilience): circuit breaker implementation

### DIFF
--- a/pkg/resilience/circuit_breaker.go
+++ b/pkg/resilience/circuit_breaker.go
@@ -1,0 +1,314 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrOpenState 表示熔断器处于打开状态
+	ErrOpenState = errors.New("circuit breaker is open")
+
+	// ErrTooManyRequests 表示半开状态下请求过多
+	ErrTooManyRequests = errors.New("too many requests in half-open state")
+)
+
+// CircuitBreaker 实现熔断器模式。
+//
+// 熔断器有三种状态：
+// - Closed: 正常处理请求，统计失败次数/失败率
+// - Open: 直接拒绝请求，快速失败
+// - Half-Open: 允许有限数量的请求通过以测试服务是否恢复
+type CircuitBreaker struct {
+	name   string
+	config CircuitBreakerConfig
+
+	mu              sync.Mutex
+	state           State
+	generation      uint64
+	counts          Counts
+	expiry          time.Time
+	halfOpenSuccess uint32
+
+	metrics *CircuitBreakerMetrics
+}
+
+// NewCircuitBreaker 创建一个新的熔断器实例。
+func NewCircuitBreaker(config CircuitBreakerConfig) (*CircuitBreaker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	// 如果没有提供 ReadyToTrip 函数，使用默认实现
+	if config.ReadyToTrip == nil {
+		config.ReadyToTrip = func(counts Counts) bool {
+			// 请求数必须达到最小阈值
+			if counts.Requests < config.MinimumRequests {
+				return false
+			}
+			// 失败次数超过阈值或失败率超过阈值
+			return counts.TotalFailures >= config.FailureThreshold ||
+				counts.FailureRate() >= config.FailureRateThreshold
+		}
+	}
+
+	// 如果没有提供 IsSuccessful 函数，使用默认实现
+	if config.IsSuccessful == nil {
+		config.IsSuccessful = func(err error) bool {
+			return err == nil
+		}
+	}
+
+	cb := &CircuitBreaker{
+		name:    config.Name,
+		config:  config,
+		state:   StateClosed,
+		expiry:  time.Now().Add(config.Interval),
+		metrics: NewCircuitBreakerMetrics(),
+	}
+
+	return cb, nil
+}
+
+// Execute 执行给定的操作，并根据结果更新熔断器状态。
+func (cb *CircuitBreaker) Execute(ctx context.Context, operation func() error) error {
+	// 检查 context 是否已取消
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	generation, err := cb.beforeRequest()
+	if err != nil {
+		cb.metrics.RecordRejection()
+		return err
+	}
+
+	defer func() {
+		if e := recover(); e != nil {
+			cb.afterRequest(generation, false)
+			panic(e)
+		}
+	}()
+
+	result := operation()
+	success := cb.config.IsSuccessful(result)
+	cb.afterRequest(generation, success)
+
+	return result
+}
+
+// ExecuteWithResult 执行给定的操作并返回结果。
+func ExecuteWithResult[T any](ctx context.Context, cb *CircuitBreaker, operation func() (T, error)) (T, error) {
+	var zero T
+
+	// 检查 context 是否已取消
+	select {
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	default:
+	}
+
+	generation, err := cb.beforeRequest()
+	if err != nil {
+		cb.metrics.RecordRejection()
+		return zero, err
+	}
+
+	defer func() {
+		if e := recover(); e != nil {
+			cb.afterRequest(generation, false)
+			panic(e)
+		}
+	}()
+
+	result, opErr := operation()
+	success := cb.config.IsSuccessful(opErr)
+	cb.afterRequest(generation, success)
+
+	return result, opErr
+}
+
+// GetState 返回当前熔断器状态。
+func (cb *CircuitBreaker) GetState() State {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := time.Now()
+	state, _ := cb.currentState(now)
+	return state
+}
+
+// GetCounts 返回当前统计计数。
+func (cb *CircuitBreaker) GetCounts() Counts {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	return cb.counts
+}
+
+// GetMetrics 返回熔断器的指标统计。
+func (cb *CircuitBreaker) GetMetrics() *CircuitBreakerMetrics {
+	return cb.metrics
+}
+
+// Reset 重置熔断器到关闭状态。
+func (cb *CircuitBreaker) Reset() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.toNewGeneration(time.Now(), StateClosed)
+}
+
+// beforeRequest 在请求执行前检查熔断器状态。
+func (cb *CircuitBreaker) beforeRequest() (uint64, error) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := time.Now()
+	state, generation := cb.currentState(now)
+
+	if state == StateOpen {
+		return generation, ErrOpenState
+	}
+
+	if state == StateHalfOpen && cb.halfOpenSuccess >= cb.config.MaxRequests {
+		return generation, ErrTooManyRequests
+	}
+
+	if state == StateHalfOpen {
+		cb.halfOpenSuccess++
+	}
+
+	cb.metrics.RecordRequest()
+	return generation, nil
+}
+
+// afterRequest 在请求执行后更新熔断器状态。
+func (cb *CircuitBreaker) afterRequest(generation uint64, success bool) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := time.Now()
+	state, currentGeneration := cb.currentState(now)
+
+	// 如果代数不匹配，说明状态已经改变，忽略这次结果
+	if generation != currentGeneration {
+		return
+	}
+
+	if success {
+		cb.onSuccess(state, now)
+	} else {
+		cb.onFailure(state, now)
+	}
+}
+
+// onSuccess 处理成功的请求。
+func (cb *CircuitBreaker) onSuccess(state State, now time.Time) {
+	cb.metrics.RecordSuccess()
+
+	switch state {
+	case StateClosed:
+		cb.counts.onSuccess()
+	case StateHalfOpen:
+		cb.counts.onSuccess()
+		// 如果半开状态下所有测试请求都成功，转换到关闭状态
+		if cb.counts.ConsecutiveSuccesses >= cb.config.MaxRequests {
+			cb.toNewGeneration(now, StateClosed)
+		}
+	}
+}
+
+// onFailure 处理失败的请求。
+func (cb *CircuitBreaker) onFailure(state State, now time.Time) {
+	cb.metrics.RecordFailure()
+
+	switch state {
+	case StateClosed:
+		cb.counts.onFailure()
+		// 检查是否应该打开熔断器
+		if cb.config.ReadyToTrip(cb.counts) {
+			cb.toNewGeneration(now, StateOpen)
+		}
+	case StateHalfOpen:
+		// 半开状态下任何失败都会重新打开熔断器
+		cb.toNewGeneration(now, StateOpen)
+	}
+}
+
+// currentState 返回当前状态和代数。
+// 如果处于打开状态且超时，则自动转换到半开状态。
+func (cb *CircuitBreaker) currentState(now time.Time) (State, uint64) {
+	switch cb.state {
+	case StateClosed:
+		// 检查是否需要重置统计窗口
+		if cb.expiry.Before(now) {
+			cb.toNewGeneration(now, StateClosed)
+		}
+	case StateOpen:
+		// 检查是否应该进入半开状态
+		if cb.expiry.Before(now) {
+			cb.toNewGeneration(now, StateHalfOpen)
+		}
+	}
+	return cb.state, cb.generation
+}
+
+// toNewGeneration 转换到新的状态和代数。
+func (cb *CircuitBreaker) toNewGeneration(now time.Time, newState State) {
+	if cb.state != newState {
+		cb.beforeStateChange(cb.state, newState)
+	}
+
+	cb.generation++
+	cb.counts.clear()
+	cb.halfOpenSuccess = 0
+
+	var expiry time.Time
+	switch newState {
+	case StateClosed:
+		expiry = now.Add(cb.config.Interval)
+		cb.metrics.RecordStateChange("closed")
+	case StateOpen:
+		expiry = now.Add(cb.config.Timeout)
+		cb.metrics.RecordStateChange("open")
+	case StateHalfOpen:
+		expiry = now.Add(cb.config.Timeout)
+		cb.metrics.RecordStateChange("half_open")
+	}
+
+	cb.state = newState
+	cb.expiry = expiry
+}
+
+// beforeStateChange 在状态改变前调用回调函数。
+func (cb *CircuitBreaker) beforeStateChange(from State, to State) {
+	if cb.config.OnStateChange != nil {
+		cb.config.OnStateChange(cb.name, from, to)
+	}
+}

--- a/pkg/resilience/circuit_breaker_config.go
+++ b/pkg/resilience/circuit_breaker_config.go
@@ -1,0 +1,177 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience
+
+import (
+	"fmt"
+	"time"
+)
+
+// CircuitBreakerConfig 定义熔断器的配置参数。
+//
+// 熔断器通过监控失败次数和失败率来决定是否打开电路，
+// 在打开状态下快速失败，避免对故障服务施加更多压力。
+type CircuitBreakerConfig struct {
+	// Name 熔断器名称，用于日志和指标标识
+	Name string `json:"name" yaml:"name"`
+
+	// MaxRequests 半开状态下允许通过的最大请求数
+	MaxRequests uint32 `json:"max_requests" yaml:"max_requests"`
+
+	// Interval 统计窗口期，在此期间内计算失败率
+	Interval time.Duration `json:"interval" yaml:"interval"`
+
+	// Timeout 打开状态持续时间，超时后进入半开状态
+	Timeout time.Duration `json:"timeout" yaml:"timeout"`
+
+	// ReadyToTrip 决定是否应该打开熔断器的函数
+	// 参数为当前计数器状态（请求总数、失败数）
+	ReadyToTrip func(counts Counts) bool `json:"-" yaml:"-"`
+
+	// OnStateChange 状态变化时的回调函数
+	OnStateChange func(name string, from State, to State) `json:"-" yaml:"-"`
+
+	// IsSuccessful 判断结果是否成功的函数
+	// 如果未设置，则将 error == nil 视为成功
+	IsSuccessful func(err error) bool `json:"-" yaml:"-"`
+
+	// FailureThreshold 失败次数阈值（当 ReadyToTrip 未设置时使用）
+	FailureThreshold uint32 `json:"failure_threshold" yaml:"failure_threshold"`
+
+	// FailureRateThreshold 失败率阈值（0-1），当 ReadyToTrip 未设置时使用
+	FailureRateThreshold float64 `json:"failure_rate_threshold" yaml:"failure_rate_threshold"`
+
+	// MinimumRequests 最小请求数，只有达到此数量才会计算失败率
+	MinimumRequests uint32 `json:"minimum_requests" yaml:"minimum_requests"`
+}
+
+// DefaultCircuitBreakerConfig 返回熔断器的默认配置。
+func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		Name:                 "default",
+		MaxRequests:          1,
+		Interval:             60 * time.Second,
+		Timeout:              60 * time.Second,
+		FailureThreshold:     5,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      10,
+		ReadyToTrip:          nil, // 使用默认实现
+		OnStateChange:        nil,
+		IsSuccessful:         nil, // 使用默认实现（error == nil）
+	}
+}
+
+// Validate 校验配置合法性。
+func (c *CircuitBreakerConfig) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("circuit breaker name cannot be empty")
+	}
+	if c.MaxRequests == 0 {
+		return fmt.Errorf("max_requests must be greater than 0")
+	}
+	if c.Interval <= 0 {
+		return fmt.Errorf("interval must be positive")
+	}
+	if c.Timeout <= 0 {
+		return fmt.Errorf("timeout must be positive")
+	}
+	if c.FailureRateThreshold < 0 || c.FailureRateThreshold > 1 {
+		return fmt.Errorf("failure_rate_threshold must be between 0 and 1")
+	}
+	if c.MinimumRequests == 0 {
+		return fmt.Errorf("minimum_requests must be greater than 0")
+	}
+	return nil
+}
+
+// State 表示熔断器的状态。
+type State int
+
+const (
+	// StateClosed 关闭状态，正常处理请求
+	StateClosed State = iota
+	// StateHalfOpen 半开状态，允许有限数量的请求通过以测试服务是否恢复
+	StateHalfOpen
+	// StateOpen 打开状态，直接拒绝请求
+	StateOpen
+)
+
+// String 返回状态的字符串表示。
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateHalfOpen:
+		return "half-open"
+	case StateOpen:
+		return "open"
+	default:
+		return fmt.Sprintf("unknown state: %d", s)
+	}
+}
+
+// Counts 记录熔断器的请求统计。
+type Counts struct {
+	// Requests 总请求数
+	Requests uint32
+	// TotalSuccesses 总成功数
+	TotalSuccesses uint32
+	// TotalFailures 总失败数
+	TotalFailures uint32
+	// ConsecutiveSuccesses 连续成功数
+	ConsecutiveSuccesses uint32
+	// ConsecutiveFailures 连续失败数
+	ConsecutiveFailures uint32
+}
+
+// FailureRate 计算失败率（0-1）。
+func (c *Counts) FailureRate() float64 {
+	if c.Requests == 0 {
+		return 0
+	}
+	return float64(c.TotalFailures) / float64(c.Requests)
+}
+
+// onSuccess 记录一次成功。
+func (c *Counts) onSuccess() {
+	c.Requests++
+	c.TotalSuccesses++
+	c.ConsecutiveSuccesses++
+	c.ConsecutiveFailures = 0
+}
+
+// onFailure 记录一次失败。
+func (c *Counts) onFailure() {
+	c.Requests++
+	c.TotalFailures++
+	c.ConsecutiveFailures++
+	c.ConsecutiveSuccesses = 0
+}
+
+// clear 清空计数器。
+func (c *Counts) clear() {
+	c.Requests = 0
+	c.TotalSuccesses = 0
+	c.TotalFailures = 0
+	c.ConsecutiveSuccesses = 0
+	c.ConsecutiveFailures = 0
+}

--- a/pkg/resilience/circuit_breaker_example_test.go
+++ b/pkg/resilience/circuit_breaker_example_test.go
@@ -1,0 +1,233 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/innovationmech/swit/pkg/resilience"
+)
+
+// ExampleCircuitBreaker_basic 演示熔断器的基本使用。
+func ExampleCircuitBreaker_basic() {
+	// 创建熔断器配置
+	config := resilience.CircuitBreakerConfig{
+		Name:                 "api-service",
+		MaxRequests:          1,
+		Interval:             60 * time.Second,
+		Timeout:              30 * time.Second,
+		FailureThreshold:     5,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      10,
+	}
+
+	// 创建熔断器
+	cb, err := resilience.NewCircuitBreaker(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// 执行操作
+	err = cb.Execute(ctx, func() error {
+		// 你的业务逻辑
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, resilience.ErrOpenState) {
+			fmt.Println("Circuit breaker is open")
+		} else {
+			fmt.Println("Operation failed:", err)
+		}
+	} else {
+		fmt.Println("Operation succeeded")
+	}
+
+	// Output: Operation succeeded
+}
+
+// ExampleCircuitBreaker_withResult 演示如何使用熔断器执行有返回值的操作。
+func ExampleCircuitBreaker_withResult() {
+	config := resilience.DefaultCircuitBreakerConfig()
+	cb, err := resilience.NewCircuitBreaker(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// 执行带返回值的操作
+	result, err := resilience.ExecuteWithResult(ctx, cb, func() (string, error) {
+		// 模拟 API 调用
+		return "success response", nil
+	})
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Result:", result)
+	// Output: Result: success response
+}
+
+// ExampleCircuitBreaker_stateTransitions 演示熔断器的状态转换。
+func ExampleCircuitBreaker_stateTransitions() {
+	config := resilience.CircuitBreakerConfig{
+		Name:                 "demo",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              100 * time.Millisecond,
+		FailureThreshold:     3,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      3,
+		OnStateChange: func(name string, from resilience.State, to resilience.State) {
+			fmt.Printf("State changed from %s to %s\n", from, to)
+		},
+	}
+
+	cb, _ := resilience.NewCircuitBreaker(config)
+	ctx := context.Background()
+
+	// 触发失败，打开熔断器
+	for i := 0; i < 3; i++ {
+		_ = cb.Execute(ctx, func() error {
+			return errors.New("service unavailable")
+		})
+	}
+
+	// 尝试执行请求（将被拒绝）
+	err := cb.Execute(ctx, func() error {
+		return nil
+	})
+
+	if errors.Is(err, resilience.ErrOpenState) {
+		fmt.Println("Request rejected: circuit breaker is open")
+	}
+
+	// Output:
+	// State changed from closed to open
+	// Request rejected: circuit breaker is open
+}
+
+// ExampleCircuitBreaker_customReadyToTrip 演示自定义熔断触发逻辑。
+func ExampleCircuitBreaker_customReadyToTrip() {
+	config := resilience.CircuitBreakerConfig{
+		Name:                 "custom",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              time.Second,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      5,
+		// 自定义触发逻辑：连续3次失败就打开
+		ReadyToTrip: func(counts resilience.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	}
+
+	cb, _ := resilience.NewCircuitBreaker(config)
+	ctx := context.Background()
+
+	// 连续3次失败会触发熔断
+	for i := 0; i < 3; i++ {
+		_ = cb.Execute(ctx, func() error {
+			return errors.New("failed")
+		})
+	}
+
+	fmt.Println("State:", cb.GetState())
+	// Output: State: open
+}
+
+// ExampleCircuitBreaker_metrics 演示如何获取和使用指标。
+func ExampleCircuitBreaker_metrics() {
+	config := resilience.DefaultCircuitBreakerConfig()
+	cb, _ := resilience.NewCircuitBreaker(config)
+	ctx := context.Background()
+
+	// 执行一些操作
+	_ = cb.Execute(ctx, func() error { return nil })
+	_ = cb.Execute(ctx, func() error { return errors.New("error") })
+
+	// 获取指标
+	metrics := cb.GetMetrics()
+	fmt.Printf("Total requests: %d\n", metrics.GetTotalRequests())
+	fmt.Printf("Total successes: %d\n", metrics.GetTotalSuccesses())
+	fmt.Printf("Total failures: %d\n", metrics.GetTotalFailures())
+	fmt.Printf("Failure rate: %.2f\n", metrics.GetFailureRate())
+
+	// Output:
+	// Total requests: 2
+	// Total successes: 1
+	// Total failures: 1
+	// Failure rate: 0.50
+}
+
+// ExampleCircuitBreaker_reset 演示如何重置熔断器。
+func ExampleCircuitBreaker_reset() {
+	config := resilience.CircuitBreakerConfig{
+		Name:                 "resetable",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              time.Hour, // 很长的超时
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+	}
+
+	cb, _ := resilience.NewCircuitBreaker(config)
+	ctx := context.Background()
+
+	// 触发熔断
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, func() error {
+			return errors.New("error")
+		})
+	}
+
+	fmt.Println("State before reset:", cb.GetState())
+
+	// 手动重置熔断器（例如在服务恢复后）
+	cb.Reset()
+
+	fmt.Println("State after reset:", cb.GetState())
+
+	// 现在可以正常执行请求
+	err := cb.Execute(ctx, func() error {
+		return nil
+	})
+
+	if err == nil {
+		fmt.Println("Request succeeded after reset")
+	}
+
+	// Output:
+	// State before reset: open
+	// State after reset: closed
+	// Request succeeded after reset
+}

--- a/pkg/resilience/circuit_breaker_metrics.go
+++ b/pkg/resilience/circuit_breaker_metrics.go
@@ -1,0 +1,139 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience
+
+import (
+	"sync/atomic"
+)
+
+// CircuitBreakerMetrics 包含熔断器的度量指标。
+type CircuitBreakerMetrics struct {
+	// TotalRequests 总请求数
+	TotalRequests atomic.Int64
+
+	// TotalSuccesses 总成功数
+	TotalSuccesses atomic.Int64
+
+	// TotalFailures 总失败数
+	TotalFailures atomic.Int64
+
+	// TotalRejections 总拒绝数（熔断器打开或半开状态下的请求）
+	TotalRejections atomic.Int64
+
+	// StateChanges 状态变更次数（按状态分类）
+	StateChangesToClosed   atomic.Int64
+	StateChangesToOpen     atomic.Int64
+	StateChangesToHalfOpen atomic.Int64
+}
+
+// NewCircuitBreakerMetrics 创建新的度量指标实例。
+func NewCircuitBreakerMetrics() *CircuitBreakerMetrics {
+	return &CircuitBreakerMetrics{}
+}
+
+// RecordRequest 记录一次请求。
+func (m *CircuitBreakerMetrics) RecordRequest() {
+	m.TotalRequests.Add(1)
+}
+
+// RecordSuccess 记录一次成功。
+func (m *CircuitBreakerMetrics) RecordSuccess() {
+	m.TotalSuccesses.Add(1)
+}
+
+// RecordFailure 记录一次失败。
+func (m *CircuitBreakerMetrics) RecordFailure() {
+	m.TotalFailures.Add(1)
+}
+
+// RecordRejection 记录一次拒绝。
+func (m *CircuitBreakerMetrics) RecordRejection() {
+	m.TotalRejections.Add(1)
+}
+
+// RecordStateChange 记录状态变更。
+func (m *CircuitBreakerMetrics) RecordStateChange(state string) {
+	switch state {
+	case "closed":
+		m.StateChangesToClosed.Add(1)
+	case "open":
+		m.StateChangesToOpen.Add(1)
+	case "half_open":
+		m.StateChangesToHalfOpen.Add(1)
+	}
+}
+
+// GetTotalRequests 返回总请求数。
+func (m *CircuitBreakerMetrics) GetTotalRequests() int64 {
+	return m.TotalRequests.Load()
+}
+
+// GetTotalSuccesses 返回总成功数。
+func (m *CircuitBreakerMetrics) GetTotalSuccesses() int64 {
+	return m.TotalSuccesses.Load()
+}
+
+// GetTotalFailures 返回总失败数。
+func (m *CircuitBreakerMetrics) GetTotalFailures() int64 {
+	return m.TotalFailures.Load()
+}
+
+// GetTotalRejections 返回总拒绝数。
+func (m *CircuitBreakerMetrics) GetTotalRejections() int64 {
+	return m.TotalRejections.Load()
+}
+
+// GetStateChangesToClosed 返回转换到关闭状态的次数。
+func (m *CircuitBreakerMetrics) GetStateChangesToClosed() int64 {
+	return m.StateChangesToClosed.Load()
+}
+
+// GetStateChangesToOpen 返回转换到打开状态的次数。
+func (m *CircuitBreakerMetrics) GetStateChangesToOpen() int64 {
+	return m.StateChangesToOpen.Load()
+}
+
+// GetStateChangesToHalfOpen 返回转换到半开状态的次数。
+func (m *CircuitBreakerMetrics) GetStateChangesToHalfOpen() int64 {
+	return m.StateChangesToHalfOpen.Load()
+}
+
+// GetFailureRate 返回失败率（0-1）。
+func (m *CircuitBreakerMetrics) GetFailureRate() float64 {
+	total := m.TotalRequests.Load()
+	if total == 0 {
+		return 0
+	}
+	failures := m.TotalFailures.Load()
+	return float64(failures) / float64(total)
+}
+
+// Reset 重置所有度量指标。
+func (m *CircuitBreakerMetrics) Reset() {
+	m.TotalRequests.Store(0)
+	m.TotalSuccesses.Store(0)
+	m.TotalFailures.Store(0)
+	m.TotalRejections.Store(0)
+	m.StateChangesToClosed.Store(0)
+	m.StateChangesToOpen.Store(0)
+	m.StateChangesToHalfOpen.Store(0)
+}

--- a/pkg/resilience/circuit_breaker_prometheus.go
+++ b/pkg/resilience/circuit_breaker_prometheus.go
@@ -1,0 +1,157 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// CircuitBreakerPrometheusMetrics 包含熔断器的 Prometheus 指标。
+type CircuitBreakerPrometheusMetrics struct {
+	Requests        *prometheus.CounterVec
+	Successes       *prometheus.CounterVec
+	Failures        *prometheus.CounterVec
+	Rejections      *prometheus.CounterVec
+	StateChanges    *prometheus.CounterVec
+	State           *prometheus.GaugeVec
+	FailureRate     *prometheus.GaugeVec
+	RequestDuration *prometheus.HistogramVec
+}
+
+// NewCircuitBreakerPrometheusMetrics 创建并注册熔断器 Prometheus 指标。
+func NewCircuitBreakerPrometheusMetrics(namespace string, subsystem string) *CircuitBreakerPrometheusMetrics {
+	if namespace == "" {
+		namespace = "swit"
+	}
+	if subsystem == "" {
+		subsystem = "circuit_breaker"
+	}
+
+	return &CircuitBreakerPrometheusMetrics{
+		Requests: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "requests_total",
+			Help:      "Total number of requests processed by the circuit breaker",
+		}, []string{"name"}),
+
+		Successes: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "successes_total",
+			Help:      "Total number of successful requests",
+		}, []string{"name"}),
+
+		Failures: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "failures_total",
+			Help:      "Total number of failed requests",
+		}, []string{"name"}),
+
+		Rejections: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rejections_total",
+			Help:      "Total number of rejected requests (circuit breaker open or half-open)",
+		}, []string{"name"}),
+
+		StateChanges: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "state_changes_total",
+			Help:      "Total number of state changes",
+		}, []string{"name", "state"}),
+
+		State: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "state",
+			Help:      "Current state of the circuit breaker (0=closed, 1=half-open, 2=open)",
+		}, []string{"name"}),
+
+		FailureRate: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "failure_rate",
+			Help:      "Current failure rate of the circuit breaker",
+		}, []string{"name"}),
+
+		RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "request_duration_seconds",
+			Help:      "Duration of requests processed by the circuit breaker",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"name", "result"}),
+	}
+}
+
+// RecordRequest 记录一次请求。
+func (p *CircuitBreakerPrometheusMetrics) RecordRequest(name string) {
+	p.Requests.WithLabelValues(name).Inc()
+}
+
+// RecordSuccess 记录一次成功。
+func (p *CircuitBreakerPrometheusMetrics) RecordSuccess(name string) {
+	p.Successes.WithLabelValues(name).Inc()
+}
+
+// RecordFailure 记录一次失败。
+func (p *CircuitBreakerPrometheusMetrics) RecordFailure(name string) {
+	p.Failures.WithLabelValues(name).Inc()
+}
+
+// RecordRejection 记录一次拒绝。
+func (p *CircuitBreakerPrometheusMetrics) RecordRejection(name string) {
+	p.Rejections.WithLabelValues(name).Inc()
+}
+
+// RecordStateChange 记录状态变更。
+func (p *CircuitBreakerPrometheusMetrics) RecordStateChange(name string, toState string) {
+	p.StateChanges.WithLabelValues(name, toState).Inc()
+}
+
+// UpdateState 更新当前状态。
+func (p *CircuitBreakerPrometheusMetrics) UpdateState(name string, state State) {
+	p.State.WithLabelValues(name).Set(float64(state))
+}
+
+// UpdateFailureRate 更新失败率。
+func (p *CircuitBreakerPrometheusMetrics) UpdateFailureRate(name string, rate float64) {
+	p.FailureRate.WithLabelValues(name).Set(rate)
+}
+
+// RecordDuration 记录请求持续时间。
+func (p *CircuitBreakerPrometheusMetrics) RecordDuration(name string, result string, duration float64) {
+	p.RequestDuration.WithLabelValues(name, result).Observe(duration)
+}
+
+// UpdateFromCircuitBreakerMetrics 从 CircuitBreakerMetrics 更新 Prometheus 指标。
+func (p *CircuitBreakerPrometheusMetrics) UpdateFromCircuitBreakerMetrics(name string, metrics *CircuitBreakerMetrics, state State) {
+	// 更新状态
+	p.UpdateState(name, state)
+
+	// 更新失败率
+	p.UpdateFailureRate(name, metrics.GetFailureRate())
+}

--- a/pkg/resilience/circuit_breaker_test.go
+++ b/pkg/resilience/circuit_breaker_test.go
@@ -1,0 +1,568 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package resilience
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreakerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  CircuitBreakerConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			config:  DefaultCircuitBreakerConfig(),
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			config: CircuitBreakerConfig{
+				Name:                 "",
+				MaxRequests:          1,
+				Interval:             time.Second,
+				Timeout:              time.Second,
+				FailureRateThreshold: 0.5,
+				MinimumRequests:      1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero max requests",
+			config: CircuitBreakerConfig{
+				Name:                 "test",
+				MaxRequests:          0,
+				Interval:             time.Second,
+				Timeout:              time.Second,
+				FailureRateThreshold: 0.5,
+				MinimumRequests:      1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative interval",
+			config: CircuitBreakerConfig{
+				Name:                 "test",
+				MaxRequests:          1,
+				Interval:             -time.Second,
+				Timeout:              time.Second,
+				FailureRateThreshold: 0.5,
+				MinimumRequests:      1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid failure rate",
+			config: CircuitBreakerConfig{
+				Name:                 "test",
+				MaxRequests:          1,
+				Interval:             time.Second,
+				Timeout:              time.Second,
+				FailureRateThreshold: 1.5,
+				MinimumRequests:      1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCircuitBreaker_NewCircuitBreaker(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		config := DefaultCircuitBreakerConfig()
+		cb, err := NewCircuitBreaker(config)
+		if err != nil {
+			t.Fatalf("NewCircuitBreaker() error = %v", err)
+		}
+		if cb == nil {
+			t.Fatal("NewCircuitBreaker() returned nil")
+		}
+		if cb.GetState() != StateClosed {
+			t.Errorf("initial state = %v, want %v", cb.GetState(), StateClosed)
+		}
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		config := CircuitBreakerConfig{
+			Name: "", // invalid
+		}
+		_, err := NewCircuitBreaker(config)
+		if err == nil {
+			t.Error("NewCircuitBreaker() expected error, got nil")
+		}
+	})
+}
+
+func TestCircuitBreaker_Execute_SuccessPath(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Second,
+		Timeout:              time.Second,
+		FailureThreshold:     3,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      1,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	successOp := func() error {
+		return nil
+	}
+
+	err = cb.Execute(ctx, successOp)
+	if err != nil {
+		t.Errorf("Execute() error = %v, want nil", err)
+	}
+
+	if cb.GetState() != StateClosed {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateClosed)
+	}
+
+	counts := cb.GetCounts()
+	if counts.TotalSuccesses != 1 {
+		t.Errorf("TotalSuccesses = %d, want 1", counts.TotalSuccesses)
+	}
+}
+
+func TestCircuitBreaker_Execute_FailureThreshold(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              100 * time.Millisecond,
+		FailureThreshold:     3,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      3,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+
+	// 触发失败阈值
+	for i := 0; i < 3; i++ {
+		err := cb.Execute(ctx, failOp)
+		if err == nil {
+			t.Error("Execute() expected error, got nil")
+		}
+	}
+
+	// 熔断器应该打开
+	if cb.GetState() != StateOpen {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateOpen)
+	}
+
+	// 下一次请求应该被拒绝
+	err = cb.Execute(ctx, failOp)
+	if !errors.Is(err, ErrOpenState) {
+		t.Errorf("Execute() error = %v, want %v", err, ErrOpenState)
+	}
+
+	metrics := cb.GetMetrics()
+	if metrics.GetTotalRejections() != 1 {
+		t.Errorf("TotalRejections = %d, want 1", metrics.GetTotalRejections())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenState(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          2,
+		Interval:             time.Minute,
+		Timeout:              50 * time.Millisecond, // 短超时以便快速测试
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+	successOp := func() error {
+		return nil
+	}
+
+	// 触发熔断器打开
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, failOp)
+	}
+
+	if cb.GetState() != StateOpen {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateOpen)
+	}
+
+	// 等待超时进入半开状态
+	time.Sleep(100 * time.Millisecond)
+
+	// 半开状态下的第一个请求
+	state := cb.GetState()
+	if state != StateHalfOpen {
+		t.Errorf("state = %v, want %v", state, StateHalfOpen)
+	}
+
+	// 半开状态下成功的请求应该关闭熔断器
+	for i := 0; i < 2; i++ {
+		err := cb.Execute(ctx, successOp)
+		if err != nil {
+			t.Errorf("Execute() error = %v, want nil", err)
+		}
+	}
+
+	// 熔断器应该关闭
+	if cb.GetState() != StateClosed {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateClosed)
+	}
+}
+
+func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              50 * time.Millisecond,
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+
+	// 打开熔断器
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, failOp)
+	}
+
+	// 等待进入半开状态
+	time.Sleep(100 * time.Millisecond)
+
+	if cb.GetState() != StateHalfOpen {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateHalfOpen)
+	}
+
+	// 半开状态下失败应该重新打开
+	_ = cb.Execute(ctx, failOp)
+
+	if cb.GetState() != StateOpen {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateOpen)
+	}
+}
+
+func TestCircuitBreaker_TooManyRequests(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              50 * time.Millisecond,
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+	successOp := func() error {
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}
+
+	// 打开熔断器
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, failOp)
+	}
+
+	// 等待进入半开状态
+	time.Sleep(100 * time.Millisecond)
+
+	// 启动第一个请求但不等待完成
+	go func() {
+		_ = cb.Execute(ctx, successOp)
+	}()
+
+	// 稍微等待确保第一个请求已经开始
+	time.Sleep(5 * time.Millisecond)
+
+	// 第二个请求应该被拒绝（超过 MaxRequests）
+	err = cb.Execute(ctx, successOp)
+	if !errors.Is(err, ErrTooManyRequests) {
+		t.Errorf("Execute() error = %v, want %v", err, ErrTooManyRequests)
+	}
+}
+
+func TestCircuitBreaker_Reset(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              time.Minute,
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+
+	// 打开熔断器
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, failOp)
+	}
+
+	if cb.GetState() != StateOpen {
+		t.Errorf("state = %v, want %v", cb.GetState(), StateOpen)
+	}
+
+	// 重置熔断器
+	cb.Reset()
+
+	if cb.GetState() != StateClosed {
+		t.Errorf("state after reset = %v, want %v", cb.GetState(), StateClosed)
+	}
+
+	counts := cb.GetCounts()
+	if counts.TotalFailures != 0 {
+		t.Errorf("TotalFailures after reset = %d, want 0", counts.TotalFailures)
+	}
+}
+
+func TestCircuitBreaker_StateCallback(t *testing.T) {
+	stateChanges := make([]string, 0)
+	config := CircuitBreakerConfig{
+		Name:                 "test",
+		MaxRequests:          1,
+		Interval:             time.Minute,
+		Timeout:              50 * time.Millisecond,
+		FailureThreshold:     2,
+		FailureRateThreshold: 0.5,
+		MinimumRequests:      2,
+		OnStateChange: func(name string, from State, to State) {
+			stateChanges = append(stateChanges, to.String())
+		},
+	}
+
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+	failOp := func() error {
+		return errors.New("operation failed")
+	}
+
+	// 打开熔断器
+	for i := 0; i < 2; i++ {
+		_ = cb.Execute(ctx, failOp)
+	}
+
+	// 等待进入半开状态
+	time.Sleep(100 * time.Millisecond)
+	_ = cb.GetState() // 触发状态检查
+
+	if len(stateChanges) < 2 {
+		t.Errorf("state changes = %v, want at least 2", stateChanges)
+	}
+
+	if stateChanges[0] != "open" {
+		t.Errorf("first state change = %v, want open", stateChanges[0])
+	}
+}
+
+func TestCircuitBreaker_ExecuteWithResult(t *testing.T) {
+	config := DefaultCircuitBreakerConfig()
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		op := func() (int, error) {
+			return 42, nil
+		}
+
+		result, err := ExecuteWithResult(ctx, cb, op)
+		if err != nil {
+			t.Errorf("ExecuteWithResult() error = %v, want nil", err)
+		}
+		if result != 42 {
+			t.Errorf("result = %d, want 42", result)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		expectedErr := errors.New("operation failed")
+		op := func() (int, error) {
+			return 0, expectedErr
+		}
+
+		result, err := ExecuteWithResult(ctx, cb, op)
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("ExecuteWithResult() error = %v, want %v", err, expectedErr)
+		}
+		if result != 0 {
+			t.Errorf("result = %d, want 0", result)
+		}
+	})
+}
+
+func TestCircuitBreaker_ContextCancellation(t *testing.T) {
+	config := DefaultCircuitBreakerConfig()
+	cb, err := NewCircuitBreaker(config)
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消
+
+	op := func() error {
+		return nil
+	}
+
+	err = cb.Execute(ctx, op)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Execute() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestCounts_FailureRate(t *testing.T) {
+	tests := []struct {
+		name     string
+		counts   Counts
+		wantRate float64
+	}{
+		{
+			name:     "no requests",
+			counts:   Counts{},
+			wantRate: 0,
+		},
+		{
+			name: "50% failure rate",
+			counts: Counts{
+				Requests:      10,
+				TotalFailures: 5,
+			},
+			wantRate: 0.5,
+		},
+		{
+			name: "100% failure rate",
+			counts: Counts{
+				Requests:      10,
+				TotalFailures: 10,
+			},
+			wantRate: 1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rate := tt.counts.FailureRate()
+			if rate != tt.wantRate {
+				t.Errorf("FailureRate() = %v, want %v", rate, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestCircuitBreakerMetrics(t *testing.T) {
+	metrics := NewCircuitBreakerMetrics()
+
+	metrics.RecordRequest()
+	metrics.RecordSuccess()
+	metrics.RecordFailure()
+	metrics.RecordRejection()
+	metrics.RecordStateChange("open")
+
+	if metrics.GetTotalRequests() != 1 {
+		t.Errorf("TotalRequests = %d, want 1", metrics.GetTotalRequests())
+	}
+	if metrics.GetTotalSuccesses() != 1 {
+		t.Errorf("TotalSuccesses = %d, want 1", metrics.GetTotalSuccesses())
+	}
+	if metrics.GetTotalFailures() != 1 {
+		t.Errorf("TotalFailures = %d, want 1", metrics.GetTotalFailures())
+	}
+	if metrics.GetTotalRejections() != 1 {
+		t.Errorf("TotalRejections = %d, want 1", metrics.GetTotalRejections())
+	}
+	if metrics.GetStateChangesToOpen() != 1 {
+		t.Errorf("StateChangesToOpen = %d, want 1", metrics.GetStateChangesToOpen())
+	}
+
+	metrics.Reset()
+	if metrics.GetTotalRequests() != 0 {
+		t.Errorf("TotalRequests after reset = %d, want 0", metrics.GetTotalRequests())
+	}
+}


### PR DESCRIPTION
## 概述

实现熔断器模式，包含可配置的阈值和半开状态探测。

## 变更内容

### 核心功能
- ✅ 三种状态：Closed、Open、Half-Open，支持自动状态转换
- ✅ 可配置的失败阈值和失败率
- ✅ 半开状态探测，支持受控的请求数量
- ✅ 基于 atomic 操作的综合指标收集
- ✅ Prometheus 监控集成
- ✅ 泛型 ExecuteWithResult 支持带返回值的操作
- ✅ Context 感知的执行，支持取消操作
- ✅ 状态变更回调，增强可观测性

### 文件清单
- `circuit_breaker_config.go` - 配置结构和验证
- `circuit_breaker.go` - 核心熔断器逻辑和状态机
- `circuit_breaker_metrics.go` - 指标收集
- `circuit_breaker_prometheus.go` - Prometheus 集成
- `circuit_breaker_test.go` - 单元测试（67.6% 覆盖率）
- `circuit_breaker_example_test.go` - 使用示例

### 测试覆盖
- ✅ 配置验证测试（表驱动）
- ✅ 所有状态转换场景测试
- ✅ 半开状态并发测试
- ✅ Context 取消测试
- ✅ 指标收集测试

## 完成定义 (DoD)
- ✅ States: 实现了三种状态和自动转换
- ✅ Metrics: 完整的指标收集和 Prometheus 集成
- ✅ Tests: 67.6% 测试覆盖率，包含所有关键场景
- ✅ Docs: godoc 注释和使用示例

## 测试结果
```
go test ./pkg/resilience -v -run TestCircuitBreaker
PASS
ok      github.com/innovationmech/swit/pkg/resilience   0.983s

go test ./pkg/resilience -coverprofile=coverage.out
ok      github.com/innovationmech/swit/pkg/resilience   1.031s  coverage: 67.6%
```

## 使用示例
```go
// 创建熔断器配置
config := resilience.CircuitBreakerConfig{
    Name:                 "api-service",
    MaxRequests:          1,
    Interval:             60 * time.Second,
    Timeout:              30 * time.Second,
    FailureThreshold:     5,
    FailureRateThreshold: 0.5,
    MinimumRequests:      10,
}

// 创建熔断器
cb, err := resilience.NewCircuitBreaker(config)

// 执行操作
err = cb.Execute(ctx, func() error {
    // 业务逻辑
    return nil
})
```

Closes #434