### PR TITLE
fix(test): initialize logger in tracing demo test to prevent nil pointer dereference

### DIFF
--- a/demo_tracing_scenarios_test.go
+++ b/demo_tracing_scenarios_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	notificationServiceV1 "github.com/innovationmech/swit/internal/switserve/service/notification/v1"
+	"github.com/innovationmech/swit/pkg/logger"
 	"github.com/innovationmech/swit/pkg/tracing"
 )
 
@@ -52,6 +53,9 @@ func TestTracingDemonstrationScenarios(t *testing.T) {
 }
 
 func setupTracingDemonstration(t *testing.T) *TracingDemonstrationTestSuite {
+	// Initialize logger to prevent nil pointer dereference
+	logger.InitLogger()
+
 	// Initialize basic tracing manager (simplified for demo)
 	tracingManager := tracing.NewTracingManager()
 


### PR DESCRIPTION
- Add logger.InitLogger() call in setupTracingDemonstration
- Import logger package to support initialization
- Fixes CI test failure in TestTracingDemonstrationScenarios

Resolves GitHub Action job #54441784473 failure
