### PR TITLE
[codex] fix JWKS auto-refresh race test

### DIFF
--- a/pkg/security/jwt/jwks_cache_test.go
+++ b/pkg/security/jwt/jwks_cache_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -201,9 +202,9 @@ func TestJWKSCache_Refresh(t *testing.T) {
 }
 
 func TestJWKSCache_AutoRefresh(t *testing.T) {
-	callCount := 0
+	var callCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		callCount.Add(1)
 		jwks := JWKSet{
 			Keys: []JWK{
 				{
@@ -232,16 +233,16 @@ func TestJWKSCache_AutoRefresh(t *testing.T) {
 	defer cache.Stop()
 
 	// Initial call count should be 1
-	if callCount != 1 {
-		t.Errorf("Expected 1 initial call, got %d", callCount)
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("Expected 1 initial call, got %d", got)
 	}
 
 	// Wait for auto-refresh to happen
 	time.Sleep(300 * time.Millisecond)
 
 	// Should have at least one more refresh
-	if callCount < 2 {
-		t.Errorf("Expected at least 2 calls after auto-refresh, got %d", callCount)
+	if got := callCount.Load(); got < 2 {
+		t.Errorf("Expected at least 2 calls after auto-refresh, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix the `TestJWKSCache_AutoRefresh` race detected by GitHub Actions coverage runs.
- Use `atomic.Int32` for the test HTTP handler request counter so `-race` can safely observe auto-refresh calls.

## Root Cause

The test server handler incremented a plain `int` while the test goroutine read it after starting the JWKS cache auto-refresh goroutine. With `go test -race`, this unsynchronized read/write was reported as a data race.

## Validation

- `go test -race -short ./pkg/security/jwt -count=1`
- `git diff --check`

A full CI-equivalent coverage command was also run before this PR flow:

- `bash -lc 'PACKAGES=$(go list ./... | grep -v -E '\''/(api/gen|docs/generated)/'\''); go test -race -short -coverprofile=/tmp/swit-coverage.out -covermode=atomic $PACKAGES'`