### PR TITLE
feat(middleware): request context propagation

### DIFF
--- a/examples/context-propagation/README.md
+++ b/examples/context-propagation/README.md
@@ -1,0 +1,205 @@
+# Context Propagation Example
+
+This example demonstrates cross-transport context propagation in the SWIT framework. It shows how to maintain request context (correlation IDs, user information, tenant IDs, etc.) across HTTP, gRPC, and messaging transports.
+
+## Overview
+
+Context propagation is essential for:
+- **Distributed tracing**: Track requests across multiple services
+- **Request correlation**: Link related operations across different systems
+- **User context**: Maintain user identity and permissions throughout the request flow
+- **Multi-tenancy**: Preserve tenant isolation across service boundaries
+
+## Features Demonstrated
+
+1. **HTTP to Messaging**: Extract context from HTTP headers and inject into message headers
+2. **gRPC to Messaging**: Extract context from gRPC metadata and propagate to messages
+3. **Messaging to HTTP**: Extract context from messages and inject into HTTP headers
+4. **Gin to Messaging**: Extract context from Gin framework context and propagate to messages
+5. **Round-trip Propagation**: Maintain context through multiple transport hops (HTTP → Message → gRPC → Message → HTTP)
+
+## Running the Example
+
+```bash
+# From the project root directory
+cd examples/context-propagation
+go run main.go
+```
+
+## Expected Output
+
+The example will demonstrate five scenarios:
+
+### Example 1: HTTP to Messaging
+Shows how HTTP headers are extracted and propagated to message headers.
+
+```
+HTTP Headers:
+  Correlation-ID: http-corr-12345
+  User-ID: user-789
+  Tenant-ID: tenant-001
+
+Message Headers:
+  Correlation-ID: http-corr-12345
+  User-ID: user-789
+  Tenant-ID: tenant-001
+```
+
+### Example 2: gRPC to Messaging
+Shows how gRPC metadata is extracted and propagated to message headers.
+
+### Example 3: Messaging to HTTP
+Shows how message headers are extracted and propagated to HTTP headers.
+
+### Example 4: Gin to Messaging
+Shows how Gin context values and HTTP headers are combined and propagated.
+
+### Example 5: Round-trip Propagation
+Demonstrates end-to-end context propagation through multiple transports:
+- HTTP Request → Message Queue → gRPC Service → Message Queue → HTTP Webhook
+
+## Context Keys
+
+The following context keys are propagated across transports:
+
+- `X-Correlation-ID` / `x-correlation-id`: Unique identifier for request correlation
+- `X-Trace-ID` / `x-trace-id`: Distributed tracing trace ID
+- `X-Span-ID` / `x-span-id`: Distributed tracing span ID
+- `X-Request-ID` / `x-request-id`: Unique request identifier
+- `X-User-ID` / `x-user-id`: User identity
+- `X-Tenant-ID` / `x-tenant-id`: Tenant identifier for multi-tenant systems
+- `X-Session-ID` / `x-session-id`: Session identifier
+
+## API Reference
+
+### Context Propagator
+
+```go
+// Create a standard context propagator
+propagator := messaging.NewStandardContextPropagator()
+
+// Extract from HTTP
+ctx := propagator.ExtractFromHTTP(ctx, request)
+
+// Inject to Message
+propagator.InjectToMessage(ctx, message)
+```
+
+### Helper Functions
+
+```go
+// HTTP to Message
+ctx := messaging.PropagateHTTPToMessage(ctx, request, message)
+
+// Gin to Message
+ctx := messaging.PropagateGinToMessage(ginContext, message)
+
+// gRPC to Message
+ctx := messaging.PropagateGRPCToMessage(ctx, message)
+
+// Message to HTTP
+ctx := messaging.PropagateMessageToHTTP(ctx, message, httpHeader)
+
+// Message to gRPC
+ctx, metadata := messaging.PropagateMessageToGRPC(ctx, message)
+```
+
+## Integration with Your Service
+
+### HTTP Handler Example
+
+```go
+func handleRequest(c *gin.Context) {
+    // Create a message to publish
+    message := &messaging.Message{
+        ID:      "msg-001",
+        Topic:   "user.events",
+        Payload: []byte(`{"event": "user_created"}`),
+    }
+
+    // Propagate context from HTTP to message
+    ctx := messaging.PropagateGinToMessage(c, message)
+
+    // Publish the message
+    err := publisher.Publish(ctx, message)
+    if err != nil {
+        c.JSON(500, gin.H{"error": err.Error()})
+        return
+    }
+
+    c.JSON(200, gin.H{"status": "published"})
+}
+```
+
+### Message Handler Example
+
+```go
+func handleMessage(ctx context.Context, message *messaging.Message) error {
+    // Extract context from message
+    ctx = messaging.GlobalContextPropagator.ExtractFromMessage(ctx, message)
+
+    // Get correlation ID from context
+    if correlationID, ok := ctx.Value(messaging.ContextKeyCorrelationID).(string); ok {
+        log.Printf("Processing message with correlation ID: %s", correlationID)
+    }
+
+    // Call downstream gRPC service with propagated context
+    grpcCtx, md := messaging.GlobalContextPropagator.InjectToGRPC(ctx)
+    response, err := grpcClient.Process(grpcCtx, request)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+```
+
+### gRPC Interceptor Example
+
+```go
+func contextPropagationInterceptor() grpc.UnaryServerInterceptor {
+    return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+        // Extract context from gRPC metadata
+        propagator := messaging.NewStandardContextPropagator()
+        ctx = propagator.ExtractFromGRPC(ctx)
+
+        // Process the request with propagated context
+        return handler(ctx, req)
+    }
+}
+```
+
+## Custom Header Names
+
+You can customize the header names used for context propagation:
+
+```go
+propagator := messaging.NewContextPropagatorWithHeaders(map[string]string{
+    "trace_id":       "X-B3-TraceId",      // Use Zipkin B3 headers
+    "span_id":        "X-B3-SpanId",
+    "correlation_id": "X-Request-ID",      // Use Request-ID for correlation
+    "user_id":        "X-Auth-User-ID",
+    "tenant_id":      "X-Tenant-Code",
+})
+```
+
+## Best Practices
+
+1. **Always use correlation IDs**: Ensure every request has a unique correlation ID for tracing
+2. **Generate IDs at the edge**: Create correlation IDs at the first entry point (API Gateway, Load Balancer)
+3. **Preserve context across async operations**: Always propagate context when publishing messages
+4. **Use middleware consistently**: Apply context propagation middleware to all transports
+5. **Log with context**: Include correlation IDs in all log messages
+6. **Handle missing context gracefully**: Don't fail requests if context is missing, generate new IDs
+
+## Related Documentation
+
+- [Middleware Guide](../../docs/middleware-guide.md)
+- [Distributed Tracing](../../docs/tracing-user-guide.md)
+- [Messaging Documentation](../../pkg/messaging/README.md)
+
+## See Also
+
+- [Correlation Middleware](../../pkg/messaging/middleware/correlation.go)
+- [Tracing Middleware](../../pkg/messaging/middleware/tracing.go)
+- [Context Management](../../pkg/messaging/context.go)

--- a/examples/context-propagation/main.go
+++ b/examples/context-propagation/main.go
@@ -1,0 +1,315 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Package main demonstrates cross-transport context propagation in SWIT framework.
+// This example shows how to propagate request context information across HTTP, gRPC,
+// and messaging transports to maintain correlation IDs, user context, and trace information.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/innovationmech/swit/pkg/messaging"
+	"google.golang.org/grpc/metadata"
+)
+
+func main() {
+	fmt.Println("=== SWIT Context Propagation Example ===\n")
+
+	// Example 1: HTTP to Messaging
+	example1HTTPToMessaging()
+
+	// Example 2: gRPC to Messaging
+	example2GRPCToMessaging()
+
+	// Example 3: Messaging to HTTP
+	example3MessagingToHTTP()
+
+	// Example 4: Gin to Messaging
+	example4GinToMessaging()
+
+	// Example 5: Round-trip propagation
+	example5RoundTripPropagation()
+}
+
+// example1HTTPToMessaging demonstrates propagating context from HTTP request to messaging.
+func example1HTTPToMessaging() {
+	fmt.Println("Example 1: HTTP to Messaging")
+	fmt.Println("-----------------------------")
+
+	// Simulate an incoming HTTP request with headers
+	req, _ := http.NewRequest("GET", "/api/users", nil)
+	req.Header.Set("X-Correlation-ID", "http-corr-12345")
+	req.Header.Set("X-User-ID", "user-789")
+	req.Header.Set("X-Tenant-ID", "tenant-001")
+
+	// Create a message to publish
+	message := &messaging.Message{
+		ID:      "msg-001",
+		Topic:   "user.events",
+		Payload: []byte(`{"event": "user_created"}`),
+	}
+
+	// Propagate context from HTTP to message
+	ctx := messaging.PropagateHTTPToMessage(context.Background(), req, message)
+
+	// Display the results
+	fmt.Printf("HTTP Headers:\n")
+	fmt.Printf("  Correlation-ID: %s\n", req.Header.Get("X-Correlation-ID"))
+	fmt.Printf("  User-ID: %s\n", req.Header.Get("X-User-ID"))
+	fmt.Printf("  Tenant-ID: %s\n\n", req.Header.Get("X-Tenant-ID"))
+
+	fmt.Printf("Message Headers:\n")
+	fmt.Printf("  Correlation-ID: %s\n", message.CorrelationID)
+	fmt.Printf("  User-ID: %s\n", message.Headers["user_id"])
+	fmt.Printf("  Tenant-ID: %s\n\n", message.Headers["tenant_id"])
+
+	// Verify context
+	if correlationID := ctx.Value(messaging.ContextKeyCorrelationID); correlationID != nil {
+		fmt.Printf("✓ Context propagated successfully: Correlation ID = %v\n", correlationID)
+	}
+
+	fmt.Println()
+}
+
+// example2GRPCToMessaging demonstrates propagating context from gRPC to messaging.
+func example2GRPCToMessaging() {
+	fmt.Println("Example 2: gRPC to Messaging")
+	fmt.Println("----------------------------")
+
+	// Simulate incoming gRPC context with metadata
+	md := metadata.New(map[string]string{
+		"x-correlation-id": "grpc-corr-67890",
+		"x-user-id":        "user-456",
+		"x-tenant-id":      "tenant-002",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	// Create a message to publish
+	message := &messaging.Message{
+		ID:      "msg-002",
+		Topic:   "order.events",
+		Payload: []byte(`{"event": "order_placed"}`),
+	}
+
+	// Propagate context from gRPC to message
+	ctx = messaging.PropagateGRPCToMessage(ctx, message)
+
+	// Display the results
+	fmt.Printf("gRPC Metadata:\n")
+	fmt.Printf("  Correlation-ID: %s\n", md.Get("x-correlation-id")[0])
+	fmt.Printf("  User-ID: %s\n", md.Get("x-user-id")[0])
+	fmt.Printf("  Tenant-ID: %s\n\n", md.Get("x-tenant-id")[0])
+
+	fmt.Printf("Message Headers:\n")
+	fmt.Printf("  Correlation-ID: %s\n", message.CorrelationID)
+	fmt.Printf("  User-ID: %s\n", message.Headers["user_id"])
+	fmt.Printf("  Tenant-ID: %s\n\n", message.Headers["tenant_id"])
+
+	// Verify context
+	if correlationID := ctx.Value(messaging.ContextKeyCorrelationID); correlationID != nil {
+		fmt.Printf("✓ Context propagated successfully: Correlation ID = %v\n", correlationID)
+	}
+
+	fmt.Println()
+}
+
+// example3MessagingToHTTP demonstrates propagating context from messaging to HTTP.
+func example3MessagingToHTTP() {
+	fmt.Println("Example 3: Messaging to HTTP")
+	fmt.Println("----------------------------")
+
+	// Simulate an incoming message
+	message := &messaging.Message{
+		ID:            "msg-003",
+		Topic:         "webhook.trigger",
+		CorrelationID: "msg-corr-abc123",
+		Headers: map[string]string{
+			"user_id":   "user-123",
+			"tenant_id": "tenant-003",
+		},
+		Payload: []byte(`{"event": "webhook_triggered"}`),
+	}
+
+	// Create HTTP headers for outgoing webhook call
+	header := http.Header{}
+	ctx := messaging.PropagateMessageToHTTP(context.Background(), message, header)
+
+	// Display the results
+	fmt.Printf("Message Headers:\n")
+	fmt.Printf("  Correlation-ID: %s\n", message.CorrelationID)
+	fmt.Printf("  User-ID: %s\n", message.Headers["user_id"])
+	fmt.Printf("  Tenant-ID: %s\n\n", message.Headers["tenant_id"])
+
+	fmt.Printf("HTTP Headers:\n")
+	fmt.Printf("  X-Correlation-ID: %s\n", header.Get("X-Correlation-ID"))
+	fmt.Printf("  X-User-ID: %s\n", header.Get("X-User-ID"))
+	fmt.Printf("  X-Tenant-ID: %s\n\n", header.Get("X-Tenant-ID"))
+
+	// Verify context
+	if correlationID := ctx.Value(messaging.ContextKeyCorrelationID); correlationID != nil {
+		fmt.Printf("✓ Context propagated successfully: Correlation ID = %v\n", correlationID)
+	}
+
+	fmt.Println()
+}
+
+// example4GinToMessaging demonstrates propagating context from Gin context to messaging.
+func example4GinToMessaging() {
+	fmt.Println("Example 4: Gin to Messaging")
+	fmt.Println("---------------------------")
+
+	// Create a test Gin context
+	gin.SetMode(gin.TestMode)
+	w := &mockResponseWriter{}
+	c, _ := gin.CreateTestContext(w)
+
+	// Simulate incoming request with headers and gin context values
+	req, _ := http.NewRequest("POST", "/api/orders", nil)
+	req.Header.Set("X-Correlation-ID", "gin-corr-xyz789")
+	c.Request = req
+	c.Set("user_id", "user-999")
+	c.Set("tenant_id", "tenant-004")
+
+	// Create a message to publish
+	message := &messaging.Message{
+		ID:      "msg-004",
+		Topic:   "order.created",
+		Payload: []byte(`{"order_id": "order-123"}`),
+	}
+
+	// Propagate context from Gin to message
+	ctx := messaging.PropagateGinToMessage(c, message)
+
+	// Display the results
+	fmt.Printf("Gin Context:\n")
+	fmt.Printf("  Header Correlation-ID: %s\n", c.Request.Header.Get("X-Correlation-ID"))
+	fmt.Printf("  Context User-ID: %v\n", c.GetString("user_id"))
+	fmt.Printf("  Context Tenant-ID: %v\n\n", c.GetString("tenant_id"))
+
+	fmt.Printf("Message Headers:\n")
+	fmt.Printf("  Correlation-ID: %s\n", message.CorrelationID)
+	fmt.Printf("  User-ID: %s\n", message.Headers["user_id"])
+	fmt.Printf("  Tenant-ID: %s\n\n", message.Headers["tenant_id"])
+
+	// Verify context
+	if correlationID := ctx.Value(messaging.ContextKeyCorrelationID); correlationID != nil {
+		fmt.Printf("✓ Context propagated successfully: Correlation ID = %v\n", correlationID)
+	}
+
+	fmt.Println()
+}
+
+// example5RoundTripPropagation demonstrates context propagation through multiple transports.
+func example5RoundTripPropagation() {
+	fmt.Println("Example 5: Round-trip Context Propagation")
+	fmt.Println("------------------------------------------")
+
+	fmt.Println("Step 1: HTTP Request arrives")
+	// Step 1: HTTP Request arrives with correlation ID
+	req, _ := http.NewRequest("GET", "/api/process", nil)
+	req.Header.Set("X-Correlation-ID", "round-trip-001")
+	req.Header.Set("X-User-ID", "user-roundtrip")
+	fmt.Printf("  HTTP Correlation-ID: %s\n", req.Header.Get("X-Correlation-ID"))
+
+	fmt.Println("\nStep 2: HTTP -> Message (publish to queue)")
+	// Step 2: Service publishes message
+	message1 := &messaging.Message{
+		ID:      "msg-rt-001",
+		Topic:   "process.request",
+		Payload: []byte(`{"action": "process"}`),
+	}
+	ctx1 := messaging.PropagateHTTPToMessage(context.Background(), req, message1)
+	fmt.Printf("  Message Correlation-ID: %s\n", message1.CorrelationID)
+
+	// Simulate message being processed by another service
+	time.Sleep(10 * time.Millisecond)
+
+	fmt.Println("\nStep 3: Message -> gRPC (call downstream service)")
+	// Step 3: Consumer calls gRPC service
+	ctx2 := messaging.GlobalContextPropagator.ExtractFromMessage(ctx1, message1)
+	_, grpcMD := messaging.GlobalContextPropagator.InjectToGRPC(ctx2)
+	fmt.Printf("  gRPC Metadata Correlation-ID: %s\n", grpcMD.Get("x-correlation-id")[0])
+
+	// Simulate gRPC service processing
+	time.Sleep(10 * time.Millisecond)
+
+	fmt.Println("\nStep 4: gRPC -> Message (publish result)")
+	// Step 4: gRPC service publishes result
+	message2 := &messaging.Message{
+		ID:      "msg-rt-002",
+		Topic:   "process.result",
+		Payload: []byte(`{"status": "completed"}`),
+	}
+	ctx4 := metadata.NewIncomingContext(context.Background(), grpcMD)
+	ctx5 := messaging.PropagateGRPCToMessage(ctx4, message2)
+	fmt.Printf("  Message Correlation-ID: %s\n", message2.CorrelationID)
+
+	fmt.Println("\nStep 5: Message -> HTTP (send webhook)")
+	// Step 5: Send webhook with results
+	webhookHeader := http.Header{}
+	ctx6 := messaging.PropagateMessageToHTTP(ctx5, message2, webhookHeader)
+	fmt.Printf("  Webhook Header Correlation-ID: %s\n", webhookHeader.Get("X-Correlation-ID"))
+
+	// Verify correlation ID is preserved throughout the journey
+	originalCorrelationID := req.Header.Get("X-Correlation-ID")
+	finalCorrelationID := webhookHeader.Get("X-Correlation-ID")
+
+	fmt.Printf("\n✓ Correlation ID preserved: %s -> %s\n", originalCorrelationID, finalCorrelationID)
+	if originalCorrelationID == finalCorrelationID {
+		fmt.Println("✓ Round-trip propagation successful!")
+	} else {
+		log.Printf("✗ Correlation ID mismatch!")
+	}
+
+	// Verify user context is also preserved
+	if userID := ctx6.Value(messaging.ContextKeyUserID); userID == "user-roundtrip" {
+		fmt.Printf("✓ User context preserved: %v\n", userID)
+	}
+
+	fmt.Println()
+}
+
+// mockResponseWriter is a simple mock implementation for testing
+type mockResponseWriter struct {
+	headers http.Header
+	status  int
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	if m.headers == nil {
+		m.headers = http.Header{}
+	}
+	return m.headers
+}
+
+func (m *mockResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.status = statusCode
+}

--- a/pkg/messaging/context_propagation.go
+++ b/pkg/messaging/context_propagation.go
@@ -1,0 +1,438 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package messaging
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
+)
+
+// ContextPropagator defines the interface for context propagation across transport layers.
+// It provides methods to extract and inject context information between HTTP, gRPC, and messaging systems.
+type ContextPropagator interface {
+	// ExtractFromHTTP extracts context information from HTTP request
+	ExtractFromHTTP(ctx context.Context, r *http.Request) context.Context
+
+	// ExtractFromGin extracts context information from Gin context
+	ExtractFromGin(c *gin.Context) context.Context
+
+	// ExtractFromGRPC extracts context information from gRPC metadata
+	ExtractFromGRPC(ctx context.Context) context.Context
+
+	// ExtractFromMessage extracts context information from message headers
+	ExtractFromMessage(ctx context.Context, message *Message) context.Context
+
+	// InjectToHTTP injects context information into HTTP headers
+	InjectToHTTP(ctx context.Context, header http.Header)
+
+	// InjectToGRPC injects context information into gRPC metadata
+	InjectToGRPC(ctx context.Context) (context.Context, metadata.MD)
+
+	// InjectToMessage injects context information into message headers
+	InjectToMessage(ctx context.Context, message *Message)
+}
+
+// standardContextPropagator implements ContextPropagator with standard header names.
+type standardContextPropagator struct {
+	traceIDHeader       string
+	spanIDHeader        string
+	correlationIDHeader string
+	requestIDHeader     string
+	userIDHeader        string
+	tenantIDHeader      string
+	sessionIDHeader     string
+}
+
+// NewStandardContextPropagator creates a new standard context propagator with default header names.
+func NewStandardContextPropagator() ContextPropagator {
+	return &standardContextPropagator{
+		traceIDHeader:       "X-Trace-ID",
+		spanIDHeader:        "X-Span-ID",
+		correlationIDHeader: "X-Correlation-ID",
+		requestIDHeader:     "X-Request-ID",
+		userIDHeader:        "X-User-ID",
+		tenantIDHeader:      "X-Tenant-ID",
+		sessionIDHeader:     "X-Session-ID",
+	}
+}
+
+// NewContextPropagatorWithHeaders creates a context propagator with custom header names.
+func NewContextPropagatorWithHeaders(headers map[string]string) ContextPropagator {
+	cp := &standardContextPropagator{
+		traceIDHeader:       headers["trace_id"],
+		spanIDHeader:        headers["span_id"],
+		correlationIDHeader: headers["correlation_id"],
+		requestIDHeader:     headers["request_id"],
+		userIDHeader:        headers["user_id"],
+		tenantIDHeader:      headers["tenant_id"],
+		sessionIDHeader:     headers["session_id"],
+	}
+
+	// Set defaults for missing headers
+	if cp.traceIDHeader == "" {
+		cp.traceIDHeader = "X-Trace-ID"
+	}
+	if cp.spanIDHeader == "" {
+		cp.spanIDHeader = "X-Span-ID"
+	}
+	if cp.correlationIDHeader == "" {
+		cp.correlationIDHeader = "X-Correlation-ID"
+	}
+	if cp.requestIDHeader == "" {
+		cp.requestIDHeader = "X-Request-ID"
+	}
+	if cp.userIDHeader == "" {
+		cp.userIDHeader = "X-User-ID"
+	}
+	if cp.tenantIDHeader == "" {
+		cp.tenantIDHeader = "X-Tenant-ID"
+	}
+	if cp.sessionIDHeader == "" {
+		cp.sessionIDHeader = "X-Session-ID"
+	}
+
+	return cp
+}
+
+// ExtractFromHTTP extracts context information from HTTP request.
+func (cp *standardContextPropagator) ExtractFromHTTP(ctx context.Context, r *http.Request) context.Context {
+	if r == nil {
+		return ctx
+	}
+
+	// Extract trace information from OpenTelemetry span context if available
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		ctx = context.WithValue(ctx, ContextKeyTraceID, span.SpanContext().TraceID().String())
+		ctx = context.WithValue(ctx, "span_id", span.SpanContext().SpanID().String())
+	}
+
+	// Extract custom headers
+	if correlationID := r.Header.Get(cp.correlationIDHeader); correlationID != "" {
+		ctx = context.WithValue(ctx, ContextKeyCorrelationID, correlationID)
+	}
+
+	if requestID := r.Header.Get(cp.requestIDHeader); requestID != "" {
+		ctx = context.WithValue(ctx, ContextKeyRequestID, requestID)
+	}
+
+	if userID := r.Header.Get(cp.userIDHeader); userID != "" {
+		ctx = context.WithValue(ctx, ContextKeyUserID, userID)
+	}
+
+	if tenantID := r.Header.Get(cp.tenantIDHeader); tenantID != "" {
+		ctx = context.WithValue(ctx, ContextKeyTenantID, tenantID)
+	}
+
+	if sessionID := r.Header.Get(cp.sessionIDHeader); sessionID != "" {
+		ctx = context.WithValue(ctx, "session_id", sessionID)
+	}
+
+	return ctx
+}
+
+// ExtractFromGin extracts context information from Gin context.
+func (cp *standardContextPropagator) ExtractFromGin(c *gin.Context) context.Context {
+	ctx := c.Request.Context()
+
+	// Extract from HTTP request
+	ctx = cp.ExtractFromHTTP(ctx, c.Request)
+
+	// Also check Gin-specific context values
+	if userID, exists := c.Get("user_id"); exists {
+		if uid, ok := userID.(string); ok && uid != "" {
+			ctx = context.WithValue(ctx, ContextKeyUserID, uid)
+		}
+	}
+
+	if tenantID, exists := c.Get("tenant_id"); exists {
+		if tid, ok := tenantID.(string); ok && tid != "" {
+			ctx = context.WithValue(ctx, ContextKeyTenantID, tid)
+		}
+	}
+
+	return ctx
+}
+
+// ExtractFromGRPC extracts context information from gRPC metadata.
+func (cp *standardContextPropagator) ExtractFromGRPC(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	// Extract trace information from OpenTelemetry span context if available
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		ctx = context.WithValue(ctx, ContextKeyTraceID, span.SpanContext().TraceID().String())
+		ctx = context.WithValue(ctx, "span_id", span.SpanContext().SpanID().String())
+	}
+
+	// Extract correlation ID
+	if values := md.Get(cp.correlationIDHeader); len(values) > 0 {
+		ctx = context.WithValue(ctx, ContextKeyCorrelationID, values[0])
+	}
+
+	// Extract request ID
+	if values := md.Get(cp.requestIDHeader); len(values) > 0 {
+		ctx = context.WithValue(ctx, ContextKeyRequestID, values[0])
+	}
+
+	// Extract user ID
+	if values := md.Get(cp.userIDHeader); len(values) > 0 {
+		ctx = context.WithValue(ctx, ContextKeyUserID, values[0])
+	}
+
+	// Extract tenant ID
+	if values := md.Get(cp.tenantIDHeader); len(values) > 0 {
+		ctx = context.WithValue(ctx, ContextKeyTenantID, values[0])
+	}
+
+	// Extract session ID
+	if values := md.Get(cp.sessionIDHeader); len(values) > 0 {
+		ctx = context.WithValue(ctx, "session_id", values[0])
+	}
+
+	return ctx
+}
+
+// ExtractFromMessage extracts context information from message headers.
+func (cp *standardContextPropagator) ExtractFromMessage(ctx context.Context, message *Message) context.Context {
+	if message == nil || message.Headers == nil {
+		return ctx
+	}
+
+	// Extract trace ID
+	if traceID, ok := message.Headers["trace_id"]; ok {
+		ctx = context.WithValue(ctx, ContextKeyTraceID, traceID)
+	}
+
+	// Extract span ID
+	if spanID, ok := message.Headers["span_id"]; ok {
+		ctx = context.WithValue(ctx, "span_id", spanID)
+	}
+
+	// Extract correlation ID
+	if message.CorrelationID != "" {
+		ctx = context.WithValue(ctx, ContextKeyCorrelationID, message.CorrelationID)
+	}
+
+	// Extract request ID
+	if requestID, ok := message.Headers["request_id"]; ok {
+		ctx = context.WithValue(ctx, ContextKeyRequestID, requestID)
+	}
+
+	// Extract user ID
+	if userID, ok := message.Headers["user_id"]; ok {
+		ctx = context.WithValue(ctx, ContextKeyUserID, userID)
+	}
+
+	// Extract tenant ID
+	if tenantID, ok := message.Headers["tenant_id"]; ok {
+		ctx = context.WithValue(ctx, ContextKeyTenantID, tenantID)
+	}
+
+	// Extract session ID
+	if sessionID, ok := message.Headers["session_id"]; ok {
+		ctx = context.WithValue(ctx, "session_id", sessionID)
+	}
+
+	return ctx
+}
+
+// InjectToHTTP injects context information into HTTP headers.
+func (cp *standardContextPropagator) InjectToHTTP(ctx context.Context, header http.Header) {
+	if header == nil {
+		return
+	}
+
+	// Inject trace ID
+	if traceID, ok := ctx.Value(ContextKeyTraceID).(string); ok && traceID != "" {
+		header.Set(cp.traceIDHeader, traceID)
+	}
+
+	// Inject span ID
+	if spanID, ok := ctx.Value("span_id").(string); ok && spanID != "" {
+		header.Set(cp.spanIDHeader, spanID)
+	}
+
+	// Inject correlation ID
+	if correlationID, ok := ctx.Value(ContextKeyCorrelationID).(string); ok && correlationID != "" {
+		header.Set(cp.correlationIDHeader, correlationID)
+	}
+
+	// Inject request ID
+	if requestID, ok := ctx.Value(ContextKeyRequestID).(string); ok && requestID != "" {
+		header.Set(cp.requestIDHeader, requestID)
+	}
+
+	// Inject user ID
+	if userID, ok := ctx.Value(ContextKeyUserID).(string); ok && userID != "" {
+		header.Set(cp.userIDHeader, userID)
+	}
+
+	// Inject tenant ID
+	if tenantID, ok := ctx.Value(ContextKeyTenantID).(string); ok && tenantID != "" {
+		header.Set(cp.tenantIDHeader, tenantID)
+	}
+
+	// Inject session ID
+	if sessionID, ok := ctx.Value("session_id").(string); ok && sessionID != "" {
+		header.Set(cp.sessionIDHeader, sessionID)
+	}
+}
+
+// InjectToGRPC injects context information into gRPC metadata.
+func (cp *standardContextPropagator) InjectToGRPC(ctx context.Context) (context.Context, metadata.MD) {
+	md := metadata.MD{}
+
+	// Inject trace ID
+	if traceID, ok := ctx.Value(ContextKeyTraceID).(string); ok && traceID != "" {
+		md.Set(cp.traceIDHeader, traceID)
+	}
+
+	// Inject span ID
+	if spanID, ok := ctx.Value("span_id").(string); ok && spanID != "" {
+		md.Set(cp.spanIDHeader, spanID)
+	}
+
+	// Inject correlation ID
+	if correlationID, ok := ctx.Value(ContextKeyCorrelationID).(string); ok && correlationID != "" {
+		md.Set(cp.correlationIDHeader, correlationID)
+	}
+
+	// Inject request ID
+	if requestID, ok := ctx.Value(ContextKeyRequestID).(string); ok && requestID != "" {
+		md.Set(cp.requestIDHeader, requestID)
+	}
+
+	// Inject user ID
+	if userID, ok := ctx.Value(ContextKeyUserID).(string); ok && userID != "" {
+		md.Set(cp.userIDHeader, userID)
+	}
+
+	// Inject tenant ID
+	if tenantID, ok := ctx.Value(ContextKeyTenantID).(string); ok && tenantID != "" {
+		md.Set(cp.tenantIDHeader, tenantID)
+	}
+
+	// Inject session ID
+	if sessionID, ok := ctx.Value("session_id").(string); ok && sessionID != "" {
+		md.Set(cp.sessionIDHeader, sessionID)
+	}
+
+	// Merge with existing metadata if present
+	if existingMD, ok := metadata.FromOutgoingContext(ctx); ok {
+		md = metadata.Join(existingMD, md)
+	}
+
+	return metadata.NewOutgoingContext(ctx, md), md
+}
+
+// InjectToMessage injects context information into message headers.
+func (cp *standardContextPropagator) InjectToMessage(ctx context.Context, message *Message) {
+	if message == nil {
+		return
+	}
+
+	// Initialize headers if nil
+	if message.Headers == nil {
+		message.Headers = make(map[string]string)
+	}
+
+	// Inject trace ID
+	if traceID, ok := ctx.Value(ContextKeyTraceID).(string); ok && traceID != "" {
+		message.Headers["trace_id"] = traceID
+	}
+
+	// Inject span ID
+	if spanID, ok := ctx.Value("span_id").(string); ok && spanID != "" {
+		message.Headers["span_id"] = spanID
+	}
+
+	// Inject correlation ID
+	if correlationID, ok := ctx.Value(ContextKeyCorrelationID).(string); ok && correlationID != "" {
+		message.CorrelationID = correlationID
+		message.Headers["correlation_id"] = correlationID
+	}
+
+	// Inject request ID
+	if requestID, ok := ctx.Value(ContextKeyRequestID).(string); ok && requestID != "" {
+		message.Headers["request_id"] = requestID
+	}
+
+	// Inject user ID
+	if userID, ok := ctx.Value(ContextKeyUserID).(string); ok && userID != "" {
+		message.Headers["user_id"] = userID
+	}
+
+	// Inject tenant ID
+	if tenantID, ok := ctx.Value(ContextKeyTenantID).(string); ok && tenantID != "" {
+		message.Headers["tenant_id"] = tenantID
+	}
+
+	// Inject session ID
+	if sessionID, ok := ctx.Value("session_id").(string); ok && sessionID != "" {
+		message.Headers["session_id"] = sessionID
+	}
+}
+
+// GlobalContextPropagator provides a global instance for context propagation.
+var GlobalContextPropagator = NewStandardContextPropagator()
+
+// Helper functions for common use cases
+
+// PropagateHTTPToMessage propagates context from HTTP request to message.
+func PropagateHTTPToMessage(ctx context.Context, r *http.Request, message *Message) context.Context {
+	ctx = GlobalContextPropagator.ExtractFromHTTP(ctx, r)
+	GlobalContextPropagator.InjectToMessage(ctx, message)
+	return ctx
+}
+
+// PropagateGinToMessage propagates context from Gin context to message.
+func PropagateGinToMessage(c *gin.Context, message *Message) context.Context {
+	ctx := GlobalContextPropagator.ExtractFromGin(c)
+	GlobalContextPropagator.InjectToMessage(ctx, message)
+	return ctx
+}
+
+// PropagateGRPCToMessage propagates context from gRPC context to message.
+func PropagateGRPCToMessage(ctx context.Context, message *Message) context.Context {
+	ctx = GlobalContextPropagator.ExtractFromGRPC(ctx)
+	GlobalContextPropagator.InjectToMessage(ctx, message)
+	return ctx
+}
+
+// PropagateMessageToHTTP propagates context from message to HTTP headers.
+func PropagateMessageToHTTP(ctx context.Context, message *Message, header http.Header) context.Context {
+	ctx = GlobalContextPropagator.ExtractFromMessage(ctx, message)
+	GlobalContextPropagator.InjectToHTTP(ctx, header)
+	return ctx
+}
+
+// PropagateMessageToGRPC propagates context from message to gRPC metadata.
+func PropagateMessageToGRPC(ctx context.Context, message *Message) (context.Context, metadata.MD) {
+	ctx = GlobalContextPropagator.ExtractFromMessage(ctx, message)
+	return GlobalContextPropagator.InjectToGRPC(ctx)
+}

--- a/pkg/messaging/context_propagation_test.go
+++ b/pkg/messaging/context_propagation_test.go
@@ -1,0 +1,489 @@
+// Copyright © 2025 jackelyj <dreamerlyj@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package messaging
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestStandardContextPropagator_ExtractFromHTTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected map[ContextKey]string
+	}{
+		{
+			name: "extract all headers",
+			headers: map[string]string{
+				"X-Correlation-ID": "corr-123",
+				"X-Request-ID":     "req-456",
+				"X-User-ID":        "user-789",
+				"X-Tenant-ID":      "tenant-001",
+			},
+			expected: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyRequestID:     "req-456",
+				ContextKeyUserID:        "user-789",
+				ContextKeyTenantID:      "tenant-001",
+			},
+		},
+		{
+			name: "extract partial headers",
+			headers: map[string]string{
+				"X-Correlation-ID": "corr-123",
+				"X-User-ID":        "user-789",
+			},
+			expected: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyUserID:        "user-789",
+			},
+		},
+		{
+			name:     "no headers",
+			headers:  map[string]string{},
+			expected: map[ContextKey]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			propagator := NewStandardContextPropagator()
+			req := httptest.NewRequest("GET", "/test", nil)
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			ctx := propagator.ExtractFromHTTP(context.Background(), req)
+
+			for key, expectedValue := range tt.expected {
+				actualValue := ctx.Value(key)
+				assert.Equal(t, expectedValue, actualValue, "Expected %s to be %s", key, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_ExtractFromGin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		headers      map[string]string
+		ginValues    map[string]interface{}
+		expectedKeys map[ContextKey]string
+	}{
+		{
+			name: "extract from headers and gin context",
+			headers: map[string]string{
+				"X-Correlation-ID": "corr-123",
+				"X-Request-ID":     "req-456",
+			},
+			ginValues: map[string]interface{}{
+				"user_id":   "user-from-gin",
+				"tenant_id": "tenant-from-gin",
+			},
+			expectedKeys: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyRequestID:     "req-456",
+				ContextKeyUserID:        "user-from-gin",
+				ContextKeyTenantID:      "tenant-from-gin",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest("GET", "/test", nil)
+
+			for k, v := range tt.headers {
+				c.Request.Header.Set(k, v)
+			}
+
+			for k, v := range tt.ginValues {
+				c.Set(k, v)
+			}
+
+			propagator := NewStandardContextPropagator()
+			ctx := propagator.ExtractFromGin(c)
+
+			for key, expectedValue := range tt.expectedKeys {
+				actualValue := ctx.Value(key)
+				assert.Equal(t, expectedValue, actualValue, "Expected %s to be %s", key, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_ExtractFromGRPC(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     map[string]string
+		expectedKeys map[ContextKey]string
+	}{
+		{
+			name: "extract all metadata",
+			metadata: map[string]string{
+				"x-correlation-id": "corr-123",
+				"x-request-id":     "req-456",
+				"x-user-id":        "user-789",
+				"x-tenant-id":      "tenant-001",
+			},
+			expectedKeys: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyRequestID:     "req-456",
+				ContextKeyUserID:        "user-789",
+				ContextKeyTenantID:      "tenant-001",
+			},
+		},
+		{
+			name:         "no metadata",
+			metadata:     map[string]string{},
+			expectedKeys: map[ContextKey]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(tt.metadata)
+			ctx := metadata.NewIncomingContext(context.Background(), md)
+
+			propagator := NewStandardContextPropagator()
+			ctx = propagator.ExtractFromGRPC(ctx)
+
+			for key, expectedValue := range tt.expectedKeys {
+				actualValue := ctx.Value(key)
+				assert.Equal(t, expectedValue, actualValue, "Expected %s to be %s", key, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_ExtractFromMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		message      *Message
+		expectedKeys map[ContextKey]string
+	}{
+		{
+			name: "extract from message headers",
+			message: &Message{
+				ID:            "msg-123",
+				CorrelationID: "corr-123",
+				Headers: map[string]string{
+					"trace_id":   "trace-456",
+					"request_id": "req-789",
+					"user_id":    "user-001",
+					"tenant_id":  "tenant-002",
+				},
+			},
+			expectedKeys: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyTraceID:       "trace-456",
+				ContextKeyRequestID:     "req-789",
+				ContextKeyUserID:        "user-001",
+				ContextKeyTenantID:      "tenant-002",
+			},
+		},
+		{
+			name: "empty message",
+			message: &Message{
+				ID: "msg-123",
+			},
+			expectedKeys: map[ContextKey]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			propagator := NewStandardContextPropagator()
+			ctx := propagator.ExtractFromMessage(context.Background(), tt.message)
+
+			for key, expectedValue := range tt.expectedKeys {
+				actualValue := ctx.Value(key)
+				assert.Equal(t, expectedValue, actualValue, "Expected %s to be %s", key, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_InjectToHTTP(t *testing.T) {
+	tests := []struct {
+		name            string
+		contextValues   map[ContextKey]string
+		expectedHeaders map[string]string
+	}{
+		{
+			name: "inject all values",
+			contextValues: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyRequestID:     "req-456",
+				ContextKeyUserID:        "user-789",
+				ContextKeyTenantID:      "tenant-001",
+			},
+			expectedHeaders: map[string]string{
+				"X-Correlation-Id": "corr-123",
+				"X-Request-Id":     "req-456",
+				"X-User-Id":        "user-789",
+				"X-Tenant-Id":      "tenant-001",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			for k, v := range tt.contextValues {
+				ctx = context.WithValue(ctx, k, v)
+			}
+
+			header := http.Header{}
+			propagator := NewStandardContextPropagator()
+			propagator.InjectToHTTP(ctx, header)
+
+			for expectedKey, expectedValue := range tt.expectedHeaders {
+				actualValue := header.Get(expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Expected header %s to be %s", expectedKey, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_InjectToGRPC(t *testing.T) {
+	tests := []struct {
+		name             string
+		contextValues    map[ContextKey]string
+		expectedMetadata map[string]string
+	}{
+		{
+			name: "inject all values",
+			contextValues: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyRequestID:     "req-456",
+				ContextKeyUserID:        "user-789",
+				ContextKeyTenantID:      "tenant-001",
+			},
+			expectedMetadata: map[string]string{
+				"x-correlation-id": "corr-123",
+				"x-request-id":     "req-456",
+				"x-user-id":        "user-789",
+				"x-tenant-id":      "tenant-001",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			for k, v := range tt.contextValues {
+				ctx = context.WithValue(ctx, k, v)
+			}
+
+			propagator := NewStandardContextPropagator()
+			ctx, md := propagator.InjectToGRPC(ctx)
+
+			for expectedKey, expectedValue := range tt.expectedMetadata {
+				values := md.Get(expectedKey)
+				require.NotEmpty(t, values, "Expected metadata %s to exist", expectedKey)
+				assert.Equal(t, expectedValue, values[0], "Expected metadata %s to be %s", expectedKey, expectedValue)
+			}
+		})
+	}
+}
+
+func TestStandardContextPropagator_InjectToMessage(t *testing.T) {
+	tests := []struct {
+		name            string
+		contextValues   map[ContextKey]string
+		expectedHeaders map[string]string
+	}{
+		{
+			name: "inject all values",
+			contextValues: map[ContextKey]string{
+				ContextKeyCorrelationID: "corr-123",
+				ContextKeyTraceID:       "trace-456",
+				ContextKeyRequestID:     "req-789",
+				ContextKeyUserID:        "user-001",
+				ContextKeyTenantID:      "tenant-002",
+			},
+			expectedHeaders: map[string]string{
+				"correlation_id": "corr-123",
+				"trace_id":       "trace-456",
+				"request_id":     "req-789",
+				"user_id":        "user-001",
+				"tenant_id":      "tenant-002",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			for k, v := range tt.contextValues {
+				ctx = context.WithValue(ctx, k, v)
+			}
+
+			message := &Message{
+				ID: "msg-test",
+			}
+
+			propagator := NewStandardContextPropagator()
+			propagator.InjectToMessage(ctx, message)
+
+			for expectedKey, expectedValue := range tt.expectedHeaders {
+				actualValue, exists := message.Headers[expectedKey]
+				require.True(t, exists, "Expected header %s to exist", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Expected header %s to be %s", expectedKey, expectedValue)
+			}
+
+			// Check correlation ID is set on message
+			assert.Equal(t, "corr-123", message.CorrelationID)
+		})
+	}
+}
+
+func TestPropagateHTTPToMessage(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Correlation-ID", "corr-123")
+	req.Header.Set("X-User-ID", "user-789")
+
+	message := &Message{
+		ID: "msg-test",
+	}
+
+	ctx := PropagateHTTPToMessage(context.Background(), req, message)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "corr-123", message.CorrelationID)
+	assert.Equal(t, "corr-123", message.Headers["correlation_id"])
+	assert.Equal(t, "user-789", message.Headers["user_id"])
+}
+
+func TestPropagateGinToMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/test", nil)
+	c.Request.Header.Set("X-Correlation-ID", "corr-123")
+	c.Set("user_id", "user-from-gin")
+
+	message := &Message{
+		ID: "msg-test",
+	}
+
+	ctx := PropagateGinToMessage(c, message)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "corr-123", message.CorrelationID)
+	assert.Equal(t, "user-from-gin", message.Headers["user_id"])
+}
+
+func TestPropagateGRPCToMessage(t *testing.T) {
+	md := metadata.New(map[string]string{
+		"x-correlation-id": "corr-123",
+		"x-user-id":        "user-789",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	message := &Message{
+		ID: "msg-test",
+	}
+
+	ctx = PropagateGRPCToMessage(ctx, message)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "corr-123", message.CorrelationID)
+	assert.Equal(t, "user-789", message.Headers["user_id"])
+}
+
+func TestPropagateMessageToHTTP(t *testing.T) {
+	message := &Message{
+		ID:            "msg-test",
+		CorrelationID: "corr-123",
+		Headers: map[string]string{
+			"user_id":   "user-789",
+			"tenant_id": "tenant-001",
+		},
+	}
+
+	header := http.Header{}
+	ctx := PropagateMessageToHTTP(context.Background(), message, header)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "corr-123", header.Get("X-Correlation-ID"))
+	assert.Equal(t, "user-789", header.Get("X-User-ID"))
+	assert.Equal(t, "tenant-001", header.Get("X-Tenant-ID"))
+}
+
+func TestPropagateMessageToGRPC(t *testing.T) {
+	message := &Message{
+		ID:            "msg-test",
+		CorrelationID: "corr-123",
+		Headers: map[string]string{
+			"user_id":   "user-789",
+			"tenant_id": "tenant-001",
+		},
+	}
+
+	ctx, md := PropagateMessageToGRPC(context.Background(), message)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "corr-123", md.Get("x-correlation-id")[0])
+	assert.Equal(t, "user-789", md.Get("x-user-id")[0])
+	assert.Equal(t, "tenant-001", md.Get("x-tenant-id")[0])
+}
+
+func TestContextPropagation_RoundTrip(t *testing.T) {
+	// Test that context can be propagated through multiple layers
+	originalCtx := context.Background()
+	originalCtx = context.WithValue(originalCtx, ContextKeyCorrelationID, "corr-123")
+	originalCtx = context.WithValue(originalCtx, ContextKeyUserID, "user-789")
+
+	// HTTP -> Message
+	message := &Message{ID: "msg-test"}
+	GlobalContextPropagator.InjectToMessage(originalCtx, message)
+
+	// Message -> gRPC
+	grpcCtx := GlobalContextPropagator.ExtractFromMessage(context.Background(), message)
+	grpcCtx, grpcMD := GlobalContextPropagator.InjectToGRPC(grpcCtx)
+
+	// gRPC -> Message
+	message2 := &Message{ID: "msg-test-2"}
+	grpcCtx2 := metadata.NewIncomingContext(context.Background(), grpcMD)
+	grpcCtx2 = GlobalContextPropagator.ExtractFromGRPC(grpcCtx2)
+	GlobalContextPropagator.InjectToMessage(grpcCtx2, message2)
+
+	// Verify correlation ID and user ID are preserved
+	assert.Equal(t, "corr-123", message2.CorrelationID)
+	assert.Equal(t, "user-789", message2.Headers["user_id"])
+}


### PR DESCRIPTION
## Summary
Implements request context propagation through middleware chain and transports to address issue #438.

This PR introduces a comprehensive context propagation system that enables seamless information flow between HTTP, gRPC, and messaging transports.

## Changes

### Core Implementation
- **Context Propagation Interface**: Defines  interface for cross-transport context propagation
- **Standard Propagator**: Implements  with customizable header names
- **Extract/Inject Methods**: Provides methods for HTTP, gRPC, and messaging systems
- **Helper Functions**: Adds convenient helper functions for common propagation patterns

### Context Keys
The following context keys are now propagated across transports:
- Correlation ID: Unique identifier for request correlation
- Trace ID: Distributed tracing trace identifier  
- Span ID: Distributed tracing span identifier
- Request ID: Unique request identifier
- User ID: User identity for authorization
- Tenant ID: Tenant identifier for multi-tenancy
- Session ID: Session identifier

### Testing
- Comprehensive unit tests covering all propagation scenarios
- Tests for extract/inject operations across all transport types
- Round-trip propagation test verifying context preservation

### Documentation
- Detailed example demonstrating real-world usage patterns
- README with integration guide and best practices
- API reference and usage examples

## Testing

All tests pass successfully:
```bash
go test ./pkg/messaging -v -run TestContext
go test ./pkg/messaging -v -run TestStandardContextPropagator
go test ./pkg/messaging -v -run TestPropagate
```

Example program runs without errors:
```bash
cd examples/context-propagation && go run main.go
```

## Examples

### HTTP to Messaging
```go
func handleRequest(c *gin.Context) {
    message := &messaging.Message{
        ID:      "msg-001",
        Topic:   "user.events",
        Payload: []byte(`{"event": "user_created"}`),
    }
    
    // Propagate context from HTTP to message
    ctx := messaging.PropagateGinToMessage(c, message)
    
    err := publisher.Publish(ctx, message)
    // ...
}
```

### gRPC to Messaging
```go
func ProcessRequest(ctx context.Context, req *pb.Request) (*pb.Response, error) {
    message := &messaging.Message{
        ID:      "msg-002",
        Topic:   "process.request",
        Payload: data,
    }
    
    // Propagate context from gRPC to message
    ctx = messaging.PropagateGRPCToMessage(ctx, message)
    
    err := publisher.Publish(ctx, message)
    // ...
}
```

## Related Issues

Closes #438

## Dependencies

Depends on: #173, #174, #175 (already merged)
Parent issue: #177

## Checklist

- [x] Implementation complete
- [x] Unit tests added and passing
- [x] Example code provided
- [x] Documentation updated
- [x] No linter errors
- [x] All tests passing