### PR TITLE
feat(saga): implement orchestrator coordinator lifecycle APIs

### DIFF
--- a/pkg/saga/coordinator/orchestrator.go
+++ b/pkg/saga/coordinator/orchestrator.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/innovationmech/swit/pkg/logger"
 	"github.com/innovationmech/swit/pkg/saga"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -96,6 +97,15 @@ type OrchestratorCoordinator struct {
 
 	// instances tracks active Saga instances.
 	instances sync.Map
+
+	// definitions tracks Saga definitions by Saga ID. The definition is
+	// required to drive compensation and lifecycle operations (cancel/stop)
+	// for active instances.
+	definitions sync.Map
+
+	// cancelFuncs tracks per-Saga execution cancellation functions, enabling
+	// graceful interruption of in-flight step execution.
+	cancelFuncs sync.Map
 
 	// metrics holds aggregated coordinator metrics.
 	metrics *saga.CoordinatorMetrics
@@ -438,29 +448,45 @@ func (oc *OrchestratorCoordinator) StartSaga(
 		_ = saga.NewEventPublishError(saga.EventSagaStarted, err)
 	}
 
+	// Track the definition and a cancellable execution context so that the
+	// lifecycle APIs (CancelSaga / StopSaga) can interrupt in-flight execution
+	// and trigger compensation when required.
+	oc.definitions.Store(sagaID, definition)
+	execCtx, execCancel := context.WithCancel(context.Background())
+	oc.cancelFuncs.Store(sagaID, execCancel)
+
 	// Acquire concurrency slot before starting execution
 	if err := oc.concurrencyController.AcquireSlot(ctx, sagaID); err != nil {
-		// Failed to acquire slot, mark as failed and clean up
+		// Failed to acquire slot, clean up tracking state and persist instance
+		oc.releaseExecution(sagaID)
 		_ = oc.stateStorage.SaveSaga(ctx, instance)
 		return nil, fmt.Errorf("failed to acquire concurrency slot: %w", err)
 	}
 
 	// Start asynchronous step execution using worker pool
-	execTask := func(execCtx context.Context) error {
+	execTask := func(taskCtx context.Context) error {
 		defer oc.concurrencyController.ReleaseSlot(sagaID)
 
 		// Execute steps
 		executor := newStepExecutor(oc, instance, definition)
-		return executor.executeSteps(execCtx)
+		return executor.executeSteps(taskCtx)
 	}
 
-	// Submit task to worker pool
-	if err := oc.concurrencyController.SubmitTask(context.Background(), execTask); err != nil {
+	// Submit task to worker pool using the cancellable execution context.
+	submitErr := oc.concurrencyController.SubmitTask(execCtx, execTask)
+
+	// SubmitTask blocks until the worker reports completion, so the per-Saga
+	// execution tracking can be released now. Releasing here (rather than in a
+	// deferred cleanup inside the task) avoids cancelling the execution context
+	// before the worker has reported its result.
+	oc.releaseExecution(sagaID)
+
+	if submitErr != nil {
 		// Failed to submit task, release slot and return error
 		oc.concurrencyController.ReleaseSlot(sagaID)
-		span.SetStatus(2, fmt.Sprintf("failed to submit task: %v", err))
-		span.RecordError(err)
-		return nil, fmt.Errorf("failed to submit execution task: %w", err)
+		span.SetStatus(2, fmt.Sprintf("failed to submit task: %v", submitErr))
+		span.RecordError(submitErr)
+		return nil, fmt.Errorf("failed to submit execution task: %w", submitErr)
 	}
 
 	// Mark span as successful
@@ -571,20 +597,28 @@ func copyMetadata(metadata map[string]interface{}) map[string]interface{} {
 //   - An error if the instance does not exist or the coordinator is closed.
 func (oc *OrchestratorCoordinator) GetSagaInstance(sagaID string) (saga.SagaInstance, error) {
 	oc.mu.RLock()
-	defer oc.mu.RUnlock()
+	closed := oc.closed
+	oc.mu.RUnlock()
 
-	if oc.closed {
+	if closed {
 		return nil, ErrCoordinatorClosed
 	}
 
-	// Check in-memory cache first
+	// Check in-memory cache first for the live runtime instance.
 	if instance, ok := oc.instances.Load(sagaID); ok {
 		return instance.(saga.SagaInstance), nil
 	}
 
-	// Query from state storage
-	// TODO: Implementation will be completed in future issues
-	return nil, saga.NewSagaNotFoundError(sagaID)
+	// Fall back to the configured state storage. This allows querying Sagas
+	// that are no longer cached in memory (for example after a restart).
+	instance, err := oc.stateStorage.GetSaga(context.Background(), sagaID)
+	if err != nil {
+		return nil, err
+	}
+	if instance == nil {
+		return nil, saga.NewSagaNotFoundError(sagaID)
+	}
+	return instance, nil
 }
 
 // CancelSaga cancels a running Saga instance with the specified reason.
@@ -605,8 +639,89 @@ func (oc *OrchestratorCoordinator) CancelSaga(ctx context.Context, sagaID string
 	}
 	oc.mu.RUnlock()
 
-	// TODO: Implementation will be completed in future issues
-	return errors.New("not yet implemented: cancellation logic pending")
+	ctx, span := oc.tracingManager.StartSpan(ctx, "saga.cancel")
+	defer span.End()
+	span.SetAttribute("saga.id", sagaID)
+
+	// Resolve the instance. In-memory instances are preferred because they
+	// carry the live runtime state required to drive compensation.
+	instance, inMemory := oc.loadInstance(ctx, sagaID)
+	if instance == nil {
+		err := saga.NewSagaNotFoundError(sagaID)
+		span.RecordError(err)
+		span.SetStatus(2, "saga not found")
+		return err
+	}
+
+	if instance.GetState().IsTerminal() {
+		err := saga.NewInvalidSagaStateError(instance.GetState(), saga.StateCancelled)
+		span.RecordError(err)
+		span.SetStatus(2, "saga already terminal")
+		return err
+	}
+
+	startTime := instance.GetStartTime()
+
+	// Signal any in-flight execution to stop before compensation begins.
+	oc.cancelExecution(sagaID)
+
+	// Trigger compensation for completed steps when the live instance and its
+	// definition are available.
+	if inMemory {
+		if orchInstance, ok := instance.(*OrchestratorSagaInstance); ok {
+			oc.compensateForCancellation(ctx, orchInstance)
+		}
+	}
+
+	// Transition to the Cancelled terminal state and persist it.
+	if orchInstance, ok := instance.(*OrchestratorSagaInstance); ok {
+		now := time.Now()
+		orchInstance.mu.Lock()
+		orchInstance.state = saga.StateCancelled
+		orchInstance.completedAt = &now
+		orchInstance.updatedAt = now
+		if orchInstance.sagaError == nil {
+			orchInstance.sagaError = saga.NewSagaError(
+				saga.ErrCodeInvalidSagaState, reason, saga.ErrorTypeBusiness, false)
+		}
+		orchInstance.mu.Unlock()
+
+		if err := oc.stateStorage.SaveSaga(ctx, orchInstance); err != nil {
+			span.RecordError(err)
+			span.SetStatus(2, "failed to persist cancelled state")
+			return saga.NewStorageError("SaveSaga", err)
+		}
+	} else {
+		// Storage-only instance: update the persisted state directly.
+		metadata := map[string]interface{}{"cancellation_reason": reason}
+		if err := oc.stateStorage.UpdateSagaState(ctx, sagaID, saga.StateCancelled, metadata); err != nil {
+			span.RecordError(err)
+			span.SetStatus(2, "failed to persist cancelled state")
+			return saga.NewStorageError("UpdateSagaState", err)
+		}
+	}
+
+	// Publish the cancellation event for observability.
+	oc.publishCancellationEvent(ctx, instance, reason, time.Since(startTime))
+
+	// Update aggregate metrics.
+	oc.mu.Lock()
+	oc.metrics.CancelledSagas++
+	if oc.metrics.ActiveSagas > 0 {
+		oc.metrics.ActiveSagas--
+	}
+	oc.metrics.LastUpdateTime = time.Now()
+	oc.mu.Unlock()
+
+	oc.metricsCollector.RecordSagaCancelled(instance.GetDefinitionID(), time.Since(startTime))
+
+	// Clean up tracking state.
+	oc.instances.Delete(sagaID)
+	oc.releaseExecution(sagaID)
+
+	span.SetStatus(1, "saga cancelled")
+	span.AddEvent("saga_cancelled")
+	return nil
 }
 
 // GetActiveSagas retrieves all currently active Saga instances based on the filter.
@@ -620,14 +735,43 @@ func (oc *OrchestratorCoordinator) CancelSaga(ctx context.Context, sagaID string
 //   - An error if the query fails or the coordinator is closed.
 func (oc *OrchestratorCoordinator) GetActiveSagas(filter *saga.SagaFilter) ([]saga.SagaInstance, error) {
 	oc.mu.RLock()
-	defer oc.mu.RUnlock()
+	closed := oc.closed
+	oc.mu.RUnlock()
 
-	if oc.closed {
+	if closed {
 		return nil, ErrCoordinatorClosed
 	}
 
-	// TODO: Implementation will query from state storage with filter
-	return []saga.SagaInstance{}, nil
+	// Constrain the query to active states. If the caller supplied explicit
+	// states we respect them, otherwise default to the set of states that are
+	// considered active (Running, StepCompleted, Compensating).
+	effectiveFilter := buildActiveSagaFilter(filter)
+
+	instances, err := oc.stateStorage.GetActiveSagas(context.Background(), effectiveFilter)
+	if err != nil {
+		return nil, saga.NewStorageError("GetActiveSagas", err)
+	}
+	return instances, nil
+}
+
+// buildActiveSagaFilter returns a filter constrained to active Saga states.
+// It never mutates the caller-supplied filter.
+func buildActiveSagaFilter(filter *saga.SagaFilter) *saga.SagaFilter {
+	activeStates := []saga.SagaState{
+		saga.StateRunning,
+		saga.StateStepCompleted,
+		saga.StateCompensating,
+	}
+
+	if filter == nil {
+		return &saga.SagaFilter{States: activeStates}
+	}
+
+	copied := *filter
+	if len(copied.States) == 0 {
+		copied.States = activeStates
+	}
+	return &copied
 }
 
 // GetMetrics returns runtime metrics about the coordinator's performance.
@@ -657,14 +801,58 @@ func (oc *OrchestratorCoordinator) GetMetrics() *saga.CoordinatorMetrics {
 //   - An error describing which component is unhealthy.
 func (oc *OrchestratorCoordinator) HealthCheck(ctx context.Context) error {
 	oc.mu.RLock()
-	defer oc.mu.RUnlock()
+	closed := oc.closed
+	stateStorage := oc.stateStorage
+	eventPublisher := oc.eventPublisher
+	oc.mu.RUnlock()
 
-	if oc.closed {
+	if closed {
 		return ErrCoordinatorClosed
 	}
 
-	// TODO: Implement actual health checks for dependencies
-	// For now, just verify the coordinator is not closed
+	// Respect caller cancellation or deadline.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Probe the state storage dependency.
+	if stateStorage == nil {
+		return ErrStateStorageNotConfigured
+	}
+	if err := probeHealth(ctx, stateStorage, func() error {
+		_, err := stateStorage.GetActiveSagas(ctx, &saga.SagaFilter{Limit: 1})
+		return err
+	}); err != nil {
+		return fmt.Errorf("state storage unhealthy: %w", err)
+	}
+
+	// Probe the event publisher dependency.
+	if eventPublisher == nil {
+		return ErrEventPublisherNotConfigured
+	}
+	if err := probeHealth(ctx, eventPublisher, nil); err != nil {
+		return fmt.Errorf("event publisher unhealthy: %w", err)
+	}
+
+	return nil
+}
+
+// healthCheckable is implemented by dependencies that expose an explicit
+// health probe (such as the Redis and Postgres state storage backends).
+type healthCheckable interface {
+	HealthCheck(ctx context.Context) error
+}
+
+// probeHealth checks the health of a dependency. It prefers an explicit
+// HealthCheck method when the dependency implements healthCheckable, otherwise
+// it falls back to the provided lightweight probe (if any).
+func probeHealth(ctx context.Context, dependency interface{}, fallback func() error) error {
+	if hc, ok := dependency.(healthCheckable); ok {
+		return hc.HealthCheck(ctx)
+	}
+	if fallback != nil {
+		return fallback()
+	}
 	return nil
 }
 
@@ -725,8 +913,167 @@ func (oc *OrchestratorCoordinator) StopSaga(ctx context.Context, sagaID string) 
 	}
 	oc.mu.RUnlock()
 
-	// TODO: Implementation will be completed in future issues
-	return errors.New("not yet implemented: stop logic pending")
+	ctx, span := oc.tracingManager.StartSpan(ctx, "saga.stop")
+	defer span.End()
+	span.SetAttribute("saga.id", sagaID)
+
+	instance, _ := oc.loadInstance(ctx, sagaID)
+	if instance == nil {
+		err := saga.NewSagaNotFoundError(sagaID)
+		span.RecordError(err)
+		span.SetStatus(2, "saga not found")
+		return err
+	}
+
+	if instance.GetState().IsTerminal() {
+		err := saga.NewInvalidSagaStateError(instance.GetState(), saga.StateCancelled)
+		span.RecordError(err)
+		span.SetStatus(2, "saga already terminal")
+		return err
+	}
+
+	// Signal in-flight execution to stop gracefully. The currently executing
+	// step is allowed to finish; no new steps will be started once the
+	// execution context is cancelled.
+	oc.cancelExecution(sagaID)
+
+	// Persist the current state so the Saga can be inspected or recovered
+	// after the stop request.
+	if orchInstance, ok := instance.(*OrchestratorSagaInstance); ok {
+		orchInstance.mu.Lock()
+		orchInstance.updatedAt = time.Now()
+		orchInstance.mu.Unlock()
+
+		if err := oc.stateStorage.SaveSaga(ctx, orchInstance); err != nil {
+			span.RecordError(err)
+			span.SetStatus(2, "failed to persist current state")
+			return saga.NewStorageError("SaveSaga", err)
+		}
+	} else {
+		if err := oc.stateStorage.UpdateSagaState(ctx, sagaID, instance.GetState(), nil); err != nil {
+			span.RecordError(err)
+			span.SetStatus(2, "failed to persist current state")
+			return saga.NewStorageError("UpdateSagaState", err)
+		}
+	}
+
+	span.SetStatus(1, "saga stopped")
+	span.AddEvent("saga_stopped")
+	return nil
+}
+
+// loadInstance resolves a Saga instance by ID. It prefers the in-memory cache
+// (which holds the live runtime instance) and falls back to the configured
+// state storage. The boolean return value reports whether the instance was
+// resolved from the in-memory cache.
+func (oc *OrchestratorCoordinator) loadInstance(ctx context.Context, sagaID string) (saga.SagaInstance, bool) {
+	if v, ok := oc.instances.Load(sagaID); ok {
+		return v.(saga.SagaInstance), true
+	}
+
+	instance, err := oc.stateStorage.GetSaga(ctx, sagaID)
+	if err != nil || instance == nil {
+		return nil, false
+	}
+	return instance, false
+}
+
+// cancelExecution signals any in-flight execution for the given Saga to stop
+// by cancelling its execution context. It is a no-op if no execution is
+// currently tracked.
+func (oc *OrchestratorCoordinator) cancelExecution(sagaID string) {
+	if cancel, ok := oc.cancelFuncs.Load(sagaID); ok {
+		cancel.(context.CancelFunc)()
+	}
+}
+
+// releaseExecution releases the per-Saga execution tracking state. It cancels
+// and removes the execution context and removes the cached definition.
+func (oc *OrchestratorCoordinator) releaseExecution(sagaID string) {
+	if cancel, ok := oc.cancelFuncs.LoadAndDelete(sagaID); ok {
+		cancel.(context.CancelFunc)()
+	}
+	oc.definitions.Delete(sagaID)
+}
+
+// compensateForCancellation drives compensation for the steps that have
+// already completed when a Saga is cancelled. It reuses the per-step
+// compensation logic from the compensation executor without performing the
+// terminal state transition, which the caller controls.
+func (oc *OrchestratorCoordinator) compensateForCancellation(ctx context.Context, instance *OrchestratorSagaInstance) {
+	definitionValue, ok := oc.definitions.Load(instance.id)
+	if !ok {
+		return
+	}
+	definition, ok := definitionValue.(saga.SagaDefinition)
+	if !ok {
+		return
+	}
+
+	completedCount := instance.GetCompletedSteps()
+	if completedCount <= 0 {
+		return
+	}
+
+	steps := definition.GetSteps()
+	if completedCount > len(steps) {
+		completedCount = len(steps)
+	}
+	completedSteps := steps[:completedCount]
+
+	strategy := definition.GetCompensationStrategy()
+	if strategy == nil {
+		strategy = saga.NewSequentialCompensationStrategy(30 * time.Second)
+	}
+
+	// Mark the instance as compensating for observability.
+	instance.mu.Lock()
+	instance.state = saga.StateCompensating
+	instance.updatedAt = time.Now()
+	instance.mu.Unlock()
+
+	ce := newCompensationExecutor(oc, instance, definition)
+	ce.publishCompensationStartedEvent(ctx, len(completedSteps))
+
+	for compIndex, step := range strategy.GetCompensationOrder(completedSteps) {
+		originalIndex := ce.findOriginalStepIndex(step, completedSteps)
+		if originalIndex < 0 {
+			continue
+		}
+		if err := ce.compensateStep(ctx, step, originalIndex, compIndex); err != nil {
+			logger.GetSugaredLogger().Warnf(
+				"Cancellation compensation failed for step %d of Saga %s: %v",
+				originalIndex, instance.id, err)
+		}
+	}
+}
+
+// publishCancellationEvent publishes a Saga cancelled event for observability.
+func (oc *OrchestratorCoordinator) publishCancellationEvent(
+	ctx context.Context,
+	instance saga.SagaInstance,
+	reason string,
+	duration time.Duration,
+) {
+	event := &saga.SagaEvent{
+		ID:        generateEventID(),
+		SagaID:    instance.GetID(),
+		Type:      saga.EventSagaCancelled,
+		Version:   "1.0",
+		Timestamp: time.Now(),
+		Data: map[string]interface{}{
+			"reason": reason,
+		},
+		NewState: saga.StateCancelled,
+		Duration: duration,
+		TraceID:  instance.GetTraceID(),
+		Source:   "OrchestratorCoordinator",
+		Metadata: instance.GetMetadata(),
+	}
+
+	if err := oc.eventPublisher.PublishEvent(ctx, event); err != nil {
+		logger.GetSugaredLogger().Warnf("Failed to publish saga cancelled event: %v", err)
+	}
 }
 
 // OrchestratorSagaInstance is the concrete implementation of saga.SagaInstance for orchestrator-based Sagas.

--- a/pkg/saga/coordinator/orchestrator_test.go
+++ b/pkg/saga/coordinator/orchestrator_test.go
@@ -24,10 +24,14 @@ package coordinator
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/innovationmech/swit/pkg/saga"
+	"github.com/innovationmech/swit/pkg/saga/state/storage"
 )
 
 // mockStateStorage is a mock implementation of saga.StateStorage for testing.
@@ -41,17 +45,38 @@ type mockStateStorage struct {
 	saveStepStateErr       error
 	getStepStatesErr       error
 	cleanupExpiredSagasErr error
+
+	// sagas allows GetSaga to return a configured instance by ID.
+	sagas map[string]saga.SagaInstance
+
+	// activeSagas allows GetActiveSagas to return a configured slice.
+	activeSagas []saga.SagaInstance
+
+	// saveSagaCount tracks the number of SaveSaga invocations.
+	saveSagaCount int
+	// lastUpdatedState records the most recent state passed to UpdateSagaState.
+	lastUpdatedState saga.SagaState
 }
 
 func (m *mockStateStorage) SaveSaga(ctx context.Context, saga saga.SagaInstance) error {
+	m.saveSagaCount++
 	return m.saveSagaErr
 }
 
 func (m *mockStateStorage) GetSaga(ctx context.Context, sagaID string) (saga.SagaInstance, error) {
-	return nil, m.getSagaErr
+	if m.getSagaErr != nil {
+		return nil, m.getSagaErr
+	}
+	if m.sagas != nil {
+		if instance, ok := m.sagas[sagaID]; ok {
+			return instance, nil
+		}
+	}
+	return nil, nil
 }
 
 func (m *mockStateStorage) UpdateSagaState(ctx context.Context, sagaID string, state saga.SagaState, metadata map[string]interface{}) error {
+	m.lastUpdatedState = state
 	return m.updateSagaStateErr
 }
 
@@ -62,6 +87,9 @@ func (m *mockStateStorage) DeleteSaga(ctx context.Context, sagaID string) error 
 func (m *mockStateStorage) GetActiveSagas(ctx context.Context, filter *saga.SagaFilter) ([]saga.SagaInstance, error) {
 	if m.getActiveSagasErr != nil {
 		return nil, m.getActiveSagasErr
+	}
+	if m.activeSagas != nil {
+		return m.activeSagas, nil
 	}
 	return []saga.SagaInstance{}, nil
 }
@@ -734,13 +762,65 @@ func TestCopyMetadata(t *testing.T) {
 	}
 }
 
+// fakeSagaInstance is a minimal saga.SagaInstance implementation that is NOT
+// an *OrchestratorSagaInstance. It is used to exercise the storage-only
+// lifecycle code paths (where the live runtime instance is unavailable).
+type fakeSagaInstance struct {
+	id           string
+	definitionID string
+	state        saga.SagaState
+	startTime    time.Time
+}
+
+func (f *fakeSagaInstance) GetID() string                       { return f.id }
+func (f *fakeSagaInstance) GetDefinitionID() string             { return f.definitionID }
+func (f *fakeSagaInstance) GetState() saga.SagaState            { return f.state }
+func (f *fakeSagaInstance) GetCurrentStep() int                 { return 0 }
+func (f *fakeSagaInstance) GetStartTime() time.Time             { return f.startTime }
+func (f *fakeSagaInstance) GetEndTime() time.Time               { return time.Time{} }
+func (f *fakeSagaInstance) GetResult() interface{}              { return nil }
+func (f *fakeSagaInstance) GetError() *saga.SagaError           { return nil }
+func (f *fakeSagaInstance) GetTotalSteps() int                  { return 0 }
+func (f *fakeSagaInstance) GetCompletedSteps() int              { return 0 }
+func (f *fakeSagaInstance) GetCreatedAt() time.Time             { return f.startTime }
+func (f *fakeSagaInstance) GetUpdatedAt() time.Time             { return f.startTime }
+func (f *fakeSagaInstance) GetTimeout() time.Duration           { return 0 }
+func (f *fakeSagaInstance) GetMetadata() map[string]interface{} { return nil }
+func (f *fakeSagaInstance) GetTraceID() string                  { return "" }
+func (f *fakeSagaInstance) IsTerminal() bool                    { return f.state.IsTerminal() }
+func (f *fakeSagaInstance) IsActive() bool                      { return f.state.IsActive() }
+
+// newRunningInstance creates an in-memory OrchestratorSagaInstance in the
+// running state with the supplied number of completed steps, useful for
+// exercising the lifecycle APIs deterministically.
+func newRunningInstance(id string, totalSteps, completedSteps int) *OrchestratorSagaInstance {
+	now := time.Now()
+	started := now.Add(-time.Minute)
+	return &OrchestratorSagaInstance{
+		id:             id,
+		definitionID:   "test-def",
+		name:           "Test Saga",
+		state:          saga.StateRunning,
+		currentStep:    completedSteps,
+		completedSteps: completedSteps,
+		totalSteps:     totalSteps,
+		createdAt:      started,
+		updatedAt:      now,
+		startedAt:      &started,
+		metadata:       map[string]interface{}{"env": "test"},
+	}
+}
+
 func TestOrchestratorCoordinatorGetSagaInstance(t *testing.T) {
+	cachedInstance := newRunningInstance("cached-saga", 2, 1)
+	storedInstance := newRunningInstance("stored-saga", 3, 2)
+
 	tests := []struct {
-		name        string
-		setupCoord  func() *OrchestratorCoordinator
-		sagaID      string
-		wantErr     bool
-		expectedErr error
+		name       string
+		setupCoord func() *OrchestratorCoordinator
+		sagaID     string
+		wantErr    bool
+		wantID     string
 	}{
 		{
 			name: "closed coordinator",
@@ -750,9 +830,8 @@ func TestOrchestratorCoordinatorGetSagaInstance(t *testing.T) {
 				coord.closed = true
 				return coord
 			},
-			sagaID:      "test-saga-id",
-			wantErr:     true,
-			expectedErr: ErrCoordinatorClosed,
+			sagaID:  "test-saga-id",
+			wantErr: true,
 		},
 		{
 			name: "saga not found",
@@ -764,13 +843,54 @@ func TestOrchestratorCoordinatorGetSagaInstance(t *testing.T) {
 			sagaID:  "non-existent-saga",
 			wantErr: true,
 		},
+		{
+			name: "found in memory cache",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				coord, _ := NewOrchestratorCoordinator(config)
+				coord.instances.Store(cachedInstance.id, cachedInstance)
+				return coord
+			},
+			sagaID:  "cached-saga",
+			wantErr: false,
+			wantID:  "cached-saga",
+		},
+		{
+			name: "found in storage fallback",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				config.StateStorage = &mockStateStorage{
+					sagas: map[string]saga.SagaInstance{
+						storedInstance.id: storedInstance,
+					},
+				}
+				coord, _ := NewOrchestratorCoordinator(config)
+				return coord
+			},
+			sagaID:  "stored-saga",
+			wantErr: false,
+			wantID:  "stored-saga",
+		},
+		{
+			name: "storage error",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				config.StateStorage = &mockStateStorage{
+					getSagaErr: errors.New("storage failure"),
+				}
+				coord, _ := NewOrchestratorCoordinator(config)
+				return coord
+			},
+			sagaID:  "any-saga",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			coord := tt.setupCoord()
 
-			_, err := coord.GetSagaInstance(tt.sagaID)
+			instance, err := coord.GetSagaInstance(tt.sagaID)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("GetSagaInstance() expected error but got nil")
@@ -780,64 +900,173 @@ func TestOrchestratorCoordinatorGetSagaInstance(t *testing.T) {
 
 			if err != nil {
 				t.Errorf("GetSagaInstance() unexpected error = %v", err)
+				return
+			}
+			if instance == nil {
+				t.Fatal("GetSagaInstance() returned nil instance")
+			}
+			if instance.GetID() != tt.wantID {
+				t.Errorf("GetSagaInstance() ID = %s, expected %s", instance.GetID(), tt.wantID)
 			}
 		})
 	}
 }
 
 func TestOrchestratorCoordinatorCancelSaga(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupCoord  func() *OrchestratorCoordinator
-		sagaID      string
-		reason      string
-		wantErr     bool
-		expectedErr error
-	}{
-		{
-			name: "closed coordinator",
-			setupCoord: func() *OrchestratorCoordinator {
-				config := newTestConfig()
-				coord, _ := NewOrchestratorCoordinator(config)
-				coord.closed = true
-				return coord
+	t.Run("closed coordinator", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		coord.closed = true
+		if err := coord.CancelSaga(context.Background(), "id", "reason"); err == nil {
+			t.Error("CancelSaga() expected error for closed coordinator")
+		}
+	})
+
+	t.Run("saga not found", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		if err := coord.CancelSaga(context.Background(), "missing", "reason"); err == nil {
+			t.Error("CancelSaga() expected error for missing saga")
+		}
+	})
+
+	t.Run("terminal saga rejected", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		instance := newRunningInstance("done-saga", 1, 1)
+		instance.state = saga.StateCompleted
+		coord.instances.Store(instance.id, instance)
+		if err := coord.CancelSaga(context.Background(), instance.id, "reason"); err == nil {
+			t.Error("CancelSaga() expected error for terminal saga")
+		}
+	})
+
+	t.Run("successful cancel triggers compensation", func(t *testing.T) {
+		metrics := &mockMetricsCollector{}
+		config := newTestConfig()
+		config.MetricsCollector = metrics
+		coord, _ := NewOrchestratorCoordinator(config)
+
+		var compensated1, compensated2 int32
+		step1 := &mockSagaStep{
+			id:   "step-1",
+			name: "Step 1",
+			compensate: func(ctx context.Context, data interface{}) error {
+				atomic.AddInt32(&compensated1, 1)
+				return nil
 			},
-			sagaID:      "test-saga-id",
-			reason:      "test cancellation",
-			wantErr:     true,
-			expectedErr: ErrCoordinatorClosed,
-		},
-		{
-			name: "not implemented yet",
-			setupCoord: func() *OrchestratorCoordinator {
-				config := newTestConfig()
-				coord, _ := NewOrchestratorCoordinator(config)
-				return coord
+		}
+		step2 := &mockSagaStep{
+			id:   "step-2",
+			name: "Step 2",
+			compensate: func(ctx context.Context, data interface{}) error {
+				atomic.AddInt32(&compensated2, 1)
+				return nil
 			},
-			sagaID:  "test-saga-id",
-			reason:  "test cancellation",
-			wantErr: true,
-		},
-	}
+		}
+		definition := &mockSagaDefinition{
+			id:    "test-def",
+			name:  "Test Saga",
+			steps: []saga.SagaStep{step1, step2},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			coord := tt.setupCoord()
-			ctx := context.Background()
+		instance := newRunningInstance("active-saga", 2, 2)
+		coord.instances.Store(instance.id, instance)
+		coord.definitions.Store(instance.id, definition)
+		coord.mu.Lock()
+		coord.metrics.ActiveSagas = 1
+		coord.mu.Unlock()
 
-			err := coord.CancelSaga(ctx, tt.sagaID, tt.reason)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("CancelSaga() expected error but got nil")
-				}
-				return
-			}
+		err := coord.CancelSaga(context.Background(), instance.id, "user requested")
+		if err != nil {
+			t.Fatalf("CancelSaga() unexpected error = %v", err)
+		}
 
-			if err != nil {
-				t.Errorf("CancelSaga() unexpected error = %v", err)
-			}
-		})
-	}
+		if instance.GetState() != saga.StateCancelled {
+			t.Errorf("instance state = %v, expected Cancelled", instance.GetState())
+		}
+		if atomic.LoadInt32(&compensated1) != 1 {
+			t.Errorf("step1 compensation called %d times, expected 1", compensated1)
+		}
+		if atomic.LoadInt32(&compensated2) != 1 {
+			t.Errorf("step2 compensation called %d times, expected 1", compensated2)
+		}
+		if metrics.sagaCancelledCount != 1 {
+			t.Errorf("RecordSagaCancelled called %d times, expected 1", metrics.sagaCancelledCount)
+		}
+
+		m := coord.GetMetrics()
+		if m.CancelledSagas != 1 {
+			t.Errorf("CancelledSagas = %d, expected 1", m.CancelledSagas)
+		}
+		if m.ActiveSagas != 0 {
+			t.Errorf("ActiveSagas = %d, expected 0", m.ActiveSagas)
+		}
+
+		// The instance should be removed from the active cache after cancel.
+		if _, ok := coord.instances.Load(instance.id); ok {
+			t.Error("instance should be removed from cache after cancellation")
+		}
+	})
+
+	t.Run("cancel without completed steps skips compensation", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		step := &mockSagaStep{
+			id:   "step-1",
+			name: "Step 1",
+			compensate: func(ctx context.Context, data interface{}) error {
+				t.Error("compensation should not be called when no steps completed")
+				return nil
+			},
+		}
+		definition := &mockSagaDefinition{
+			id:    "test-def",
+			steps: []saga.SagaStep{step},
+		}
+		instance := newRunningInstance("pending-saga", 1, 0)
+		instance.state = saga.StatePending
+		coord.instances.Store(instance.id, instance)
+		coord.definitions.Store(instance.id, definition)
+
+		if err := coord.CancelSaga(context.Background(), instance.id, "reason"); err != nil {
+			t.Fatalf("CancelSaga() unexpected error = %v", err)
+		}
+		if instance.GetState() != saga.StateCancelled {
+			t.Errorf("instance state = %v, expected Cancelled", instance.GetState())
+		}
+	})
+
+	t.Run("storage failure on persist", func(t *testing.T) {
+		config := newTestConfig()
+		config.StateStorage = &mockStateStorage{saveSagaErr: errors.New("save failed")}
+		coord, _ := NewOrchestratorCoordinator(config)
+		instance := newRunningInstance("active-saga", 1, 0)
+		coord.instances.Store(instance.id, instance)
+
+		if err := coord.CancelSaga(context.Background(), instance.id, "reason"); err == nil {
+			t.Error("CancelSaga() expected storage error")
+		}
+	})
+
+	t.Run("storage-only instance updates state", func(t *testing.T) {
+		storage := &mockStateStorage{
+			sagas: map[string]saga.SagaInstance{
+				"stored-saga": &fakeSagaInstance{
+					id:           "stored-saga",
+					definitionID: "test-def",
+					state:        saga.StateRunning,
+					startTime:    time.Now().Add(-time.Minute),
+				},
+			},
+		}
+		config := newTestConfig()
+		config.StateStorage = storage
+		coord, _ := NewOrchestratorCoordinator(config)
+
+		if err := coord.CancelSaga(context.Background(), "stored-saga", "reason"); err != nil {
+			t.Fatalf("CancelSaga() unexpected error = %v", err)
+		}
+		if storage.lastUpdatedState != saga.StateCancelled {
+			t.Errorf("UpdateSagaState state = %v, expected Cancelled", storage.lastUpdatedState)
+		}
+	})
 }
 
 func TestOrchestratorCoordinatorGetActiveSagas(t *testing.T) {
@@ -870,6 +1099,36 @@ func TestOrchestratorCoordinatorGetActiveSagas(t *testing.T) {
 			wantErr: false,
 			wantLen: 0,
 		},
+		{
+			name: "returns active sagas from storage",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				config.StateStorage = &mockStateStorage{
+					activeSagas: []saga.SagaInstance{
+						newRunningInstance("saga-1", 2, 1),
+						newRunningInstance("saga-2", 3, 0),
+					},
+				}
+				coord, _ := NewOrchestratorCoordinator(config)
+				return coord
+			},
+			filter:  nil,
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "storage error is wrapped",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				config.StateStorage = &mockStateStorage{
+					getActiveSagasErr: errors.New("query failed"),
+				}
+				coord, _ := NewOrchestratorCoordinator(config)
+				return coord
+			},
+			filter:  nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -894,6 +1153,34 @@ func TestOrchestratorCoordinatorGetActiveSagas(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildActiveSagaFilter(t *testing.T) {
+	t.Run("nil filter defaults to active states", func(t *testing.T) {
+		f := buildActiveSagaFilter(nil)
+		if len(f.States) != 3 {
+			t.Fatalf("expected 3 default active states, got %d", len(f.States))
+		}
+	})
+
+	t.Run("explicit states are preserved and original not mutated", func(t *testing.T) {
+		original := &saga.SagaFilter{States: []saga.SagaState{saga.StateCompleted}}
+		f := buildActiveSagaFilter(original)
+		if len(f.States) != 1 || f.States[0] != saga.StateCompleted {
+			t.Errorf("explicit states should be preserved, got %v", f.States)
+		}
+	})
+
+	t.Run("empty states are populated with defaults without mutating caller", func(t *testing.T) {
+		original := &saga.SagaFilter{Limit: 5}
+		f := buildActiveSagaFilter(original)
+		if len(f.States) != 3 {
+			t.Errorf("expected default active states, got %v", f.States)
+		}
+		if len(original.States) != 0 {
+			t.Error("buildActiveSagaFilter must not mutate the caller filter")
+		}
+	})
 }
 
 func TestOrchestratorCoordinatorGetMetrics(t *testing.T) {
@@ -956,6 +1243,18 @@ func TestOrchestratorCoordinatorHealthCheck(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "state storage probe failure",
+			setupCoord: func() *OrchestratorCoordinator {
+				config := newTestConfig()
+				config.StateStorage = &mockStateStorage{
+					getActiveSagasErr: errors.New("storage down"),
+				}
+				coord, _ := NewOrchestratorCoordinator(config)
+				return coord
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -975,6 +1274,49 @@ func TestOrchestratorCoordinatorHealthCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOrchestratorCoordinatorHealthCheckExplicitProbe(t *testing.T) {
+	t.Run("healthy explicit probe", func(t *testing.T) {
+		config := newTestConfig()
+		config.StateStorage = &healthCheckStateStorage{mockStateStorage: &mockStateStorage{}}
+		coord, _ := NewOrchestratorCoordinator(config)
+		if err := coord.HealthCheck(context.Background()); err != nil {
+			t.Errorf("HealthCheck() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("unhealthy explicit probe", func(t *testing.T) {
+		config := newTestConfig()
+		config.StateStorage = &healthCheckStateStorage{
+			mockStateStorage: &mockStateStorage{},
+			healthErr:        errors.New("ping failed"),
+		}
+		coord, _ := NewOrchestratorCoordinator(config)
+		if err := coord.HealthCheck(context.Background()); err == nil {
+			t.Error("HealthCheck() expected error from explicit probe")
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := coord.HealthCheck(ctx); err == nil {
+			t.Error("HealthCheck() expected error for cancelled context")
+		}
+	})
+}
+
+// healthCheckStateStorage wraps mockStateStorage and adds an explicit
+// HealthCheck method, exercising the healthCheckable code path.
+type healthCheckStateStorage struct {
+	*mockStateStorage
+	healthErr error
+}
+
+func (h *healthCheckStateStorage) HealthCheck(ctx context.Context) error {
+	return h.healthErr
 }
 
 func TestOrchestratorCoordinatorClose(t *testing.T) {
@@ -1026,51 +1368,123 @@ func TestOrchestratorCoordinatorClose(t *testing.T) {
 }
 
 func TestOrchestratorCoordinatorStopSaga(t *testing.T) {
-	tests := []struct {
-		name       string
-		setupCoord func() *OrchestratorCoordinator
-		sagaID     string
-		wantErr    bool
-	}{
-		{
-			name: "closed coordinator",
-			setupCoord: func() *OrchestratorCoordinator {
-				config := newTestConfig()
-				coord, _ := NewOrchestratorCoordinator(config)
-				coord.closed = true
-				return coord
-			},
-			sagaID:  "test-saga-id",
-			wantErr: true,
-		},
-		{
-			name: "not implemented yet",
-			setupCoord: func() *OrchestratorCoordinator {
-				config := newTestConfig()
-				coord, _ := NewOrchestratorCoordinator(config)
-				return coord
-			},
-			sagaID:  "test-saga-id",
-			wantErr: true,
-		},
+	t.Run("closed coordinator", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		coord.closed = true
+		if err := coord.StopSaga(context.Background(), "id"); err == nil {
+			t.Error("StopSaga() expected error for closed coordinator")
+		}
+	})
+
+	t.Run("saga not found", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		if err := coord.StopSaga(context.Background(), "missing"); err == nil {
+			t.Error("StopSaga() expected error for missing saga")
+		}
+	})
+
+	t.Run("terminal saga rejected", func(t *testing.T) {
+		coord, _ := NewOrchestratorCoordinator(newTestConfig())
+		instance := newRunningInstance("done-saga", 1, 1)
+		instance.state = saga.StateCompleted
+		coord.instances.Store(instance.id, instance)
+		if err := coord.StopSaga(context.Background(), instance.id); err == nil {
+			t.Error("StopSaga() expected error for terminal saga")
+		}
+	})
+
+	t.Run("successful stop persists state and cancels execution", func(t *testing.T) {
+		storage := &mockStateStorage{}
+		config := newTestConfig()
+		config.StateStorage = storage
+		coord, _ := NewOrchestratorCoordinator(config)
+
+		instance := newRunningInstance("active-saga", 2, 1)
+		coord.instances.Store(instance.id, instance)
+
+		// Track a cancellation function to verify it is invoked.
+		var cancelled int32
+		coord.cancelFuncs.Store(instance.id, context.CancelFunc(func() {
+			atomic.AddInt32(&cancelled, 1)
+		}))
+
+		before := storage.saveSagaCount
+		if err := coord.StopSaga(context.Background(), instance.id); err != nil {
+			t.Fatalf("StopSaga() unexpected error = %v", err)
+		}
+		if storage.saveSagaCount <= before {
+			t.Error("StopSaga() should persist current state via SaveSaga")
+		}
+		if atomic.LoadInt32(&cancelled) != 1 {
+			t.Errorf("StopSaga() should cancel in-flight execution, calls = %d", cancelled)
+		}
+	})
+
+	t.Run("storage failure on persist", func(t *testing.T) {
+		config := newTestConfig()
+		config.StateStorage = &mockStateStorage{saveSagaErr: errors.New("save failed")}
+		coord, _ := NewOrchestratorCoordinator(config)
+		instance := newRunningInstance("active-saga", 1, 0)
+		coord.instances.Store(instance.id, instance)
+
+		if err := coord.StopSaga(context.Background(), instance.id); err == nil {
+			t.Error("StopSaga() expected storage error")
+		}
+	})
+}
+
+// TestOrchestratorCoordinatorLifecycleConcurrent exercises the lifecycle APIs
+// under concurrent access to surface data races in the coordinator (run with
+// -race). It uses the thread-safe in-memory storage and the stateless no-op
+// metrics collector so that any race surfaced originates from the coordinator
+// itself rather than from test doubles.
+func TestOrchestratorCoordinatorLifecycleConcurrent(t *testing.T) {
+	config := &OrchestratorConfig{
+		StateStorage:     storage.NewMemoryStateStorage(),
+		EventPublisher:   &mockEventPublisher{},
+		MetricsCollector: &noOpMetricsCollector{},
+	}
+	coord, err := NewOrchestratorCoordinator(config)
+	if err != nil {
+		t.Fatalf("failed to create coordinator: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			coord := tt.setupCoord()
-			ctx := context.Background()
+	const numSagas = 20
+	ids := make([]string, 0, numSagas)
+	for i := 0; i < numSagas; i++ {
+		id := fmt.Sprintf("saga-%02d", i)
+		ids = append(ids, id)
+		instance := newRunningInstance(id, 1, 0)
+		coord.instances.Store(id, instance)
+		coord.mu.Lock()
+		coord.metrics.ActiveSagas++
+		coord.mu.Unlock()
+	}
 
-			err := coord.StopSaga(ctx, tt.sagaID)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("StopSaga() expected error but got nil")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("StopSaga() unexpected error = %v", err)
-				}
-			}
-		})
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		id := id
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_ = coord.CancelSaga(context.Background(), id, "concurrent cancel")
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = coord.GetSagaInstance(id)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = coord.GetActiveSagas(nil)
+		}()
+	}
+
+	wg.Wait()
+
+	// After cancellation, cancelled count should not exceed the number created.
+	m := coord.GetMetrics()
+	if m.CancelledSagas > numSagas {
+		t.Errorf("CancelledSagas = %d, expected <= %d", m.CancelledSagas, numSagas)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #953 (part of Epic #950).

`pkg/saga/coordinator/orchestrator.go` previously had several core lifecycle APIs returning `not yet implemented` or stub values, which was the largest blocker to using Saga in production. This PR completes them:

- **`GetSagaInstance`** — prefers the in-memory runtime cache, then falls back to the configured `StateStorage` so Sagas can be queried even when no longer cached.
- **`GetActiveSagas`** — queries `StateStorage` constrained to active states (`Running`, `StepCompleted`, `Compensating`). Caller-supplied state filters are respected; the caller's filter is never mutated. Storage errors are wrapped.
- **`CancelSaga`** — resolves the instance, rejects terminal Sagas, signals in-flight execution to stop, drives compensation for completed steps (reusing the per-step logic in `compensation.go`), transitions to `Cancelled`, persists, publishes a `saga.cancelled` event, and updates aggregate + collector metrics.
- **`StopSaga`** — gracefully signals in-flight execution to stop (current step allowed to finish) and persists the current state.
- **`HealthCheck`** — probes the `StateStorage` and `EventPublisher` dependencies, preferring an explicit `HealthCheck(ctx)` method (implemented by the Redis/Postgres backends) and falling back to a lightweight storage probe.

To support the above, `StartSaga` now tracks the Saga definition and a cancellable execution context per Saga (cleaned up once execution completes), enabling the lifecycle APIs to act on active instances.

No `not yet implemented` strings remain in the package.

## Test plan

- [x] `go test ./pkg/saga/coordinator/... -run 'Cancel|Stop|GetActive|GetSagaInstance|Health' -v` — all green
- [x] New/updated table tests cover: closed coordinator, not-found, terminal-state rejection, successful cancel with compensation, cancel without completed steps, storage-failure on persist, storage-only instance, active-saga listing, filter defaults/immutability, explicit + fallback health probes, and a concurrent lifecycle stress test (`-race`).
- [x] Full `pkg/saga/coordinator` suite passes (non-race).
- [x] New lifecycle tests pass under `-race`.
- [x] `go vet` and `make quality-dev` clean.

> Note: a pre-existing `-race` failure in `TestHybrid_ConcurrentMixedModes` (`SmartModeSelector.SelectMode`) exists on `master` and is unrelated to this change.

Made with [Cursor](https://cursor.com)