### PR TITLE
feat(middleware): implement OPA HTTP policy middleware

### DIFF
--- a/pkg/middleware/policy_opa_test.go
+++ b/pkg/middleware/policy_opa_test.go
@@ -832,3 +832,49 @@ func TestIsInWhiteList(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeLogValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no_special_chars",
+			input:    "/api/users",
+			expected: "/api/users",
+		},
+		{
+			name:     "with_newline",
+			input:    "/api/users\n",
+			expected: "/api/users",
+		},
+		{
+			name:     "with_carriage_return",
+			input:    "/api/users\r\n",
+			expected: "/api/users",
+		},
+		{
+			name:     "with_tab",
+			input:    "/api\t/users",
+			expected: "/api /users",
+		},
+		{
+			name:     "multiple_special_chars",
+			input:    "/api/users\nGET /admin\r\n",
+			expected: "/api/usersGET /admin",
+		},
+		{
+			name:     "log_injection_attempt",
+			input:    "user123\nERROR: Unauthorized access",
+			expected: "user123ERROR: Unauthorized access",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeLogValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## 概述

实现 OPA HTTP 策略中间件，提供细粒度的基于策略的访问控制能力。

## 实现内容

### 核心功能

- **OPAMiddleware**: 请求级策略评估中间件
  - 支持白名单路径配置
  - 自定义策略输入构建器
  - 自定义错误和拒绝处理函数
  - 可配置的评估超时
  - 集成日志记录

- **ResourcePolicy**: 资源级策略评估中间件
  - 动态提取资源类型和 ID
  - 与 OPAMiddleware 无缝集成

- **DynamicPolicyPath**: 动态策略路径中间件
  - 根据请求动态确定策略路径
  - 支持自定义路径生成函数

### 决策缓存和审计日志

- 通过 OPA 客户端的缓存配置集成决策缓存
- 内置审计日志记录功能
  - 记录决策 ID、结果、耗时等信息
  - 支持自定义审计日志处理器
  - 默认集成 Zap 日志记录

### 辅助功能

- **WithResourceInfo**: 添加资源信息到上下文
- **WithCustomAttribute**: 添加自定义属性到上下文
- 多种配置选项函数（WithDecisionPath、WithWhiteList 等）

## 测试覆盖

- 23 个单元测试，覆盖所有核心功能
- 测试场景包括：
  - 策略允许/拒绝
  - 评估错误处理
  - 白名单路径
  - 自定义配置选项
  - 资源级策略评估
  - 动态策略路径
  - 审计日志记录
  - 并发请求
  - 超时处理
  - 用户上下文提取

## 验收标准

- ✅ 实现 OPAMiddleware
- ✅ 请求级策略评估
- ✅ 资源级策略评估（ResourcePolicy）
- ✅ 动态策略路径
- ✅ 决策缓存集成
- ✅ 审计日志记录
- ✅ 自定义错误响应
- ✅ 集成测试

## 相关链接

- Epic: #776
- Depends on: #796 (已完成)
- Closes: #797