### PR TITLE
feat(opa): implement policy input builder for HTTP and gRPC requests

### DIFF
--- a/pkg/security/opa/input.go
+++ b/pkg/security/opa/input.go
@@ -485,23 +485,33 @@ func extractSafeHeaders(headers http.Header) map[string][]string {
 }
 
 // isSafeMetadataKey 检查 gRPC metadata 键是否安全
-// 排除敏感信息如 authorization 等
+// 使用白名单方式，只允许已知的安全 metadata 键
 func isSafeMetadataKey(key string) bool {
-	// 不安全的 metadata 键
-	unsafeKeys := []string{
-		"authorization",
-		"cookie",
-		"x-api-key",
-		"x-auth-token",
+	// 安全的 metadata 键白名单
+	safeKeys := []string{
+		"content-type",
+		"user-agent",
+		"accept",
+		"accept-language",
+		"accept-encoding",
+		"x-request-id",
+		"x-correlation-id",
+		"x-forwarded-for",
+		"x-forwarded-proto",
+		"x-forwarded-host",
+		"x-real-ip",
+		"grpc-timeout",
+		"grpc-encoding",
+		"grpc-accept-encoding",
 	}
 
-	for _, unsafeKey := range unsafeKeys {
-		if key == unsafeKey {
-			return false
+	for _, safeKey := range safeKeys {
+		if key == safeKey {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 // BuildPolicyInputFromHTTP 从 HTTP 请求构建策略输入（便捷函数）

--- a/pkg/security/opa/input_test.go
+++ b/pkg/security/opa/input_test.go
@@ -501,13 +501,19 @@ func TestIsSafeMetadataKey(t *testing.T) {
 		key      string
 		expected bool
 	}{
-		{"Safe key", "content-type", true},
-		{"Safe key", "user-agent", true},
+		{"Safe key - content-type", "content-type", true},
+		{"Safe key - user-agent", "user-agent", true},
+		{"Safe key - x-request-id", "x-request-id", true},
+		{"Safe key - x-forwarded-for", "x-forwarded-for", true},
+		{"Safe key - grpc-timeout", "grpc-timeout", true},
 		{"Unsafe key - authorization", "authorization", false},
 		{"Unsafe key - cookie", "cookie", false},
-		{"Unsafe key - api key", "x-api-key", false},
-		{"Unsafe key - auth token", "x-auth-token", false},
-		{"Safe custom key", "x-request-id", true},
+		{"Unsafe key - x-api-key", "x-api-key", false},
+		{"Unsafe key - x-auth-token", "x-auth-token", false},
+		{"Unsafe key - grpcgateway-authorization", "grpcgateway-authorization", false},
+		{"Unsafe key - authorization-bin", "authorization-bin", false},
+		{"Unsafe key - custom-secret", "custom-secret", false},
+		{"Unsafe key - any-unknown-key", "any-unknown-key", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概述

实现策略输入数据构建器，为 OPA 策略评估提供标准化的输入格式。

## 实现内容

### ✅ 核心结构体
- **PolicyInput**: 策略输入主结构体
  - Request: 请求信息（方法、路径、头部、查询参数等）
  - User: 用户信息（ID、角色、权限、组等）
  - Resource: 资源信息（类型、ID、所有者等）
  - Custom: 自定义数据

### ✅ 构建器模式
- **PolicyInputBuilder**: 链式调用构建器
  - FromHTTPRequest(): 从 Gin HTTP 请求构建
  - FromGRPCContext(): 从 gRPC 上下文构建
  - WithUser/WithUserID/WithUserRoles: 设置用户信息
  - WithResource/WithResourceType/WithResourceID: 设置资源信息
  - WithCustomData(): 注入自定义数据

### ✅ 信息提取
- **ExtractUserFromContext()**: 从 Gin 上下文提取用户信息
  - 支持从 JWT claims 提取
  - 支持从认证中间件设置的上下文提取
- **ExtractUserFromGRPCContext()**: 从 gRPC 上下文提取用户信息

### ✅ 安全特性
- 请求头白名单过滤（排除 Authorization、Cookie 等敏感信息）
- gRPC metadata 安全过滤
- 只提取必要的请求信息

### ✅ 便捷函数
- **BuildPolicyInputFromHTTP()**: 从 HTTP 请求一键构建完整输入
- **BuildPolicyInputFromGRPC()**: 从 gRPC 请求一键构建完整输入

## 测试覆盖

- ✅ 16 个单元测试全部通过
- ✅ 测试覆盖 HTTP 和 gRPC 场景
- ✅ 测试用户信息提取
- ✅ 测试资源信息构建
- ✅ 测试自定义数据注入
- ✅ 测试安全过滤功能
- ✅ 测试链式调用

## 使用示例

### HTTP 请求
```go
// 自动构建
input := opa.BuildPolicyInputFromHTTP(c)

// 手动构建
input := opa.NewPolicyInputBuilder().
    FromHTTPRequest(c).
    WithResourceType("document").
    WithResourceID("123").
    WithCustomData("tenant_id", "tenant-001").
    Build()
```

### gRPC 请求
```go
// 自动构建
input := opa.BuildPolicyInputFromGRPC(ctx, fullMethod)

// 手动构建
input := opa.NewPolicyInputBuilder().
    FromGRPCContext(ctx, fullMethod).
    WithResourceType("project").
    WithResourceID("proj-001").
    Build()
```

## 验收标准

- [x] 实现 PolicyInput 结构体
- [x] HTTP 请求输入构建
- [x] gRPC 请求输入构建
- [x] 用户信息提取
- [x] 资源信息提取
- [x] 自定义数据注入
- [x] 单元测试

Closes #796