### PR TITLE
fix(ci): pre-download go modules before swagger generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,12 @@ jobs:
       if: needs.changes.outputs.code_changed == 'true'
       run: make setup-dev
 
+    # 预下载模块依赖，确保 swag --parseDependency 能解析全部依赖
+    # 否则 swagger 文档生成会报 "cannot find all dependencies"
+    - name: Download Go module dependencies
+      if: needs.changes.outputs.code_changed == 'true'
+      run: go mod download
+
     - name: Generate proto code (dev)
       if: needs.changes.outputs.code_changed == 'true'
       run: make proto-dev

--- a/scripts/tools/swagger-manage.sh
+++ b/scripts/tools/swagger-manage.sh
@@ -143,6 +143,25 @@ format_swagger() {
     done
 }
 
+# 函数：确保模块依赖已下载
+# swag init 使用 --parseDependency 时需要全部依赖位于模块缓存中，
+# 否则会报 "cannot find all dependencies"，因此在生成前预下载依赖。
+ensure_dependencies() {
+    log_info "确保Go模块依赖已下载..."
+
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "go mod download"
+        return 0
+    fi
+
+    if go mod download; then
+        log_success "✓ Go模块依赖已就绪"
+    else
+        log_error "Go模块依赖下载失败"
+        exit 1
+    fi
+}
+
 # 函数：生成特定服务的swagger文档
 generate_service_swagger() {
     local service_name=$1
@@ -157,7 +176,10 @@ generate_service_swagger() {
         echo "swag init -g $main_file -o $output_dir --parseDependency --parseInternal --exclude $exclude_dir"
         return 0
     fi
-    
+
+    # 预下载依赖，保证 --parseDependency 能解析全部依赖
+    ensure_dependencies
+
     # 创建输出目录
     mkdir -p "$output_dir"
     


### PR DESCRIPTION
## Summary
- CI 的 `Setup & Code Quality` job 在 master 上失败（[run #1450](https://github.com/innovationmech/swit/actions/runs/23104976165)）。`make quality` → `swagger` 会执行 `swag init --parseDependency`，它要求所有模块依赖已存在于模块缓存中。
- CI setup job 此前从未运行 `go mod download`，导致 swag 在边解析边下载依赖时报错 `cannot find all dependencies` 并以 exit code 2 失败。

## Changes
- 在 `ci.yml` 的 setup job 中新增显式的 `go mod download` 步骤（与 `coverage.yml` / `quality-badges.yml` / `security-checks.yml` 中已有的模式保持一致）。
- 强化 `scripts/tools/swagger-manage.sh`：在每次 `swag init` 之前确保依赖已下载，使该故障无法再从任何调用方复现。

## Test plan
- [x] `bash -n scripts/tools/swagger-manage.sh` 语法检查通过
- [x] `bash scripts/tools/swagger-manage.sh --advanced switserve` 本地实跑成功（输出"✓ Go模块依赖已就绪" + 文档生成完成）
- [ ] CI 在本 PR 上重新运行 `Setup & Code Quality` 通过

Closes #929

Made with [Cursor](https://cursor.com)