### PR TITLE
feat(examples): add mTLS authentication example

### DIFF
--- a/examples/mtls-authentication/README-CN.md
+++ b/examples/mtls-authentication/README-CN.md
@@ -1,0 +1,333 @@
+# mTLS（双向 TLS）认证示例
+
+本示例演示如何在 Swit 框架服务中实现双向 TLS（mTLS）认证。mTLS 通过要求服务器和客户端都出示并验证证书来提供强身份认证。
+
+## 功能特性
+
+### 安全特性
+
+- ✅ **双向 TLS 认证** - 服务器和客户端相互验证对方的证书
+- ✅ **基于证书的身份识别** - 从证书属性中提取客户端身份
+- ✅ **基于角色的访问控制** - 根据证书属性限制端点访问
+- ✅ **TLS 1.2/1.3 支持** - 现代 TLS 协议版本
+- ✅ **安全密码套件** - 仅使用强加密算法
+
+### 实现特性
+
+- ✅ **HTTP mTLS 服务器** - 基于 Gin 的 HTTPS 服务器，支持客户端证书验证
+- ✅ **gRPC mTLS 服务器** - 支持双向 TLS 的 gRPC 服务器
+- ✅ **证书信息提取** - 解析 CN、OU、SAN 等证书字段
+- ✅ **管理员授权** - 基于证书的授权示例
+- ✅ **证书生成脚本** - 自动化证书生成，轻松设置
+
+## 快速开始
+
+### 前置条件
+
+- Go 1.23+
+- OpenSSL（用于证书生成）
+- curl（用于测试）
+
+### 1. 生成证书
+
+```bash
+cd examples/mtls-authentication
+
+# 生成 CA、服务器和客户端证书
+./scripts/generate-certs.sh
+```
+
+这将创建：
+- `certs/ca.crt` / `certs/ca.key` - 证书颁发机构
+- `certs/server.crt` / `certs/server.key` - 服务器证书
+- `certs/client.crt` / `certs/client.key` - 普通客户端证书
+- `certs/admin-client.crt` / `certs/admin-client.key` - 管理员客户端证书
+
+### 2. 启动服务器
+
+```bash
+cd examples/mtls-authentication
+go run main.go
+```
+
+服务器将启动在：
+- **HTTPS**: https://localhost:8443
+- **gRPC**: localhost:50443
+
+### 3. 测试端点
+
+#### 使用普通客户端证书测试：
+
+```bash
+# 公开端点
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/public/info
+
+# 受保护端点
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/protected/profile
+
+# 管理员端点（使用普通客户端证书将被拒绝）
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/admin/dashboard
+```
+
+#### 使用管理员客户端证书测试：
+
+```bash
+# 管理员端点（使用管理员证书将成功）
+curl --cacert certs/ca.crt \
+     --cert certs/admin-client.crt \
+     --key certs/admin-client.key \
+     https://localhost:8443/api/v1/admin/dashboard
+```
+
+#### 不使用客户端证书测试（将失败）：
+
+```bash
+# 这将失败，因为 mTLS 需要客户端证书
+curl --cacert certs/ca.crt \
+     https://localhost:8443/api/v1/public/info
+```
+
+## API 端点
+
+### 公开端点（需要 mTLS，无身份检查）
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| GET | `/api/v1/public/info` | 服务信息和客户端证书详情 |
+| GET | `/api/v1/public/health` | 健康检查端点 |
+
+### 受保护端点（需要 mTLS）
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| GET | `/api/v1/protected/profile` | 客户端证书配置文件详情 |
+| GET | `/api/v1/protected/data` | 受保护数据访问 |
+
+### 管理员端点（需要管理员证书）
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| GET | `/api/v1/admin/dashboard` | 管理员仪表板 |
+| GET | `/api/v1/admin/certificates` | 列出所有证书 |
+
+## 配置
+
+### 配置文件 (swit.yaml)
+
+```yaml
+http:
+  enabled: true
+  port: "8443"
+  tls:
+    enabled: true
+    cert_file: "certs/server.crt"
+    key_file: "certs/server.key"
+    ca_files:
+      - "certs/ca.crt"
+    client_auth: "require_and_verify"  # 完整 mTLS
+    min_version: "TLS1.2"
+    max_version: "TLS1.3"
+```
+
+### 客户端认证模式
+
+| 模式 | 描述 |
+|------|------|
+| `none` | 不需要客户端证书 |
+| `request` | 请求客户端证书但不强制要求 |
+| `require` | 要求任意客户端证书 |
+| `verify_if_given` | 如果提供则验证客户端证书 |
+| `require_and_verify` | 要求并验证客户端证书（完整 mTLS） |
+
+### 环境变量
+
+```bash
+# 服务器配置
+export HTTP_PORT="8443"
+export GRPC_PORT="50443"
+export GRPC_ENABLED="true"
+
+# TLS 配置
+export TLS_CERT_FILE="certs/server.crt"
+export TLS_KEY_FILE="certs/server.key"
+export TLS_CA_FILE="certs/ca.crt"
+export TLS_CLIENT_AUTH="require_and_verify"
+```
+
+## 证书管理
+
+### 重新生成证书
+
+```bash
+# 清理并重新生成所有证书
+./scripts/generate-certs.sh clean
+./scripts/generate-certs.sh
+```
+
+### 验证证书
+
+```bash
+# 验证所有证书
+./scripts/generate-certs.sh verify
+```
+
+### 自定义证书配置
+
+编辑 `scripts/generate-certs.sh` 中的脚本变量：
+
+```bash
+# CA 配置
+CA_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Security/CN=YourOrg-CA"
+
+# 服务器配置
+SERVER_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Server/CN=your-domain.com"
+SERVER_SAN="DNS:your-domain.com,DNS:*.your-domain.com,IP:10.0.0.1"
+
+# 客户端配置
+CLIENT_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Client/CN=client-name"
+```
+
+## 架构
+
+```
+┌─────────────┐         ┌──────────────────┐
+│   客户端    │◄───────►│  mTLS 服务器     │
+│ (带证书)    │  mTLS   │  (Swit 框架)     │
+└─────────────┘         └──────────────────┘
+       │                        │
+       │                        │
+       ▼                        ▼
+┌─────────────┐         ┌──────────────────┐
+│ client.crt  │         │ server.crt       │
+│ client.key  │         │ server.key       │
+└─────────────┘         │ ca.crt (用于     │
+       │                │ 验证客户端)      │
+       │                └──────────────────┘
+       ▼
+┌─────────────┐
+│   ca.crt    │
+│ (用于验证   │
+│   服务器)   │
+└─────────────┘
+```
+
+### mTLS 握手流程
+
+```
+1. 客户端 → 服务器: ClientHello
+2. 服务器 → 客户端: ServerHello + 服务器证书
+3. 服务器 → 客户端: 证书请求
+4. 客户端 → 服务器: 客户端证书
+5. 客户端 → 服务器: 证书验证
+6. 双方: 根据 CA 验证证书
+7. 建立双向认证连接
+```
+
+## 安全注意事项
+
+### 生产部署
+
+1. **证书存储**: 安全存储私钥（如 HSM、Vault）
+2. **证书轮换**: 实现自动证书轮换
+3. **CRL/OCSP**: 实现证书吊销检查
+4. **审计日志**: 记录所有基于证书的认证事件
+5. **网络安全**: 对 mTLS 服务使用网络分段
+
+### 证书最佳实践
+
+1. **密钥大小**: 至少使用 2048 位 RSA 或 256 位 ECDSA 密钥
+2. **有效期**: 使用短期证书（30-90 天）
+3. **SAN 使用**: 始终包含主题备用名称
+4. **密钥用途**: 设置适当的密钥用途扩展
+5. **CA 安全**: 使用硬件安全保护 CA 私钥
+
+### 常见问题
+
+#### 连接被拒绝
+- 确保服务器在正确的端口上运行
+- 检查防火墙规则
+
+#### 证书验证失败
+- 验证证书链是否完整
+- 检查证书过期日期
+- 确保 CA 证书正确
+
+#### 握手失败
+- 检查 TLS 版本兼容性
+- 验证密码套件支持
+- 确保证书密钥匹配
+
+## 使用 gRPC 测试
+
+### 使用 grpcurl
+
+```bash
+# 安装 grpcurl
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+
+# 列出服务（带 mTLS）
+grpcurl -cacert certs/ca.crt \
+        -cert certs/client.crt \
+        -key certs/client.key \
+        localhost:50443 list
+```
+
+### 使用 Go 客户端
+
+```go
+import (
+    "crypto/tls"
+    "crypto/x509"
+    "os"
+    
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+)
+
+func createMTLSClient() (*grpc.ClientConn, error) {
+    // 加载客户端证书
+    cert, err := tls.LoadX509KeyPair("certs/client.crt", "certs/client.key")
+    if err != nil {
+        return nil, err
+    }
+    
+    // 加载 CA 证书
+    caCert, err := os.ReadFile("certs/ca.crt")
+    if err != nil {
+        return nil, err
+    }
+    caPool := x509.NewCertPool()
+    caPool.AppendCertsFromPEM(caCert)
+    
+    // 创建 TLS 配置
+    tlsConfig := &tls.Config{
+        Certificates: []tls.Certificate{cert},
+        RootCAs:      caPool,
+    }
+    
+    // 创建 gRPC 连接
+    return grpc.Dial("localhost:50443",
+        grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+}
+```
+
+## 延伸阅读
+
+- [TLS 1.3 规范 (RFC 8446)](https://datatracker.ietf.org/doc/html/rfc8446)
+- [X.509 证书标准](https://datatracker.ietf.org/doc/html/rfc5280)
+- [mTLS 最佳实践](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/)
+- [Go crypto/tls 包](https://pkg.go.dev/crypto/tls)
+
+## 许可证
+
+Copyright 2025 Swit. 保留所有权利。
+

--- a/examples/mtls-authentication/README.md
+++ b/examples/mtls-authentication/README.md
@@ -1,0 +1,333 @@
+# mTLS (Mutual TLS) Authentication Example
+
+This example demonstrates how to implement mutual TLS (mTLS) authentication in a Swit framework service. mTLS provides strong authentication by requiring both the server and client to present and verify certificates.
+
+## Features
+
+### Security Features
+
+- ✅ **Mutual TLS Authentication** - Both server and client verify each other's certificates
+- ✅ **Certificate-Based Identity** - Extract client identity from certificate attributes
+- ✅ **Role-Based Access Control** - Restrict endpoints based on certificate attributes
+- ✅ **TLS 1.2/1.3 Support** - Modern TLS protocol versions
+- ✅ **Secure Cipher Suites** - Only strong cryptographic algorithms
+
+### Implementation Features
+
+- ✅ **HTTP mTLS Server** - Gin-based HTTPS server with client certificate verification
+- ✅ **gRPC mTLS Server** - gRPC server with mutual TLS
+- ✅ **Certificate Info Extraction** - Parse CN, OU, SAN, and other certificate fields
+- ✅ **Admin Authorization** - Example of certificate-based authorization
+- ✅ **Certificate Generation Script** - Easy setup with automated certificate generation
+
+## Quick Start
+
+### Prerequisites
+
+- Go 1.23+
+- OpenSSL (for certificate generation)
+- curl (for testing)
+
+### 1. Generate Certificates
+
+```bash
+cd examples/mtls-authentication
+
+# Generate CA, server, and client certificates
+./scripts/generate-certs.sh
+```
+
+This creates:
+- `certs/ca.crt` / `certs/ca.key` - Certificate Authority
+- `certs/server.crt` / `certs/server.key` - Server certificate
+- `certs/client.crt` / `certs/client.key` - Regular client certificate
+- `certs/admin-client.crt` / `certs/admin-client.key` - Admin client certificate
+
+### 2. Start the Server
+
+```bash
+cd examples/mtls-authentication
+go run main.go
+```
+
+The server will start on:
+- **HTTPS**: https://localhost:8443
+- **gRPC**: localhost:50443
+
+### 3. Test the Endpoints
+
+#### Test with regular client certificate:
+
+```bash
+# Public endpoint
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/public/info
+
+# Protected endpoint
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/protected/profile
+
+# Admin endpoint (will be denied with regular client cert)
+curl --cacert certs/ca.crt \
+     --cert certs/client.crt \
+     --key certs/client.key \
+     https://localhost:8443/api/v1/admin/dashboard
+```
+
+#### Test with admin client certificate:
+
+```bash
+# Admin endpoint (will succeed with admin cert)
+curl --cacert certs/ca.crt \
+     --cert certs/admin-client.crt \
+     --key certs/admin-client.key \
+     https://localhost:8443/api/v1/admin/dashboard
+```
+
+#### Test without client certificate (will fail):
+
+```bash
+# This will fail because mTLS requires client certificate
+curl --cacert certs/ca.crt \
+     https://localhost:8443/api/v1/public/info
+```
+
+## API Endpoints
+
+### Public Endpoints (mTLS required, no identity check)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/public/info` | Service information and client certificate details |
+| GET | `/api/v1/public/health` | Health check endpoint |
+
+### Protected Endpoints (mTLS required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/protected/profile` | Client certificate profile details |
+| GET | `/api/v1/protected/data` | Protected data access |
+
+### Admin Endpoints (Admin certificate required)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/admin/dashboard` | Admin dashboard |
+| GET | `/api/v1/admin/certificates` | List all certificates |
+
+## Configuration
+
+### Configuration File (swit.yaml)
+
+```yaml
+http:
+  enabled: true
+  port: "8443"
+  tls:
+    enabled: true
+    cert_file: "certs/server.crt"
+    key_file: "certs/server.key"
+    ca_files:
+      - "certs/ca.crt"
+    client_auth: "require_and_verify"  # Full mTLS
+    min_version: "TLS1.2"
+    max_version: "TLS1.3"
+```
+
+### Client Authentication Modes
+
+| Mode | Description |
+|------|-------------|
+| `none` | No client certificate required |
+| `request` | Request client certificate but don't require it |
+| `require` | Require any client certificate |
+| `verify_if_given` | Verify client certificate if provided |
+| `require_and_verify` | Require and verify client certificate (full mTLS) |
+
+### Environment Variables
+
+```bash
+# Server configuration
+export HTTP_PORT="8443"
+export GRPC_PORT="50443"
+export GRPC_ENABLED="true"
+
+# TLS configuration
+export TLS_CERT_FILE="certs/server.crt"
+export TLS_KEY_FILE="certs/server.key"
+export TLS_CA_FILE="certs/ca.crt"
+export TLS_CLIENT_AUTH="require_and_verify"
+```
+
+## Certificate Management
+
+### Regenerate Certificates
+
+```bash
+# Clean and regenerate all certificates
+./scripts/generate-certs.sh clean
+./scripts/generate-certs.sh
+```
+
+### Verify Certificates
+
+```bash
+# Verify all certificates
+./scripts/generate-certs.sh verify
+```
+
+### Custom Certificate Configuration
+
+Edit the script variables in `scripts/generate-certs.sh`:
+
+```bash
+# CA Configuration
+CA_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Security/CN=YourOrg-CA"
+
+# Server Configuration
+SERVER_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Server/CN=your-domain.com"
+SERVER_SAN="DNS:your-domain.com,DNS:*.your-domain.com,IP:10.0.0.1"
+
+# Client Configuration
+CLIENT_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=YourOrg/OU=Client/CN=client-name"
+```
+
+## Architecture
+
+```
+┌─────────────┐         ┌──────────────────┐
+│   Client    │◄───────►│  mTLS Server     │
+│ (with cert) │  mTLS   │  (Swit Framework)│
+└─────────────┘         └──────────────────┘
+       │                        │
+       │                        │
+       ▼                        ▼
+┌─────────────┐         ┌──────────────────┐
+│ client.crt  │         │ server.crt       │
+│ client.key  │         │ server.key       │
+└─────────────┘         │ ca.crt (for      │
+       │                │ client verify)   │
+       │                └──────────────────┘
+       ▼
+┌─────────────┐
+│   ca.crt    │
+│ (for server │
+│   verify)   │
+└─────────────┘
+```
+
+### mTLS Handshake Flow
+
+```
+1. Client → Server: ClientHello
+2. Server → Client: ServerHello + Server Certificate
+3. Server → Client: Certificate Request
+4. Client → Server: Client Certificate
+5. Client → Server: Certificate Verify
+6. Both: Verify certificates against CA
+7. Connection established with mutual authentication
+```
+
+## Security Considerations
+
+### Production Deployment
+
+1. **Certificate Storage**: Store private keys securely (e.g., HSM, Vault)
+2. **Certificate Rotation**: Implement automatic certificate rotation
+3. **CRL/OCSP**: Implement certificate revocation checking
+4. **Audit Logging**: Log all certificate-based authentication events
+5. **Network Security**: Use network segmentation for mTLS services
+
+### Certificate Best Practices
+
+1. **Key Size**: Use at least 2048-bit RSA or 256-bit ECDSA keys
+2. **Validity Period**: Use short-lived certificates (30-90 days)
+3. **SAN Usage**: Always include Subject Alternative Names
+4. **Key Usage**: Set appropriate key usage extensions
+5. **CA Security**: Protect CA private key with hardware security
+
+### Common Issues
+
+#### Connection Refused
+- Ensure server is running on the correct port
+- Check firewall rules
+
+#### Certificate Verification Failed
+- Verify certificate chain is complete
+- Check certificate expiration dates
+- Ensure CA certificate is correct
+
+#### Handshake Failure
+- Check TLS version compatibility
+- Verify cipher suite support
+- Ensure certificate key matches
+
+## Testing with gRPC
+
+### Using grpcurl
+
+```bash
+# Install grpcurl
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+
+# List services (with mTLS)
+grpcurl -cacert certs/ca.crt \
+        -cert certs/client.crt \
+        -key certs/client.key \
+        localhost:50443 list
+```
+
+### Using Go Client
+
+```go
+import (
+    "crypto/tls"
+    "crypto/x509"
+    "os"
+    
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+)
+
+func createMTLSClient() (*grpc.ClientConn, error) {
+    // Load client certificate
+    cert, err := tls.LoadX509KeyPair("certs/client.crt", "certs/client.key")
+    if err != nil {
+        return nil, err
+    }
+    
+    // Load CA certificate
+    caCert, err := os.ReadFile("certs/ca.crt")
+    if err != nil {
+        return nil, err
+    }
+    caPool := x509.NewCertPool()
+    caPool.AppendCertsFromPEM(caCert)
+    
+    // Create TLS config
+    tlsConfig := &tls.Config{
+        Certificates: []tls.Certificate{cert},
+        RootCAs:      caPool,
+    }
+    
+    // Create gRPC connection
+    return grpc.Dial("localhost:50443",
+        grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+}
+```
+
+## Further Reading
+
+- [TLS 1.3 Specification (RFC 8446)](https://datatracker.ietf.org/doc/html/rfc8446)
+- [X.509 Certificate Standard](https://datatracker.ietf.org/doc/html/rfc5280)
+- [mTLS Best Practices](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/)
+- [Go crypto/tls Package](https://pkg.go.dev/crypto/tls)
+
+## License
+
+Copyright 2025 Swit. All rights reserved.
+

--- a/examples/mtls-authentication/certs/.gitignore
+++ b/examples/mtls-authentication/certs/.gitignore
@@ -1,0 +1,10 @@
+# Ignore all generated certificates
+*.pem
+*.crt
+*.key
+*.csr
+*.srl
+
+# Keep this .gitignore file
+!.gitignore
+

--- a/examples/mtls-authentication/main.go
+++ b/examples/mtls-authentication/main.go
@@ -1,0 +1,660 @@
+// Copyright 2025 Swit. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package main demonstrates mTLS (mutual TLS) authentication using the Swit framework.
+// This example shows how to:
+// - Configure mTLS for HTTP and gRPC transports
+// - Extract client certificate information
+// - Implement certificate-based authentication
+// - Protect endpoints based on client certificate identity
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
+
+	"github.com/innovationmech/swit/pkg/logger"
+	tlsconfig "github.com/innovationmech/swit/pkg/security/tls"
+	"github.com/innovationmech/swit/pkg/server"
+	"github.com/innovationmech/swit/pkg/transport"
+)
+
+// MTLSExampleService implements the ServiceRegistrar interface.
+type MTLSExampleService struct {
+	name string
+}
+
+// NewMTLSExampleService creates a new mTLS example service.
+func NewMTLSExampleService(name string) *MTLSExampleService {
+	return &MTLSExampleService{
+		name: name,
+	}
+}
+
+// RegisterServices registers the HTTP and gRPC handlers with the server.
+func (s *MTLSExampleService) RegisterServices(registry server.BusinessServiceRegistry) error {
+	// Register HTTP handler
+	httpHandler := &MTLSHTTPHandler{
+		serviceName: s.name,
+	}
+	if err := registry.RegisterBusinessHTTPHandler(httpHandler); err != nil {
+		return fmt.Errorf("failed to register HTTP handler: %w", err)
+	}
+
+	// Register gRPC handler
+	grpcHandler := &MTLSGRPCHandler{
+		serviceName: s.name,
+	}
+	if err := registry.RegisterBusinessGRPCService(grpcHandler); err != nil {
+		return fmt.Errorf("failed to register gRPC handler: %w", err)
+	}
+
+	// Register health check
+	healthCheck := &MTLSHealthCheck{serviceName: s.name}
+	if err := registry.RegisterBusinessHealthCheck(healthCheck); err != nil {
+		return fmt.Errorf("failed to register health check: %w", err)
+	}
+
+	return nil
+}
+
+// MTLSHTTPHandler implements the HTTPHandler interface.
+type MTLSHTTPHandler struct {
+	serviceName string
+}
+
+// RegisterRoutes registers HTTP routes with the router.
+func (h *MTLSHTTPHandler) RegisterRoutes(router interface{}) error {
+	ginRouter, ok := router.(gin.IRouter)
+	if !ok {
+		return fmt.Errorf("expected gin.IRouter, got %T", router)
+	}
+
+	// Public endpoints (still require mTLS, but no specific client identity check)
+	public := ginRouter.Group("/api/v1/public")
+	{
+		public.GET("/info", h.handlePublicInfo)
+		public.GET("/health", h.handleHealth)
+	}
+
+	// Protected endpoints (require specific client certificate attributes)
+	protected := ginRouter.Group("/api/v1/protected")
+	{
+		protected.GET("/profile", h.handleProfile)
+		protected.GET("/data", h.handleData)
+	}
+
+	// Admin endpoints (require admin client certificate)
+	admin := ginRouter.Group("/api/v1/admin")
+	admin.Use(h.requireAdminCertMiddleware())
+	{
+		admin.GET("/dashboard", h.handleAdminDashboard)
+		admin.GET("/certificates", h.handleListCertificates)
+	}
+
+	return nil
+}
+
+// GetServiceName returns the service name.
+func (h *MTLSHTTPHandler) GetServiceName() string {
+	return h.serviceName
+}
+
+// handlePublicInfo handles the public info endpoint.
+func (h *MTLSHTTPHandler) handlePublicInfo(c *gin.Context) {
+	// Extract client certificate information
+	certInfo := transport.GetClientCertificateInfo(c)
+
+	response := gin.H{
+		"message":   "Welcome to mTLS Authentication Example",
+		"service":   h.serviceName,
+		"timestamp": time.Now().UTC(),
+		"tls_info": gin.H{
+			"protocol": "mTLS",
+			"version":  "TLS 1.2+",
+		},
+	}
+
+	// Add client certificate info if available
+	if certInfo != nil {
+		response["client_certificate"] = gin.H{
+			"common_name":  certInfo.CommonName,
+			"organization": certInfo.Organization,
+			"serial":       certInfo.SerialNumber,
+			"not_before":   certInfo.NotBefore,
+			"not_after":    certInfo.NotAfter,
+			"issuer":       certInfo.Issuer,
+		}
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+// handleHealth handles the health check endpoint.
+func (h *MTLSHTTPHandler) handleHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "healthy",
+		"service":   h.serviceName,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleProfile handles the protected profile endpoint.
+func (h *MTLSHTTPHandler) handleProfile(c *gin.Context) {
+	certInfo := transport.GetClientCertificateInfo(c)
+	if certInfo == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error":   "Client certificate required",
+			"message": "This endpoint requires a valid client certificate",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Client profile retrieved successfully",
+		"profile": gin.H{
+			"identity":     certInfo.CommonName,
+			"organization": certInfo.Organization,
+			"ou":           certInfo.OrganizationalUnit,
+			"country":      certInfo.Country,
+			"email":        certInfo.EmailAddresses,
+			"dns_names":    certInfo.DNSNames,
+			"ip_addresses": certInfo.IPAddresses,
+		},
+		"certificate_details": gin.H{
+			"serial":     certInfo.SerialNumber,
+			"not_before": certInfo.NotBefore,
+			"not_after":  certInfo.NotAfter,
+			"issuer":     certInfo.Issuer,
+			"subject":    certInfo.Subject,
+		},
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleData handles the protected data endpoint.
+func (h *MTLSHTTPHandler) handleData(c *gin.Context) {
+	certInfo := transport.GetClientCertificateInfo(c)
+	if certInfo == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Client certificate required",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Protected data retrieved successfully",
+		"client":   certInfo.CommonName,
+		"data":     generateSampleData(),
+		"accessed": time.Now().UTC(),
+	})
+}
+
+// handleAdminDashboard handles the admin-only endpoint.
+func (h *MTLSHTTPHandler) handleAdminDashboard(c *gin.Context) {
+	certInfo := transport.GetClientCertificateInfo(c)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Welcome to the Admin Dashboard",
+		"admin":   certInfo.CommonName,
+		"dashboard": gin.H{
+			"total_connections":    42,
+			"active_certificates":  3,
+			"revoked_certificates": 0,
+			"last_audit":           time.Now().Add(-24 * time.Hour).UTC(),
+		},
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// handleListCertificates handles the certificate listing endpoint.
+func (h *MTLSHTTPHandler) handleListCertificates(c *gin.Context) {
+	certInfo := transport.GetClientCertificateInfo(c)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":      "Certificate inventory",
+		"requested_by": certInfo.CommonName,
+		"certificates": []gin.H{
+			{
+				"cn":      "swit-client",
+				"type":    "client",
+				"status":  "active",
+				"issued":  "2025-01-01",
+				"expires": "2026-01-01",
+			},
+			{
+				"cn":      "swit-admin",
+				"type":    "admin",
+				"status":  "active",
+				"issued":  "2025-01-01",
+				"expires": "2026-01-01",
+			},
+		},
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// requireAdminCertMiddleware creates middleware that requires admin certificate.
+func (h *MTLSHTTPHandler) requireAdminCertMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		certInfo := transport.GetClientCertificateInfo(c)
+		if certInfo == nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error":   "Client certificate required",
+				"message": "Admin endpoints require a valid client certificate",
+			})
+			return
+		}
+
+		// Check if the certificate is an admin certificate
+		// In production, you might check specific attributes, OU, or maintain a whitelist
+		if certInfo.CommonName != "swit-admin" && !containsOU(certInfo.OrganizationalUnit, "Admin") {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error":   "Admin certificate required",
+				"message": "This endpoint requires an admin-level client certificate",
+				"your_cn": certInfo.CommonName,
+				"your_ou": certInfo.OrganizationalUnit,
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// containsOU checks if the organizational unit list contains a specific value.
+func containsOU(ous []string, target string) bool {
+	for _, ou := range ous {
+		if ou == target {
+			return true
+		}
+	}
+	return false
+}
+
+// generateSampleData generates sample protected data.
+func generateSampleData() []gin.H {
+	return []gin.H{
+		{"id": 1, "name": "Confidential Report A", "classification": "internal"},
+		{"id": 2, "name": "Financial Summary Q4", "classification": "confidential"},
+		{"id": 3, "name": "Strategic Plan 2025", "classification": "restricted"},
+	}
+}
+
+// MTLSGRPCHandler implements a simple gRPC service for mTLS demonstration.
+type MTLSGRPCHandler struct {
+	serviceName string
+}
+
+// RegisterGRPC registers the gRPC service.
+func (h *MTLSGRPCHandler) RegisterGRPC(server interface{}) error {
+	// In a real application, you would register your protobuf service here
+	// For this example, we just log that gRPC is available
+	logger.GetLogger().Info("gRPC service registered for mTLS example",
+		zap.String("service", h.serviceName))
+	return nil
+}
+
+// GetServiceName returns the service name.
+func (h *MTLSGRPCHandler) GetServiceName() string {
+	return h.serviceName
+}
+
+// ExtractGRPCClientCertInfo extracts client certificate info from gRPC context.
+func ExtractGRPCClientCertInfo(ctx context.Context) (*tlsconfig.CertificateInfo, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no peer information")
+	}
+
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "no TLS information")
+	}
+
+	if len(tlsInfo.State.PeerCertificates) == 0 {
+		return nil, status.Error(codes.Unauthenticated, "no client certificate")
+	}
+
+	return tlsconfig.ExtractCertificateInfo(tlsInfo.State.PeerCertificates[0]), nil
+}
+
+// MTLSHealthCheck implements the HealthCheck interface.
+type MTLSHealthCheck struct {
+	serviceName string
+}
+
+// Check performs a health check.
+func (h *MTLSHealthCheck) Check(ctx context.Context) error {
+	// In a real service, check TLS certificate validity, CA availability, etc.
+	return nil
+}
+
+// GetServiceName returns the service name.
+func (h *MTLSHealthCheck) GetServiceName() string {
+	return h.serviceName
+}
+
+// MTLSDependencyContainer implements the DependencyContainer interface.
+type MTLSDependencyContainer struct {
+	services map[string]interface{}
+	closed   bool
+}
+
+// NewMTLSDependencyContainer creates a new dependency container.
+func NewMTLSDependencyContainer() *MTLSDependencyContainer {
+	return &MTLSDependencyContainer{
+		services: make(map[string]interface{}),
+		closed:   false,
+	}
+}
+
+// GetService retrieves a service by name.
+func (d *MTLSDependencyContainer) GetService(name string) (interface{}, error) {
+	if d.closed {
+		return nil, fmt.Errorf("dependency container is closed")
+	}
+
+	service, exists := d.services[name]
+	if !exists {
+		return nil, fmt.Errorf("service %s not found", name)
+	}
+
+	return service, nil
+}
+
+// Close closes the dependency container.
+func (d *MTLSDependencyContainer) Close() error {
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return nil
+}
+
+// loadConfigFromFile loads configuration from YAML file.
+func loadConfigFromFile(configPath string) (*server.ServerConfig, error) {
+	config := &server.ServerConfig{}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return createDefaultConfig(), nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// Apply environment variable overrides
+	applyEnvironmentOverrides(config)
+
+	return config, nil
+}
+
+// createDefaultConfig creates default configuration with mTLS enabled.
+func createDefaultConfig() *server.ServerConfig {
+	return &server.ServerConfig{
+		ServiceName: "mtls-authentication-example",
+		HTTP: server.HTTPConfig{
+			Port:         getEnv("HTTP_PORT", "8443"),
+			EnableReady:  true,
+			Enabled:      true,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
+			TLS: &tlsconfig.TLSConfig{
+				Enabled:    true,
+				CertFile:   getEnv("TLS_CERT_FILE", "certs/server.crt"),
+				KeyFile:    getEnv("TLS_KEY_FILE", "certs/server.key"),
+				CAFiles:    []string{getEnv("TLS_CA_FILE", "certs/ca.crt")},
+				ClientAuth: getEnv("TLS_CLIENT_AUTH", "require_and_verify"),
+				MinVersion: "TLS1.2",
+				MaxVersion: "TLS1.3",
+			},
+		},
+		GRPC: server.GRPCConfig{
+			Port:                getEnv("GRPC_PORT", "50443"),
+			Enabled:             getBoolEnv("GRPC_ENABLED", true),
+			EnableReflection:    true,
+			EnableHealthService: true,
+			MaxRecvMsgSize:      4 * 1024 * 1024,
+			MaxSendMsgSize:      4 * 1024 * 1024,
+			TLS: &tlsconfig.TLSConfig{
+				Enabled:    true,
+				CertFile:   getEnv("TLS_CERT_FILE", "certs/server.crt"),
+				KeyFile:    getEnv("TLS_KEY_FILE", "certs/server.key"),
+				CAFiles:    []string{getEnv("TLS_CA_FILE", "certs/ca.crt")},
+				ClientAuth: getEnv("TLS_CLIENT_AUTH", "require_and_verify"),
+				MinVersion: "TLS1.2",
+				MaxVersion: "TLS1.3",
+			},
+		},
+		ShutdownTimeout: 30 * time.Second,
+		Middleware: server.MiddlewareConfig{
+			EnableCORS:    false,
+			EnableLogging: true,
+		},
+	}
+}
+
+// applyEnvironmentOverrides applies environment variable overrides.
+func applyEnvironmentOverrides(config *server.ServerConfig) {
+	if httpPort := os.Getenv("HTTP_PORT"); httpPort != "" {
+		config.HTTP.Port = httpPort
+	}
+	if grpcPort := os.Getenv("GRPC_PORT"); grpcPort != "" {
+		config.GRPC.Port = grpcPort
+	}
+	if certFile := os.Getenv("TLS_CERT_FILE"); certFile != "" {
+		if config.HTTP.TLS != nil {
+			config.HTTP.TLS.CertFile = certFile
+		}
+		if config.GRPC.TLS != nil {
+			config.GRPC.TLS.CertFile = certFile
+		}
+	}
+	if keyFile := os.Getenv("TLS_KEY_FILE"); keyFile != "" {
+		if config.HTTP.TLS != nil {
+			config.HTTP.TLS.KeyFile = keyFile
+		}
+		if config.GRPC.TLS != nil {
+			config.GRPC.TLS.KeyFile = keyFile
+		}
+	}
+	if caFile := os.Getenv("TLS_CA_FILE"); caFile != "" {
+		if config.HTTP.TLS != nil {
+			config.HTTP.TLS.CAFiles = []string{caFile}
+		}
+		if config.GRPC.TLS != nil {
+			config.GRPC.TLS.CAFiles = []string{caFile}
+		}
+	}
+}
+
+// printCertificateInfo prints certificate information for debugging.
+func printCertificateInfo(cert *x509.Certificate) {
+	if cert == nil {
+		return
+	}
+	info := tlsconfig.ExtractCertificateInfo(cert)
+	logger.GetLogger().Info("Certificate loaded",
+		zap.String("subject", info.Subject),
+		zap.String("issuer", info.Issuer),
+		zap.String("not_before", info.NotBefore),
+		zap.String("not_after", info.NotAfter))
+}
+
+func main() {
+	// Initialize logger
+	logger.InitLogger()
+
+	// Determine working directory
+	execDir, err := os.Executable()
+	if err != nil {
+		execDir = "."
+	} else {
+		execDir = filepath.Dir(execDir)
+	}
+
+	// Load server configuration
+	configPath := getEnv("CONFIG_PATH", "swit.yaml")
+	if !filepath.IsAbs(configPath) {
+		// Try current directory first, then executable directory
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			configPath = filepath.Join(execDir, configPath)
+		}
+	}
+
+	serverConfig, err := loadConfigFromFile(configPath)
+	if err != nil {
+		logger.GetLogger().Fatal("Failed to load server configuration", zap.Error(err))
+	}
+
+	if serverConfig == nil {
+		logger.GetLogger().Warn("Using default server configuration")
+		serverConfig = createDefaultConfig()
+	}
+
+	// Adjust certificate paths if they are relative
+	adjustCertPaths(serverConfig, execDir)
+
+	// Validate server configuration
+	if err := serverConfig.Validate(); err != nil {
+		logger.GetLogger().Fatal("Invalid server configuration", zap.Error(err))
+	}
+
+	// Create service and dependencies
+	service := NewMTLSExampleService("mtls-authentication-example")
+	deps := NewMTLSDependencyContainer()
+
+	// Create base server
+	baseServer, err := server.NewBusinessServerCore(serverConfig, service, deps)
+	if err != nil {
+		logger.GetLogger().Fatal("Failed to create server", zap.Error(err))
+	}
+
+	// Start server
+	startCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := baseServer.Start(startCtx); err != nil {
+		logger.GetLogger().Fatal("Failed to start server", zap.Error(err))
+	}
+
+	// Log startup information
+	logger.GetLogger().Info("mTLS Authentication Example Service Started",
+		zap.String("https_address", baseServer.GetHTTPAddress()),
+		zap.String("grpc_address", baseServer.GetGRPCAddress()),
+		zap.String("service_name", "mtls-authentication-example"))
+
+	logger.GetLogger().Info("mTLS Configuration",
+		zap.String("client_auth", serverConfig.HTTP.TLS.ClientAuth),
+		zap.String("min_version", serverConfig.HTTP.TLS.MinVersion),
+		zap.String("max_version", serverConfig.HTTP.TLS.MaxVersion))
+
+	logger.GetLogger().Info("Example endpoints (use curl with client certificate)",
+		zap.String("public_info", fmt.Sprintf("https://localhost:%s/api/v1/public/info", serverConfig.HTTP.Port)),
+		zap.String("profile", fmt.Sprintf("https://localhost:%s/api/v1/protected/profile", serverConfig.HTTP.Port)),
+		zap.String("admin", fmt.Sprintf("https://localhost:%s/api/v1/admin/dashboard", serverConfig.HTTP.Port)))
+
+	logger.GetLogger().Info("Test with curl",
+		zap.String("command", fmt.Sprintf(
+			"curl --cacert certs/ca.crt --cert certs/client.crt --key certs/client.key https://localhost:%s/api/v1/public/info",
+			serverConfig.HTTP.Port)))
+
+	// Wait for shutdown signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	logger.GetLogger().Info("Shutdown signal received, stopping server")
+
+	// Graceful shutdown
+	if err := baseServer.Shutdown(); err != nil {
+		logger.GetLogger().Error("Error during shutdown", zap.Error(err))
+	} else {
+		logger.GetLogger().Info("Server stopped gracefully")
+	}
+}
+
+// adjustCertPaths adjusts certificate paths to be relative to the working directory.
+func adjustCertPaths(config *server.ServerConfig, baseDir string) {
+	// Check if we're running from the example directory
+	if _, err := os.Stat("certs/server.crt"); err == nil {
+		return // Paths are already correct
+	}
+
+	// Try to find certs relative to executable
+	if config.HTTP.TLS != nil {
+		if !filepath.IsAbs(config.HTTP.TLS.CertFile) {
+			config.HTTP.TLS.CertFile = filepath.Join(baseDir, config.HTTP.TLS.CertFile)
+		}
+		if !filepath.IsAbs(config.HTTP.TLS.KeyFile) {
+			config.HTTP.TLS.KeyFile = filepath.Join(baseDir, config.HTTP.TLS.KeyFile)
+		}
+		for i, caFile := range config.HTTP.TLS.CAFiles {
+			if !filepath.IsAbs(caFile) {
+				config.HTTP.TLS.CAFiles[i] = filepath.Join(baseDir, caFile)
+			}
+		}
+	}
+
+	if config.GRPC.TLS != nil {
+		if !filepath.IsAbs(config.GRPC.TLS.CertFile) {
+			config.GRPC.TLS.CertFile = filepath.Join(baseDir, config.GRPC.TLS.CertFile)
+		}
+		if !filepath.IsAbs(config.GRPC.TLS.KeyFile) {
+			config.GRPC.TLS.KeyFile = filepath.Join(baseDir, config.GRPC.TLS.KeyFile)
+		}
+		for i, caFile := range config.GRPC.TLS.CAFiles {
+			if !filepath.IsAbs(caFile) {
+				config.GRPC.TLS.CAFiles[i] = filepath.Join(baseDir, caFile)
+			}
+		}
+	}
+}
+
+// getEnv gets an environment variable with a default value.
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// getBoolEnv gets a boolean environment variable with a default value.
+func getBoolEnv(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		return value == "true" || value == "1" || value == "yes"
+	}
+	return defaultValue
+}
+
+// Compile-time interface checks
+var (
+	_ server.BusinessServiceRegistrar    = (*MTLSExampleService)(nil)
+	_ server.BusinessHTTPHandler         = (*MTLSHTTPHandler)(nil)
+	_ server.BusinessGRPCService         = (*MTLSGRPCHandler)(nil)
+	_ server.BusinessHealthCheck         = (*MTLSHealthCheck)(nil)
+	_ server.BusinessDependencyContainer = (*MTLSDependencyContainer)(nil)
+)

--- a/examples/mtls-authentication/scripts/generate-certs.sh
+++ b/examples/mtls-authentication/scripts/generate-certs.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+
+# mTLS Certificate Generation Script
+# This script generates a complete set of certificates for mTLS demonstration:
+# - CA certificate (root certificate authority)
+# - Server certificate (signed by CA)
+# - Client certificate (signed by CA)
+
+set -e
+
+# Configuration
+CERT_DIR="$(dirname "$0")/../certs"
+DAYS_VALID=365
+KEY_SIZE=4096
+
+# CA Configuration
+CA_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=Swit/OU=Security/CN=Swit-CA"
+
+# Server Configuration
+SERVER_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=Swit/OU=Server/CN=localhost"
+SERVER_SAN="DNS:localhost,DNS:*.localhost,IP:127.0.0.1,IP:::1"
+
+# Client Configuration
+CLIENT_SUBJECT="/C=CN/ST=Beijing/L=Beijing/O=Swit/OU=Client/CN=swit-client"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print functions
+info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+    exit 1
+}
+
+# Create certificate directory
+create_cert_dir() {
+    info "Creating certificate directory: $CERT_DIR"
+    mkdir -p "$CERT_DIR"
+}
+
+# Generate CA certificate
+generate_ca() {
+    info "Generating CA certificate..."
+    
+    # Generate CA private key
+    openssl genrsa -out "$CERT_DIR/ca.key" $KEY_SIZE 2>/dev/null
+    
+    # Generate CA certificate
+    openssl req -new -x509 -days $DAYS_VALID \
+        -key "$CERT_DIR/ca.key" \
+        -out "$CERT_DIR/ca.crt" \
+        -subj "$CA_SUBJECT" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign"
+    
+    success "CA certificate generated: $CERT_DIR/ca.crt"
+}
+
+# Generate server certificate
+generate_server() {
+    info "Generating server certificate..."
+    
+    # Generate server private key
+    openssl genrsa -out "$CERT_DIR/server.key" $KEY_SIZE 2>/dev/null
+    
+    # Generate server CSR
+    openssl req -new \
+        -key "$CERT_DIR/server.key" \
+        -out "$CERT_DIR/server.csr" \
+        -subj "$SERVER_SUBJECT"
+    
+    # Create server extensions file
+    cat > "$CERT_DIR/server.ext" << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=$SERVER_SAN
+EOF
+    
+    # Sign server certificate with CA
+    openssl x509 -req -days $DAYS_VALID \
+        -in "$CERT_DIR/server.csr" \
+        -CA "$CERT_DIR/ca.crt" \
+        -CAkey "$CERT_DIR/ca.key" \
+        -CAcreateserial \
+        -out "$CERT_DIR/server.crt" \
+        -extfile "$CERT_DIR/server.ext"
+    
+    # Clean up CSR and ext files
+    rm -f "$CERT_DIR/server.csr" "$CERT_DIR/server.ext"
+    
+    success "Server certificate generated: $CERT_DIR/server.crt"
+}
+
+# Generate client certificate
+generate_client() {
+    info "Generating client certificate..."
+    
+    # Generate client private key
+    openssl genrsa -out "$CERT_DIR/client.key" $KEY_SIZE 2>/dev/null
+    
+    # Generate client CSR
+    openssl req -new \
+        -key "$CERT_DIR/client.key" \
+        -out "$CERT_DIR/client.csr" \
+        -subj "$CLIENT_SUBJECT"
+    
+    # Create client extensions file
+    cat > "$CERT_DIR/client.ext" << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+    
+    # Sign client certificate with CA
+    openssl x509 -req -days $DAYS_VALID \
+        -in "$CERT_DIR/client.csr" \
+        -CA "$CERT_DIR/ca.crt" \
+        -CAkey "$CERT_DIR/ca.key" \
+        -CAcreateserial \
+        -out "$CERT_DIR/client.crt" \
+        -extfile "$CERT_DIR/client.ext"
+    
+    # Clean up CSR and ext files
+    rm -f "$CERT_DIR/client.csr" "$CERT_DIR/client.ext"
+    
+    success "Client certificate generated: $CERT_DIR/client.crt"
+}
+
+# Generate additional client certificate (for testing multiple clients)
+generate_additional_client() {
+    local client_name=$1
+    local client_cn=$2
+    
+    info "Generating additional client certificate: $client_name..."
+    
+    # Generate client private key
+    openssl genrsa -out "$CERT_DIR/${client_name}.key" $KEY_SIZE 2>/dev/null
+    
+    # Generate client CSR
+    openssl req -new \
+        -key "$CERT_DIR/${client_name}.key" \
+        -out "$CERT_DIR/${client_name}.csr" \
+        -subj "/C=CN/ST=Beijing/L=Beijing/O=Swit/OU=Client/CN=$client_cn"
+    
+    # Create client extensions file
+    cat > "$CERT_DIR/${client_name}.ext" << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+    
+    # Sign client certificate with CA
+    openssl x509 -req -days $DAYS_VALID \
+        -in "$CERT_DIR/${client_name}.csr" \
+        -CA "$CERT_DIR/ca.crt" \
+        -CAkey "$CERT_DIR/ca.key" \
+        -CAcreateserial \
+        -out "$CERT_DIR/${client_name}.crt" \
+        -extfile "$CERT_DIR/${client_name}.ext"
+    
+    # Clean up CSR and ext files
+    rm -f "$CERT_DIR/${client_name}.csr" "$CERT_DIR/${client_name}.ext"
+    
+    success "Additional client certificate generated: $CERT_DIR/${client_name}.crt"
+}
+
+# Verify certificates
+verify_certificates() {
+    info "Verifying certificates..."
+    
+    # Verify server certificate
+    if openssl verify -CAfile "$CERT_DIR/ca.crt" "$CERT_DIR/server.crt" > /dev/null 2>&1; then
+        success "Server certificate verification: PASSED"
+    else
+        error "Server certificate verification: FAILED"
+    fi
+    
+    # Verify client certificate
+    if openssl verify -CAfile "$CERT_DIR/ca.crt" "$CERT_DIR/client.crt" > /dev/null 2>&1; then
+        success "Client certificate verification: PASSED"
+    else
+        error "Client certificate verification: FAILED"
+    fi
+    
+    # Verify admin client certificate if exists
+    if [ -f "$CERT_DIR/admin-client.crt" ]; then
+        if openssl verify -CAfile "$CERT_DIR/ca.crt" "$CERT_DIR/admin-client.crt" > /dev/null 2>&1; then
+            success "Admin client certificate verification: PASSED"
+        else
+            error "Admin client certificate verification: FAILED"
+        fi
+    fi
+}
+
+# Display certificate information
+display_cert_info() {
+    info "Certificate Information:"
+    echo ""
+    
+    echo "=== CA Certificate ==="
+    openssl x509 -in "$CERT_DIR/ca.crt" -noout -subject -issuer -dates
+    echo ""
+    
+    echo "=== Server Certificate ==="
+    openssl x509 -in "$CERT_DIR/server.crt" -noout -subject -issuer -dates
+    echo "Subject Alternative Names:"
+    openssl x509 -in "$CERT_DIR/server.crt" -noout -ext subjectAltName 2>/dev/null || echo "  None"
+    echo ""
+    
+    echo "=== Client Certificate ==="
+    openssl x509 -in "$CERT_DIR/client.crt" -noout -subject -issuer -dates
+    echo ""
+    
+    if [ -f "$CERT_DIR/admin-client.crt" ]; then
+        echo "=== Admin Client Certificate ==="
+        openssl x509 -in "$CERT_DIR/admin-client.crt" -noout -subject -issuer -dates
+        echo ""
+    fi
+}
+
+# Print usage information
+print_usage() {
+    echo ""
+    echo "=== Certificate Files Generated ==="
+    echo "CA Certificate:      $CERT_DIR/ca.crt"
+    echo "CA Private Key:      $CERT_DIR/ca.key"
+    echo "Server Certificate:  $CERT_DIR/server.crt"
+    echo "Server Private Key:  $CERT_DIR/server.key"
+    echo "Client Certificate:  $CERT_DIR/client.crt"
+    echo "Client Private Key:  $CERT_DIR/client.key"
+    if [ -f "$CERT_DIR/admin-client.crt" ]; then
+        echo "Admin Certificate:   $CERT_DIR/admin-client.crt"
+        echo "Admin Private Key:   $CERT_DIR/admin-client.key"
+    fi
+    echo ""
+    echo "=== Usage Examples ==="
+    echo ""
+    echo "1. Start the mTLS server:"
+    echo "   cd examples/mtls-authentication"
+    echo "   go run main.go"
+    echo ""
+    echo "2. Test with curl (mTLS client):"
+    echo "   curl --cacert certs/ca.crt \\"
+    echo "        --cert certs/client.crt \\"
+    echo "        --key certs/client.key \\"
+    echo "        https://localhost:8443/api/v1/public/info"
+    echo ""
+    echo "3. Test without client certificate (should fail with require_and_verify):"
+    echo "   curl --cacert certs/ca.crt https://localhost:8443/api/v1/public/info"
+    echo ""
+}
+
+# Clean up generated certificates
+clean() {
+    warn "Cleaning up all generated certificates..."
+    rm -f "$CERT_DIR"/*.crt "$CERT_DIR"/*.key "$CERT_DIR"/*.srl
+    success "Cleanup complete"
+}
+
+# Main function
+main() {
+    case "${1:-}" in
+        clean)
+            clean
+            ;;
+        verify)
+            verify_certificates
+            display_cert_info
+            ;;
+        *)
+            echo "=============================================="
+            echo "  mTLS Certificate Generation Script"
+            echo "=============================================="
+            echo ""
+            
+            create_cert_dir
+            generate_ca
+            generate_server
+            generate_client
+            generate_additional_client "admin-client" "swit-admin"
+            verify_certificates
+            display_cert_info
+            print_usage
+            
+            success "All certificates generated successfully!"
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"
+

--- a/examples/mtls-authentication/swit.yaml
+++ b/examples/mtls-authentication/swit.yaml
@@ -1,0 +1,135 @@
+# mTLS Authentication Example Service Configuration
+# This configuration demonstrates mutual TLS (mTLS) authentication
+# where both server and client verify each other's certificates.
+
+service_name: "mtls-authentication-example"
+shutdown_timeout: "30s"
+
+# HTTP Configuration with mTLS
+http:
+  enabled: true
+  port: "8443"
+  enable_ready: true
+  read_timeout: "30s"
+  write_timeout: "30s"
+  idle_timeout: "60s"
+  
+  # TLS/mTLS Configuration
+  tls:
+    enabled: true
+    
+    # Server certificate and key
+    cert_file: "certs/server.crt"
+    key_file: "certs/server.key"
+    
+    # CA certificates for client verification
+    ca_files:
+      - "certs/ca.crt"
+    
+    # Client authentication mode:
+    # - none: No client certificate required
+    # - request: Request client certificate but don't require it
+    # - require: Require any client certificate
+    # - verify_if_given: Verify client certificate if provided
+    # - require_and_verify: Require and verify client certificate (full mTLS)
+    client_auth: "require_and_verify"
+    
+    # TLS version constraints
+    min_version: "TLS1.2"
+    max_version: "TLS1.3"
+    
+    # Cipher suites (optional, uses secure defaults if not specified)
+    cipher_suites:
+      - "TLS_AES_256_GCM_SHA384"
+      - "TLS_CHACHA20_POLY1305_SHA256"
+      - "TLS_AES_128_GCM_SHA256"
+      - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+      - "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+      - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+      - "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+      - "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
+      - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+    
+    # Curve preferences for ECDHE
+    curve_preferences:
+      - "X25519"
+      - "P256"
+      - "P384"
+    
+    # Security settings
+    prefer_server_cipher_suites: true
+    session_tickets_disabled: false
+    renegotiation: "never"
+    
+    # ALPN protocols
+    next_protos:
+      - "h2"
+      - "http/1.1"
+
+# gRPC Configuration with mTLS (optional)
+grpc:
+  enabled: true
+  port: "50443"
+  enable_reflection: true
+  enable_health_service: true
+  max_recv_msg_size: 4194304  # 4MB
+  max_send_msg_size: 4194304  # 4MB
+  
+  # gRPC TLS/mTLS Configuration
+  tls:
+    enabled: true
+    cert_file: "certs/server.crt"
+    key_file: "certs/server.key"
+    ca_files:
+      - "certs/ca.crt"
+    client_auth: "require_and_verify"
+    min_version: "TLS1.2"
+    max_version: "TLS1.3"
+
+# Middleware Configuration
+middleware:
+  enable_cors: false
+  enable_logging: true
+  enable_recovery: true
+
+# Service Discovery (disabled for this example)
+discovery:
+  enabled: false
+
+# Prometheus Metrics
+prometheus:
+  enabled: true
+  endpoint: "/metrics"
+  namespace: "swit"
+  subsystem: "mtls_example"
+  labels:
+    service: "mtls-authentication-example"
+    version: "v1"
+  buckets:
+    duration:
+      - 0.001
+      - 0.005
+      - 0.01
+      - 0.025
+      - 0.05
+      - 0.1
+      - 0.25
+      - 0.5
+      - 1.0
+      - 2.5
+      - 5.0
+      - 10.0
+    size:
+      - 100
+      - 1000
+      - 10000
+      - 100000
+      - 1000000
+  cardinality_limit: 1000
+
+# Logging Configuration
+logging:
+  level: "info"
+  format: "json"
+  output: "stdout"
+


### PR DESCRIPTION
## Summary

This PR adds a comprehensive mTLS (mutual TLS) authentication example that demonstrates how to implement certificate-based authentication in the Swit framework.

## Changes

### New Files
- `examples/mtls-authentication/main.go` - Main service implementation with HTTP and gRPC mTLS support
- `examples/mtls-authentication/swit.yaml` - mTLS configuration file
- `examples/mtls-authentication/scripts/generate-certs.sh` - Certificate generation script
- `examples/mtls-authentication/certs/.gitignore` - Ignore generated certificates
- `examples/mtls-authentication/README.md` - English documentation
- `examples/mtls-authentication/README-CN.md` - Chinese documentation

## Features Demonstrated

- ✅ mTLS server configuration for HTTP and gRPC transports
- ✅ Certificate generation script (CA, server, and client certificates)
- ✅ Client certificate extraction and validation
- ✅ Certificate-based authorization (admin vs regular client)
- ✅ TLS 1.2/1.3 support with secure cipher suites
- ✅ Comprehensive documentation in both English and Chinese

## Testing

The example has been tested with:
1. Public endpoint access with client certificate
2. Protected endpoint access with client certificate
3. Admin endpoint access denied with regular client certificate
4. Admin endpoint access granted with admin certificate
5. Connection rejected without client certificate (mTLS enforcement)

## Acceptance Criteria from Issue #822

- [x] 生成测试证书脚本
- [x] mTLS 服务器配置
- [x] mTLS 客户端配置
- [x] 证书验证演示
- [x] README 文档（中英文）

Closes #822

---

**Related Issues:**
- Epic: #779
- Depends on: #804 (mTLS Integration - completed)