### PR TITLE
fix(rabbitmq): 修复测试中的数据竞争问题

### DIFF
--- a/pkg/messaging/rabbitmq/broker_test.go
+++ b/pkg/messaging/rabbitmq/broker_test.go
@@ -145,8 +145,9 @@ func TestRabbitBrokerSetupTopologyOnConnect(t *testing.T) {
 	require.True(t, broker.IsConnected())
 
 	// Inspect the first created channel during topology setup
-	require.GreaterOrEqual(t, len(mconn.channels), 1)
-	mc, ok := mconn.channels[0].(*mockChannel)
+	channels := mconn.getChannels()
+	require.GreaterOrEqual(t, len(channels), 1)
+	mc, ok := channels[0].(*mockChannel)
 	require.True(t, ok)
 
 	// At least one exchange and one queue declared and one bind performed

--- a/pkg/messaging/rabbitmq/mocks_test.go
+++ b/pkg/messaging/rabbitmq/mocks_test.go
@@ -70,6 +70,15 @@ func (m *mockConnection) enqueueChannel(channel amqpChannel) {
 	m.mu.Unlock()
 }
 
+func (m *mockConnection) getChannels() []amqpChannel {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Return a copy to avoid race conditions
+	result := make([]amqpChannel, len(m.channels))
+	copy(result, m.channels)
+	return result
+}
+
 func (m *mockConnection) Close() error {
 	m.mu.Lock()
 	if m.closed {


### PR DESCRIPTION
## 问题描述

修复 GitHub Actions CI job 54439499675 中发现的数据竞争问题。

## 问题原因

在 `pkg/messaging/rabbitmq/mocks_test.go` 中，`mockConnection.channels` 字段存在并发访问问题：
- 在 `Channel()` 方法中被写入（有锁保护）
- 在测试代码中被直接读取（无锁保护）

类似地，`mockChannel.publishCalls` 也存在直接访问的问题。

## 修复方案

1. 添加 `getChannels()` 方法以线程安全地访问 `mockConnection.channels`
2. 更新所有测试代码使用 `getChannels()` 而非直接访问 `channels` 字段
3. 移除对 `publishCalls` 的直接访问，改用已有的线程安全方法 `lastPublish()`

## 测试验证

- ✅ 使用 `go test -race` 运行所有 RabbitMQ 测试，无数据竞争
- ✅ 所有相关测试通过

## 相关文件

- `pkg/messaging/rabbitmq/mocks_test.go`: 添加线程安全方法
- `pkg/messaging/rabbitmq/consumer_test.go`: 更新测试代码
- `pkg/messaging/rabbitmq/broker_test.go`: 更新测试代码

## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新