### PR TITLE
feat: Task 4.5: 服务器核心集成 (#814)

### DIFF
--- a/pkg/server/interfaces.go
+++ b/pkg/server/interfaces.go
@@ -75,6 +75,13 @@ type BusinessServerWithSentry interface {
 	GetSentryManager() *SentryManager
 }
 
+// BusinessServerWithSecurity extends BusinessServerCore with security management capabilities
+type BusinessServerWithSecurity interface {
+	BusinessServerCore
+	// GetSecurityManager returns the security manager instance
+	GetSecurityManager() *SecurityManager
+}
+
 // BusinessServiceRegistrar defines the interface for services to register themselves
 // with the server's transport layer
 type BusinessServiceRegistrar interface {


### PR DESCRIPTION
## 概述

将安全功能集成到服务器核心 (BusinessServerImpl)。

## 变更内容

### 核心集成
- ✅ 扩展 `BusinessServerImpl` 添加 `securityManager` 字段
- ✅ 在 `NewBusinessServerCore` 中初始化安全管理器（当启用时）
- ✅ 在 `Start()` 流程中调用 `InitializeSecurity()`
- ✅ 在 `configureHTTPMiddleware()` 中集成安全中间件
- ✅ 在 `Stop()` 和 `Shutdown()` 中添加安全管理器关闭逻辑

### 接口与健康检查
- ✅ 添加 `GetSecurityManager()` 方法
- ✅ 添加 `BusinessServerWithSecurity` 接口
- ✅ 通过 GetSecurityManager 支持健康检查集成

### 向后兼容
- ✅ 默认禁用安全功能（向后兼容）
- ✅ 只有当 `config.Security.Enabled = true` 时才初始化

### 测试
- ✅ 添加 `TestBaseServer_SecurityIntegration` 测试安全启用/禁用场景
- ✅ 添加 `TestBaseServer_SecurityManagerLifecycle` 测试生命周期管理
- ✅ 添加 `TestBaseServer_SecurityManagerInterface` 测试接口实现
- ✅ 所有现有测试通过

## 测试结果

```bash
$ go test -v ./pkg/server -run TestBaseServer_Security
=== RUN   TestBaseServer_SecurityIntegration
=== RUN   TestBaseServer_SecurityIntegration/security_disabled
=== RUN   TestBaseServer_SecurityIntegration/security_enabled
--- PASS: TestBaseServer_SecurityIntegration (0.00s)
=== RUN   TestBaseServer_SecurityManagerLifecycle
--- PASS: TestBaseServer_SecurityManagerLifecycle (0.00s)
=== RUN   TestBaseServer_SecurityManagerInterface
--- PASS: TestBaseServer_SecurityManagerInterface (0.00s)
PASS
ok  	github.com/innovationmech/swit/pkg/server	1.012s
```

## 验收标准

- [x] 扩展 `BusinessServerImpl`
- [x] 安全管理器初始化
- [x] 启动流程集成
- [x] 关闭流程集成
- [x] 健康检查集成
- [x] 向后兼容（默认禁用）
- [x] 集成测试

## 相关链接

- Epic: #778
- Depends on: #812, #813
- Closes: #814

## 代码检查

- [x] 代码格式化通过 (`make quality-dev`)
- [x] 所有测试通过
- [x] 无 linter 错误