### PR TITLE
fix(ci): add -short flag to coverage tests to skip long-running load tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -100,7 +100,8 @@ jobs:
         echo "$PACKAGES"
         
         # 运行测试并生成覆盖率报告 (排除自动生成的代码)
-        go test -v -race -coverprofile=coverage.out -covermode=atomic $PACKAGES
+        # 使用 -short 跳过长时间运行的负载测试和压力测试
+        go test -v -race -short -coverprofile=coverage.out -covermode=atomic $PACKAGES
         
         # 生成 HTML 报告
         go tool cover -html=coverage.out -o coverage.html


### PR DESCRIPTION
## Problem

The coverage workflow (job ID: 56598045030) was failing due to test timeout. The `TestStressHighConcurrency` test in `tests/load/security_load_test.go` ran for over 4 minutes before the 10-minute timeout was triggered.

## Root Cause

- `TestStressHighConcurrency` attempts 50,000 RPS with `runtime.NumCPU() * 10` workers
- In CI environment (typically 2 CPU cores), this creates 20 workers each handling 2,500 RPS
- The test is designed for local stress testing, not CI environments
- The test already has a `testing.Short()` guard, but CI wasn't using the `-short` flag

## Solution

Add `-short` flag to the `go test` command in `coverage.yml`. This skips all load/stress tests that have `testing.Short()` guards, including:
- `TestLoadOAuth2TokenCache`
- `TestLoadOAuth2TokenCacheConcurrentWrite`
- `TestLoadJWTValidation`
- `TestLoadOPAPolicyEvaluation`
- `TestLoadMiddlewareStack`
- `TestStabilityLongRunning`
- `TestStressHighConcurrency`
- `TestPerformanceImpact`

## Testing

Verified locally that `-short` flag correctly skips the problematic test:
```bash
go test -v -short -run TestStressHighConcurrency ./tests/load/...
# Output:
# === RUN   TestStressHighConcurrency
#     security_load_test.go:967: Skipping stress test in short mode
# --- SKIP: TestStressHighConcurrency (0.00s)
# PASS
```

## Related

- Failed job: https://github.com/innovationmech/swit/actions/runs/12063838193/job/56598045030