### PR TITLE
feat(opa): RBAC 策略模板测试和文档

### DIFF
--- a/docs/opa-rbac-guide.md
+++ b/docs/opa-rbac-guide.md
@@ -1,0 +1,811 @@
+# OPA RBAC 策略使用指南
+
+本文档介绍如何使用 OPA (Open Policy Agent) RBAC (基于角色的访问控制) 策略模板来实现细粒度的权限管理。
+
+## 目录
+
+- [概述](#概述)
+- [策略架构](#策略架构)
+- [快速开始](#快速开始)
+- [角色定义](#角色定义)
+- [权限映射](#权限映射)
+- [高级特性](#高级特性)
+- [测试策略](#测试策略)
+- [最佳实践](#最佳实践)
+- [故障排查](#故障排查)
+
+## 概述
+
+RBAC 策略模板提供了一个完整的基于角色的访问控制解决方案，支持：
+
+- ✅ **角色权限映射** - 将操作权限分配给不同角色
+- ✅ **角色资源映射** - 控制角色可以访问的资源类型
+- ✅ **超级管理员支持** - 管理员拥有所有权限
+- ✅ **资源所有者检查** - 用户可以访问自己的资源
+- ✅ **用户组支持** - 基于组的角色继承
+- ✅ **临时权限** - 支持时限性的临时访问权限
+- ✅ **审计日志** - 记录所有访问决策
+
+## 策略架构
+
+### 核心决策流程
+
+```
+┌─────────────────┐
+│  请求输入 (Input)│
+│  - subject     │
+│  - action      │
+│  - resource    │
+│  - context     │
+└────────┬────────┘
+         │
+         v
+┌────────────────────┐
+│  RBAC 策略评估     │
+│  1. 超级管理员?    │
+│  2. 角色权限匹配?  │
+│  3. 资源所有者?    │
+│  4. 组角色继承?    │
+│  5. 临时权限?      │
+└────────┬───────────┘
+         │
+         v
+┌────────────────────┐
+│   决策结果         │
+│   allow: true/false│
+└────────────────────┘
+```
+
+### 输入数据结构
+
+策略期望以下输入结构：
+
+```json
+{
+  "subject": {
+    "user": "alice",
+    "roles": ["editor", "viewer"],
+    "groups": ["engineering"],
+    "attributes": {}
+  },
+  "action": "read",
+  "resource": "documents",
+  "context": {
+    "time": true,
+    "temporary_permissions": [
+      {
+        "action": "write",
+        "resource": "project/secret",
+        "expires_at": 1735689600000000000
+      }
+    ]
+  }
+}
+```
+
+## 快速开始
+
+### 1. 加载 RBAC 策略
+
+使用嵌入式模式加载策略：
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    
+    "github.com/innovationmech/swit/pkg/security/opa"
+)
+
+func main() {
+    ctx := context.Background()
+    
+    // 创建配置
+    config := &opa.Config{
+        Mode: opa.ModeEmbedded,
+        EmbeddedConfig: &opa.EmbeddedConfig{
+            PolicyDir: "./pkg/security/opa/policies",
+        },
+        DefaultDecisionPath: "rbac/allow",
+    }
+    
+    // 创建客户端
+    client, err := opa.NewClient(ctx, config)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close(ctx)
+    
+    // 评估策略
+    result, err := client.Evaluate(ctx, "", map[string]interface{}{
+        "subject": map[string]interface{}{
+            "user":  "alice",
+            "roles": []string{"editor"},
+        },
+        "action":   "update",
+        "resource": "documents",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    if result.Allowed {
+        log.Println("Access granted")
+    } else {
+        log.Println("Access denied")
+    }
+}
+```
+
+### 2. 使用评估器（推荐）
+
+使用高级评估器 API：
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    
+    "github.com/innovationmech/swit/pkg/security/opa"
+)
+
+func main() {
+    ctx := context.Background()
+    
+    // 创建评估器
+    evaluator, err := opa.NewEvaluatorWithConfig(ctx, &opa.Config{
+        Mode: opa.ModeEmbedded,
+        EmbeddedConfig: &opa.EmbeddedConfig{
+            PolicyDir: "./pkg/security/opa/policies",
+        },
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer evaluator.Close(ctx)
+    
+    // RBAC 评估
+    input := &opa.RBACInput{
+        Subject: &opa.Subject{
+            User:  "alice",
+            Roles: []string{"editor"},
+        },
+        Action:   "update",
+        Resource: "documents",
+    }
+    
+    result, err := evaluator.EvaluateRBAC(ctx, input)
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    if result.Allowed {
+        log.Println("Access granted")
+    }
+}
+```
+
+## 角色定义
+
+### 预定义角色
+
+RBAC 策略模板包含以下预定义角色：
+
+#### 1. Admin (超级管理员)
+- **描述**: 拥有所有权限的超级管理员
+- **权限**: create, read, update, delete, list
+- **资源**: users, documents, settings, reports
+- **使用场景**: 系统管理员、运维人员
+
+```rego
+"admin": {
+    "create": true,
+    "read": true,
+    "update": true,
+    "delete": true,
+    "list": true,
+}
+```
+
+#### 2. Editor (编辑者)
+- **描述**: 可以创建、读取和更新资源
+- **权限**: create, read, update, list
+- **资源**: documents, reports
+- **使用场景**: 内容编辑、文档管理
+
+```rego
+"editor": {
+    "create": true,
+    "read": true,
+    "update": true,
+    "list": true,
+}
+```
+
+#### 3. Viewer (查看者)
+- **描述**: 只读访问权限
+- **权限**: read, list
+- **资源**: documents, reports
+- **使用场景**: 普通用户、审核人员
+
+```rego
+"viewer": {
+    "read": true,
+    "list": true,
+}
+```
+
+#### 4. Contributor (贡献者)
+- **描述**: 可以创建和读取资源
+- **权限**: create, read, list
+- **资源**: documents
+- **使用场景**: 内容创建者、提交者
+
+```rego
+"contributor": {
+    "create": true,
+    "read": true,
+    "list": true,
+}
+```
+
+### 自定义角色
+
+你可以通过修改策略文件来添加自定义角色：
+
+```rego
+role_permissions := {
+    # ... 现有角色 ...
+    
+    # 自定义角色: 审核员
+    "auditor": {
+        "read": true,
+        "list": true,
+        "audit": true,  # 自定义操作
+    },
+    
+    # 自定义角色: 报表管理员
+    "report_admin": {
+        "create": true,
+        "read": true,
+        "update": true,
+        "delete": true,
+        "list": true,
+        "export": true,  # 自定义操作
+    },
+}
+
+role_resources := {
+    # ... 现有映射 ...
+    
+    "auditor": {
+        "audit_logs": true,
+        "reports": true,
+    },
+    
+    "report_admin": {
+        "reports": true,
+    },
+}
+```
+
+## 权限映射
+
+### 操作权限
+
+策略支持以下标准操作：
+
+| 操作 | 描述 | 适用角色 |
+|-----|------|---------|
+| `create` | 创建资源 | admin, editor, contributor |
+| `read` | 读取资源 | admin, editor, viewer, contributor |
+| `update` | 更新资源 | admin, editor |
+| `delete` | 删除资源 | admin |
+| `list` | 列出资源 | admin, editor, viewer, contributor |
+
+### 资源类型
+
+策略支持以下资源类型：
+
+| 资源类型 | 描述 | 可访问角色 |
+|---------|------|----------|
+| `users` | 用户管理 | admin |
+| `documents` | 文档管理 | admin, editor, viewer, contributor |
+| `settings` | 系统设置 | admin |
+| `reports` | 报表管理 | admin, editor, viewer |
+
+### 添加自定义操作
+
+```rego
+# 在策略中添加新操作
+role_permissions := {
+    "custom_role": {
+        "read": true,
+        "export": true,      # 自定义操作
+        "share": true,       # 自定义操作
+        "analyze": true,     # 自定义操作
+    },
+}
+```
+
+## 高级特性
+
+### 1. 资源所有者权限
+
+用户自动获得对自己资源的访问权限：
+
+```go
+// Alice 可以访问 users/alice
+input := map[string]interface{}{
+    "subject": map[string]interface{}{
+        "user":  "alice",
+        "roles": []string{},  // 即使没有角色
+    },
+    "action":   "read",
+    "resource": "users/alice",  // 资源路径包含用户名
+}
+// 结果: allow = true
+```
+
+策略实现：
+
+```rego
+# 检查是否为资源所有者
+is_owner if {
+    input.resource == sprintf("users/%s", [input.subject.user])
+}
+
+# 资源所有者拥有完全访问权限
+allow if {
+    is_owner
+    input.action in ["read", "update", "delete"]
+}
+```
+
+### 2. 用户组角色继承
+
+通过用户组自动继承角色权限：
+
+```go
+input := map[string]interface{}{
+    "subject": map[string]interface{}{
+        "user":   "alice",
+        "roles":  []string{},
+        "groups": []string{"engineering"},  // Alice 属于 engineering 组
+    },
+    "action":   "update",
+    "resource": "documents",
+}
+// engineering 组继承了 editor 和 contributor 角色
+// 结果: allow = true
+```
+
+预定义组映射：
+
+```rego
+group_roles := {
+    "engineering": ["editor", "contributor"],
+    "management": ["admin"],
+    "support": ["viewer"],
+    "sales": ["viewer", "contributor"],
+}
+```
+
+### 3. 临时权限
+
+授予有时间限制的临时访问权限：
+
+```go
+input := map[string]interface{}{
+    "subject": map[string]interface{}{
+        "user":  "alice",
+        "roles": []string{},
+    },
+    "action":   "write",
+    "resource": "project/secret",
+    "context": map[string]interface{}{
+        "time": true,
+        "temporary_permissions": []map[string]interface{}{
+            {
+                "action":     "write",
+                "resource":   "project/secret",
+                "expires_at": time.Now().Add(24 * time.Hour).UnixNano(),
+            },
+        },
+    },
+}
+// 在过期时间前: allow = true
+// 过期后: allow = false
+```
+
+策略实现：
+
+```rego
+# 临时权限检查
+allow if {
+    is_business_hours
+    has_temporary_permission
+}
+
+# 检查临时权限
+has_temporary_permission if {
+    some temp_perm in input.context.temporary_permissions
+    temp_perm.action == input.action
+    temp_perm.resource == input.resource
+    temp_perm.expires_at > time.now_ns()
+}
+```
+
+### 4. 工作时间限制
+
+策略支持基于时间的访问控制：
+
+```rego
+# 判断是否在工作时间（示例）
+is_business_hours if {
+    input.context.time
+    # 实现实际的时间范围检查
+    # 例如：周一到周五 9:00-18:00
+}
+```
+
+### 5. 审计日志
+
+策略自动生成审计日志：
+
+```rego
+audit_log := {
+    "user": input.subject.user,
+    "action": input.action,
+    "resource": input.resource,
+    "roles": user_roles,
+    "decision": allow,
+    "timestamp": time.now_ns(),
+}
+```
+
+在应用中获取审计信息：
+
+```go
+result, err := client.Evaluate(ctx, "", input)
+if err != nil {
+    log.Fatal(err)
+}
+
+// 访问审计日志
+if auditLog, ok := result.Bindings["audit_log"].(map[string]interface{}); ok {
+    log.Printf("Audit: user=%s, action=%s, decision=%v",
+        auditLog["user"],
+        auditLog["action"],
+        auditLog["decision"])
+}
+```
+
+## 测试策略
+
+### 运行测试
+
+使用 OPA CLI 运行测试：
+
+```bash
+# 运行所有测试
+opa test pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego -v
+
+# 运行特定测试
+opa test pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego -v -r test_admin_has_all_permissions
+```
+
+### 测试覆盖率
+
+```bash
+# 生成覆盖率报告
+opa test --coverage pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego
+
+# 生成 HTML 覆盖率报告
+opa test --coverage --format=json pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego > coverage.json
+```
+
+### 编写自定义测试
+
+```rego
+package rbac_test
+
+import rego.v1
+import data.rbac
+
+# 测试自定义角色
+test_custom_role_has_export_permission if {
+    rbac.allow with input as {
+        "subject": {
+            "user": "reporter",
+            "roles": ["report_admin"],
+        },
+        "action": "export",
+        "resource": "reports",
+    }
+}
+
+# 测试拒绝场景
+test_custom_role_cannot_delete_users if {
+    not rbac.allow with input as {
+        "subject": {
+            "user": "reporter",
+            "roles": ["report_admin"],
+        },
+        "action": "delete",
+        "resource": "users",
+    }
+}
+```
+
+### 基准测试
+
+评估策略性能：
+
+```bash
+# 运行基准测试
+opa test --bench pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego
+```
+
+## 最佳实践
+
+### 1. 最小权限原则
+
+始终遵循最小权限原则，只授予用户完成任务所需的最小权限：
+
+```go
+// 好的做法：为特定任务分配特定角色
+user.Roles = []string{"viewer"}  // 只需要读权限
+
+// 避免：过度授权
+user.Roles = []string{"admin"}   // 不要轻易授予管理员权限
+```
+
+### 2. 使用用户组管理角色
+
+对于大型团队，使用用户组来管理角色更加高效：
+
+```go
+// 推荐：通过组管理
+user := User{
+    ID:     "alice",
+    Groups: []string{"engineering"},  // engineering 组自动继承相关角色
+}
+
+// 避免：为每个用户单独分配角色
+user := User{
+    ID:    "alice",
+    Roles: []string{"editor", "contributor", "viewer"},  // 难以维护
+}
+```
+
+### 3. 临时权限用于特殊场景
+
+只在需要时授予临时权限，并设置合理的过期时间：
+
+```go
+// 授予 24 小时的临时访问权限
+tempPermission := TempPermission{
+    Action:    "write",
+    Resource:  "sensitive/data",
+    ExpiresAt: time.Now().Add(24 * time.Hour),
+}
+```
+
+### 4. 定期审计访问日志
+
+利用审计日志定期检查访问模式：
+
+```go
+// 记录所有访问决策
+logger.Info("Access decision",
+    zap.String("user", auditLog.User),
+    zap.String("action", auditLog.Action),
+    zap.Bool("allowed", auditLog.Decision),
+    zap.Time("timestamp", auditLog.Timestamp))
+```
+
+### 5. 测试驱动策略开发
+
+在修改策略前编写测试：
+
+```rego
+# 1. 先写测试
+test_new_feature if {
+    rbac.allow with input as {...}
+}
+
+# 2. 再实现策略
+allow if {
+    # 新功能实现
+}
+
+# 3. 运行测试验证
+```
+
+### 6. 版本控制策略文件
+
+将策略文件纳入版本控制：
+
+```bash
+# 提交策略变更
+git add pkg/security/opa/policies/rbac.rego
+git commit -m "feat(rbac): add new role for report administrators"
+
+# 使用标签标记策略版本
+git tag -a v1.2.0 -m "RBAC Policy v1.2.0"
+```
+
+### 7. 分离策略和数据
+
+将策略逻辑和数据分离，便于维护：
+
+```rego
+# rbac.rego - 策略逻辑
+allow if {
+    some role in user_roles
+    role_permissions[role][input.action]
+}
+
+# data.json - 角色数据（可以从外部加载）
+{
+    "role_permissions": {
+        "admin": {...},
+        "editor": {...}
+    }
+}
+```
+
+## 故障排查
+
+### 问题 1: 策略评估返回 false，但预期应该通过
+
+**可能原因**：
+- 输入数据格式不正确
+- 角色或资源未正确定义
+- 缺少必需的输入字段
+
+**解决方法**：
+
+```bash
+# 使用 OPA REPL 调试
+opa run pkg/security/opa/policies/rbac.rego
+
+# 在 REPL 中测试
+> import data.rbac
+> rbac.allow with input as {"subject": {"user": "alice", "roles": ["editor"]}, "action": "read", "resource": "documents"}
+true
+
+# 检查中间结果
+> rbac.user_roles with input as {"subject": {"user": "alice", "roles": ["editor"]}}
+{"editor"}
+```
+
+### 问题 2: 性能问题，策略评估慢
+
+**解决方法**：
+
+1. 启用决策缓存：
+
+```go
+config := &opa.Config{
+    CacheConfig: &opa.CacheConfig{
+        Enabled:       true,
+        MaxSize:       10000,
+        TTL:           5 * time.Minute,
+        EnableMetrics: true,
+    },
+}
+```
+
+2. 使用基准测试分析：
+
+```bash
+opa test --bench pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego
+```
+
+### 问题 3: 测试失败
+
+**常见原因**：
+- 策略逻辑变更
+- 测试数据过期
+- 输入格式不匹配
+
+**解决方法**：
+
+```bash
+# 运行详细测试输出
+opa test -v pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego
+
+# 只运行失败的测试
+opa test -v -r test_name pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego
+```
+
+### 问题 4: 无法加载策略文件
+
+**可能原因**：
+- 文件路径不正确
+- 策略语法错误
+- 缺少 `import rego.v1`
+
+**解决方法**：
+
+```bash
+# 验证策略语法
+opa check pkg/security/opa/policies/rbac.rego
+
+# 格式化策略文件
+opa fmt -w pkg/security/opa/policies/rbac.rego
+```
+
+### 问题 5: 远程 OPA 服务器连接失败
+
+**解决方法**：
+
+```go
+// 添加详细的错误处理
+config := &opa.Config{
+    Mode: opa.ModeRemote,
+    RemoteConfig: &opa.RemoteConfig{
+        URL:        "http://opa-server:8181",
+        Timeout:    30 * time.Second,
+        MaxRetries: 3,
+    },
+}
+
+client, err := opa.NewClient(ctx, config)
+if err != nil {
+    log.Printf("Failed to connect to OPA server: %v", err)
+    // 回退到嵌入式模式
+    config.Mode = opa.ModeEmbedded
+    client, err = opa.NewClient(ctx, config)
+}
+```
+
+### 调试技巧
+
+1. **启用详细日志**：
+
+```go
+config := &opa.Config{
+    LogLevel: "debug",
+}
+```
+
+2. **使用 OPA 决策日志**：
+
+```rego
+# 在策略中添加调试信息
+debug_info := {
+    "user_roles": user_roles,
+    "has_permission": has_permission("read"),
+    "can_access": can_access_resource("documents"),
+}
+```
+
+3. **逐步验证**：
+
+```bash
+# 验证单个规则
+opa eval -d pkg/security/opa/policies/rbac.rego "data.rbac.user_roles" \
+  --input <(echo '{"subject": {"user": "alice", "roles": ["editor"]}}')
+```
+
+## 相关资源
+
+- [OPA 官方文档](https://www.openpolicyagent.org/docs/latest/)
+- [Rego 语言参考](https://www.openpolicyagent.org/docs/latest/policy-language/)
+- [pkg/security/opa/README.md](../pkg/security/opa/README.md) - OPA 包文档
+- [Epic #776: OPA 策略引擎集成](https://github.com/innovationmech/swit/issues/776)
+- [Task #799: RBAC 策略模板](https://github.com/innovationmech/swit/issues/799)
+
+## 许可证
+
+Copyright (c) 2024 Six-Thirty Labs, Inc.
+
+Licensed under the Apache License, Version 2.0.
+

--- a/pkg/security/opa/policies/rbac_test.rego
+++ b/pkg/security/opa/policies/rbac_test.rego
@@ -1,0 +1,631 @@
+# Copyright (c) 2024 Six-Thirty Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RBAC 策略单元测试
+# 测试基于角色的访问控制策略
+
+package rbac_test
+
+import rego.v1
+import data.rbac
+
+# ===================================
+# 测试：默认拒绝策略
+# ===================================
+
+test_default_deny if {
+	not rbac.allow with input as {}
+}
+
+test_deny_without_roles if {
+	not rbac.allow with input as {
+		"subject": {"user": "john"},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+# ===================================
+# 测试：超级管理员权限
+# ===================================
+
+test_admin_has_all_permissions if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "admin-user",
+			"roles": ["admin"],
+		},
+		"action": "delete",
+		"resource": "settings",
+	}
+}
+
+test_admin_can_create if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "admin-user",
+			"roles": ["admin"],
+		},
+		"action": "create",
+		"resource": "users",
+	}
+}
+
+test_admin_can_delete_any_resource if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "admin-user",
+			"roles": ["admin"],
+		},
+		"action": "delete",
+		"resource": "reports",
+	}
+}
+
+# ===================================
+# 测试：编辑者角色权限
+# ===================================
+
+test_editor_can_create if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+test_editor_can_update if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "update",
+		"resource": "documents",
+	}
+}
+
+test_editor_can_read if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "read",
+		"resource": "reports",
+	}
+}
+
+test_editor_cannot_delete if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "delete",
+		"resource": "documents",
+	}
+}
+
+test_editor_cannot_access_users if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "read",
+		"resource": "users",
+	}
+}
+
+test_editor_cannot_access_settings if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+		"action": "read",
+		"resource": "settings",
+	}
+}
+
+# ===================================
+# 测试：查看者角色权限
+# ===================================
+
+test_viewer_can_read if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_viewer_can_list if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "list",
+		"resource": "reports",
+	}
+}
+
+test_viewer_cannot_create if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+test_viewer_cannot_update if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "update",
+		"resource": "documents",
+	}
+}
+
+test_viewer_cannot_delete if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "delete",
+		"resource": "documents",
+	}
+}
+
+# ===================================
+# 测试：贡献者角色权限
+# ===================================
+
+test_contributor_can_create if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "contrib-user",
+			"roles": ["contributor"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+test_contributor_can_read if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "contrib-user",
+			"roles": ["contributor"],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_contributor_cannot_update if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "contrib-user",
+			"roles": ["contributor"],
+		},
+		"action": "update",
+		"resource": "documents",
+	}
+}
+
+test_contributor_cannot_delete if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "contrib-user",
+			"roles": ["contributor"],
+		},
+		"action": "delete",
+		"resource": "documents",
+	}
+}
+
+# ===================================
+# 测试：多角色场景
+# ===================================
+
+test_user_with_multiple_roles if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "multi-role-user",
+			"roles": ["viewer", "contributor"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+test_user_highest_permission_wins if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "multi-role-user",
+			"roles": ["viewer", "admin"],
+		},
+		"action": "delete",
+		"resource": "settings",
+	}
+}
+
+# ===================================
+# 测试：资源所有者检查
+# ===================================
+
+test_owner_can_read_own_resource if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "alice",
+			"roles": [],
+		},
+		"action": "read",
+		"resource": "users/alice",
+	}
+}
+
+test_owner_can_update_own_resource if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "alice",
+			"roles": [],
+		},
+		"action": "update",
+		"resource": "users/alice",
+	}
+}
+
+test_owner_can_delete_own_resource if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "alice",
+			"roles": [],
+		},
+		"action": "delete",
+		"resource": "users/alice",
+	}
+}
+
+test_non_owner_cannot_access if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "alice",
+			"roles": [],
+		},
+		"action": "read",
+		"resource": "users/bob",
+	}
+}
+
+test_owner_cannot_create_on_own_resource if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "alice",
+			"roles": [],
+		},
+		"action": "create",
+		"resource": "users/alice",
+	}
+}
+
+# ===================================
+# 测试：用户组角色继承
+# ===================================
+
+test_engineering_group_has_editor_role if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "engineer1",
+			"roles": [],
+			"groups": ["engineering"],
+		},
+		"action": "update",
+		"resource": "documents",
+	}
+}
+
+test_management_group_has_admin_role if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "manager1",
+			"roles": [],
+			"groups": ["management"],
+		},
+		"action": "delete",
+		"resource": "users",
+	}
+}
+
+test_support_group_has_viewer_role if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "support1",
+			"roles": [],
+			"groups": ["support"],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_support_group_cannot_write if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "support1",
+			"roles": [],
+			"groups": ["support"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+test_sales_group_mixed_permissions if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "sales1",
+			"roles": [],
+			"groups": ["sales"],
+		},
+		"action": "create",
+		"resource": "documents",
+	}
+}
+
+# ===================================
+# 测试：临时权限
+# ===================================
+
+test_temporary_permission_grants_access if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "temp-user",
+			"roles": [],
+		},
+		"action": "write",
+		"resource": "project/secret",
+		"context": {
+			"time": true,
+			"temporary_permissions": [{
+				"action": "write",
+				"resource": "project/secret",
+				"expires_at": 9999999999999999999,
+			}],
+		},
+	}
+}
+
+test_expired_temporary_permission_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "temp-user",
+			"roles": [],
+		},
+		"action": "write",
+		"resource": "project/secret",
+		"context": {
+			"time": true,
+			"temporary_permissions": [{
+				"action": "write",
+				"resource": "project/secret",
+				"expires_at": 1,
+			}],
+		},
+	}
+}
+
+# ===================================
+# 测试：工作时间检查
+# ===================================
+
+test_business_hours_with_temp_permission if {
+	rbac.allow with input as {
+		"subject": {
+			"user": "employee1",
+			"roles": [],
+		},
+		"action": "read",
+		"resource": "internal-docs",
+		"context": {
+			"time": true,
+			"temporary_permissions": [{
+				"action": "read",
+				"resource": "internal-docs",
+				"expires_at": 9999999999999999999,
+			}],
+		},
+	}
+}
+
+# ===================================
+# 测试：辅助函数
+# ===================================
+
+test_user_roles_extraction if {
+	result := rbac.user_roles with input as {
+		"subject": {
+			"user": "test-user",
+			"roles": ["admin", "editor"],
+		},
+	}
+	result == {"admin", "editor"}
+}
+
+test_user_permissions_includes_admin_perms if {
+	result := rbac.user_permissions with input as {
+		"subject": {
+			"user": "admin-user",
+			"roles": ["admin"],
+		},
+	}
+	"create" in result
+	"read" in result
+	"update" in result
+	"delete" in result
+	"list" in result
+}
+
+test_has_permission_checks_correctly if {
+	rbac.has_permission("read") with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+	}
+}
+
+test_user_resources_for_editor if {
+	result := rbac.user_resources with input as {
+		"subject": {
+			"user": "editor-user",
+			"roles": ["editor"],
+		},
+	}
+	"documents" in result
+	"reports" in result
+}
+
+test_can_access_resource_checks_correctly if {
+	rbac.can_access_resource("documents") with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+	}
+}
+
+test_is_owner_identifies_correctly if {
+	rbac.is_owner with input as {
+		"subject": {"user": "alice"},
+		"resource": "users/alice",
+	}
+}
+
+test_is_owner_fails_for_non_owner if {
+	not rbac.is_owner with input as {
+		"subject": {"user": "alice"},
+		"resource": "users/bob",
+	}
+}
+
+# ===================================
+# 测试：审计日志生成
+# ===================================
+
+test_audit_log_contains_required_fields if {
+	log := rbac.audit_log with input as {
+		"subject": {
+			"user": "test-user",
+			"roles": ["viewer"],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+	log.user == "test-user"
+	log.action == "read"
+	log.resource == "documents"
+	log.timestamp
+}
+
+# ===================================
+# 测试：边界情况
+# ===================================
+
+test_empty_roles_denies_access if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "user-no-roles",
+			"roles": [],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_missing_subject_denies if {
+	not rbac.allow with input as {
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_missing_action_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "test-user",
+			"roles": ["viewer"],
+		},
+		"resource": "documents",
+	}
+}
+
+test_missing_resource_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "test-user",
+			"roles": ["viewer"],
+		},
+		"action": "read",
+	}
+}
+
+test_unknown_role_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "test-user",
+			"roles": ["unknown_role"],
+		},
+		"action": "read",
+		"resource": "documents",
+	}
+}
+
+test_unknown_action_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "viewer-user",
+			"roles": ["viewer"],
+		},
+		"action": "unknown_action",
+		"resource": "documents",
+	}
+}
+
+test_unknown_resource_denies if {
+	not rbac.allow with input as {
+		"subject": {
+			"user": "admin-user",
+			"roles": ["editor"],
+		},
+		"action": "read",
+		"resource": "unknown_resource",
+	}
+}
+


### PR DESCRIPTION
## 任务描述

实现 RBAC（基于角色的访问控制）策略模板的测试和使用文档。

## 变更内容

### 新增文件
- `pkg/security/opa/policies/rbac_test.rego` - RBAC 策略单元测试
- `docs/opa-rbac-guide.md` - OPA RBAC 使用指南

### 测试覆盖
- ✅ 50 个测试用例，全部通过
- ✅ 默认拒绝策略测试
- ✅ 超级管理员权限测试
- ✅ 编辑者、查看者、贡献者角色测试
- ✅ 多角色场景测试
- ✅ 资源所有者检查测试
- ✅ 用户组角色继承测试
- ✅ 临时权限测试
- ✅ 工作时间检查测试
- ✅ 辅助函数测试
- ✅ 审计日志生成测试
- ✅ 边界情况测试

### 文档内容
- 📖 概述和策略架构
- 📖 快速开始指南（嵌入式和评估器两种方式）
- 📖 角色定义（Admin、Editor、Viewer、Contributor）
- 📖 权限映射和资源类型
- 📖 高级特性（资源所有者、用户组、临时权限、工作时间、审计日志）
- 📖 测试策略指南（单元测试、覆盖率、基准测试）
- 📖 最佳实践（最小权限、用户组管理等）
- 📖 故障排查指南

## 验收标准

- [x] 实现基础 RBAC 策略（Rego）- 策略已存在
- [x] 角色权限映射 - 已测试
- [x] 资源所有者检查 - 已测试
- [x] 超级管理员支持 - 已测试
- [x] 策略测试 - 50 个测试用例全部通过
- [x] 使用文档 - 完整的使用指南已创建

## 测试结果

```bash
$ opa test pkg/security/opa/policies/rbac.rego pkg/security/opa/policies/rbac_test.rego -v
PASS: 50/50
```

## 相关链接

Closes #799
Related to #776